### PR TITLE
Fix credentials_form return type

### DIFF
--- a/imednet/webui.py
+++ b/imednet/webui.py
@@ -72,7 +72,7 @@ def create_app() -> Flask:
         return render_template("users.html", users=users)
 
     @app.route("/credentials", methods=["GET", "POST"])
-    def credentials_form() -> str:
+    def credentials_form() -> Response | str:
         if request.method == "POST":
             save_credentials(
                 request.form["api_key"],


### PR DESCRIPTION
## Summary
- fix `credentials_form` return type union to avoid mypy error

## Testing
- `poetry run pre-commit run --all-files`
- `poetry run pytest --cov=imednet`


------