### PR TITLE
Add query and registration workflows to CLI and UI

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,11 +12,14 @@
 - Format code with [Black](https://github.com/psf/black) using a line length of 100.
 - Lint with [ruff](https://github.com/astral-sh/ruff).
 - Type‑check with [mypy](http://mypy-lang.org/).
-- These checks are executed via pre-commit:
+- These checks are executed via pre-commit. Run them once on the entire
+  repository and on the files you change before every commit:
   ```bash
+  # first run on all files
   poetry run pre-commit run --all-files
+  # then run on the specific files you changed
+  poetry run pre-commit run --files <files you changed>
   ```
-  Always run this before committing.
 
 ## Testing
 - Run the test suite with coverage:

--- a/imednet/templates/base.html
+++ b/imednet/templates/base.html
@@ -1,0 +1,28 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <title>iMednet SDK</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
+  </head>
+  <body>
+    <nav class="navbar navbar-expand-lg navbar-dark bg-dark mb-4">
+      <div class="container-fluid">
+        <a class="navbar-brand" href="{{ url_for('list_studies') }}">iMednet</a>
+        <div class="navbar-nav">
+          <a class="nav-link" href="{{ url_for('list_studies') }}">Studies</a>
+          <a class="nav-link" href="{{ url_for('list_users') }}">Users</a>
+          <a class="nav-link" href="{{ url_for('credentials_form') }}">Credentials</a>
+        </div>
+      </div>
+    </nav>
+    <div class="container">
+      {% with messages = get_flashed_messages() %}
+        {% if messages %}
+        <div class="alert alert-info">{{ messages[0] }}</div>
+        {% endif %}
+      {% endwith %}
+      {% block content %}{% endblock %}
+    </div>
+  </body>
+</html>

--- a/imednet/templates/credentials.html
+++ b/imednet/templates/credentials.html
@@ -1,0 +1,23 @@
+{% extends 'base.html' %}
+{% block content %}
+<h1>Store Credentials</h1>
+<form method="post">
+  <div class="mb-3">
+    <label class="form-label">API Key</label>
+    <input type="password" name="api_key" class="form-control" required>
+  </div>
+  <div class="mb-3">
+    <label class="form-label">Security Key</label>
+    <input type="password" name="security_key" class="form-control" required>
+  </div>
+  <div class="mb-3">
+    <label class="form-label">Study Key</label>
+    <input type="text" name="study_key" class="form-control">
+  </div>
+  <div class="mb-3">
+    <label class="form-label">Password</label>
+    <input type="password" name="password" class="form-control" required>
+  </div>
+  <button type="submit" class="btn btn-primary">Save</button>
+</form>
+{% endblock %}

--- a/imednet/templates/queries.html
+++ b/imednet/templates/queries.html
@@ -1,0 +1,9 @@
+{% extends 'base.html' %}
+{% block content %}
+<h1>Open Queries for {{ study_key }}</h1>
+<ul class="list-group">
+  {% for q in queries %}
+  <li class="list-group-item">{{ q.description }}</li>
+  {% endfor %}
+</ul>
+{% endblock %}

--- a/imednet/templates/register_subjects.html
+++ b/imednet/templates/register_subjects.html
@@ -1,0 +1,11 @@
+{% extends 'base.html' %}
+{% block content %}
+<h1>Register Subjects for {{ study_key }}</h1>
+<form method="post">
+  <div class="mb-3">
+    <label class="form-label">Subjects JSON</label>
+    <textarea name="data" class="form-control" rows="5" required></textarea>
+  </div>
+  <button type="submit" class="btn btn-primary">Submit</button>
+</form>
+{% endblock %}

--- a/imednet/templates/sites.html
+++ b/imednet/templates/sites.html
@@ -1,0 +1,9 @@
+{% extends 'base.html' %}
+{% block content %}
+<h1>Sites for {{ study_key }}</h1>
+<ul class="list-group">
+  {% for site in sites %}
+  <li class="list-group-item">{{ site.site_name }}</li>
+  {% endfor %}
+</ul>
+{% endblock %}

--- a/imednet/templates/studies.html
+++ b/imednet/templates/studies.html
@@ -1,0 +1,11 @@
+{% extends 'base.html' %}
+{% block content %}
+<h1>Studies</h1>
+<ul class="list-group">
+  {% for s in studies %}
+  <li class="list-group-item">
+    <a href="{{ url_for('list_subjects', study_key=s.study_key) }}">{{ s.study_name }}</a>
+  </li>
+  {% endfor %}
+</ul>
+{% endblock %}

--- a/imednet/templates/subjects.html
+++ b/imednet/templates/subjects.html
@@ -1,0 +1,10 @@
+{% extends 'base.html' %}
+{% block content %}
+<h1>Subjects for {{ study_key }}</h1>
+<ul class="list-group">
+  {% for subj in subjects %}
+  <li class="list-group-item">{{ subj.subject_key }}</li>
+  {% endfor %}
+</ul>
+<a href="{{ url_for('list_sites', study_key=study_key) }}" class="btn btn-secondary mt-3">View Sites</a>
+{% endblock %}

--- a/imednet/templates/users.html
+++ b/imednet/templates/users.html
@@ -1,0 +1,9 @@
+{% extends 'base.html' %}
+{% block content %}
+<h1>Users</h1>
+<ul class="list-group">
+  {% for user in users %}
+  <li class="list-group-item">{{ user.user_name }}</li>
+  {% endfor %}
+</ul>
+{% endblock %}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,6 +7,8 @@ packages = [{ include = "imednet" }]
 include = [
     "README.md",
     "LICENSE",
+    { path = "imednet/templates", format = "sdist" },
+    { path = "imednet/templates", format = "wheel" },
     { path = "examples", format = "sdist" }, # Include examples only in sdist
     { path = "examples", format = "wheel" } # Include examples also in wheel
 ]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -7,11 +7,14 @@ from imednet.cli import (
     extract_records,
     get_sdk,
     hello,
+    list_open_queries_cmd,
     list_sites,
     list_studies,
     list_subjects,
     list_users,
     parse_filter_args,
+    query_state_counts_cmd,
+    register_subjects_cmd,
     save_credentials_cmd,
 )
 from imednet.core.exceptions import ApiError
@@ -207,6 +210,56 @@ def test_extract_records_success(mock_get_sdk):
         )
 
         mock_workflow.extract_records_by_criteria.assert_called_once()
+
+
+@patch("imednet.cli.get_sdk")
+def test_list_open_queries(mock_get_sdk):
+    mock_sdk = MagicMock()
+    mock_get_sdk.return_value = mock_sdk
+    workflow_instance = MagicMock()
+    with patch("imednet.cli.QueryManagementWorkflow") as mock_wf_cls:
+        mock_wf_cls.return_value = workflow_instance
+        workflow_instance.get_open_queries.return_value = ["Q1"]
+
+        ctx = MagicMock()
+        ctx.obj = {}
+        list_open_queries_cmd(ctx, "STUDY1")
+
+        workflow_instance.get_open_queries.assert_called_once_with("STUDY1")
+
+
+@patch("imednet.cli.get_sdk")
+def test_query_state_counts(mock_get_sdk):
+    mock_sdk = MagicMock()
+    mock_get_sdk.return_value = mock_sdk
+    workflow_instance = MagicMock()
+    with patch("imednet.cli.QueryManagementWorkflow") as mock_wf_cls:
+        mock_wf_cls.return_value = workflow_instance
+        workflow_instance.get_query_state_counts.return_value = {"open": 1}
+
+        ctx = MagicMock()
+        ctx.obj = {}
+        query_state_counts_cmd(ctx, "STUDY1")
+
+        workflow_instance.get_query_state_counts.assert_called_once_with("STUDY1")
+
+
+@patch("imednet.cli.get_sdk")
+def test_register_subjects_cmd(mock_get_sdk, tmp_path):
+    mock_sdk = MagicMock()
+    mock_get_sdk.return_value = mock_sdk
+    workflow_instance = MagicMock()
+    with patch("imednet.cli.RegisterSubjectsWorkflow") as mock_wf_cls:
+        mock_wf_cls.return_value = workflow_instance
+
+        data_file = tmp_path / "subs.json"
+        data_file.write_text("[{}]")
+
+        ctx = MagicMock()
+        ctx.obj = {}
+        register_subjects_cmd(ctx, "STUDY1", data_file, None)
+
+        workflow_instance.register_subjects.assert_called_once()
 
 
 @patch("imednet.cli.store_creds")

--- a/tests/test_webui.py
+++ b/tests/test_webui.py
@@ -53,3 +53,94 @@ def test_webui_uses_stored_credentials(mock_sdk, mock_resolve):
         security_key="secret",
         base_url="https://edc.prod.imednetapi.com",
     )
+
+
+@patch.dict(os.environ, {"IMEDNET_API_KEY": "key", "IMEDNET_SECURITY_KEY": "sec"})
+@patch("imednet.webui.save_credentials")
+@patch("imednet.webui.resolve_credentials", return_value=("key", "sec", "STUDY"))
+@patch("imednet.webui.ImednetSDK")
+def test_credentials_form_saves(mock_sdk, _mock_creds, mock_save):
+    mock_sdk.return_value = MagicMock()
+
+    app = create_app()
+    with app.test_client() as client:
+        resp = client.post(
+            "/credentials",
+            data={
+                "api_key": "a",
+                "security_key": "b",
+                "study_key": "s",
+                "password": "pwd",
+            },
+        )
+        assert resp.status_code == 302
+    mock_save.assert_called_once_with("a", "b", "s", "pwd")
+
+
+@patch.dict(os.environ, {"IMEDNET_API_KEY": "key", "IMEDNET_SECURITY_KEY": "sec"})
+@patch("imednet.webui.resolve_credentials", return_value=("key", "sec", "STUDY"))
+@patch("imednet.webui.ImednetSDK")
+def test_list_sites(mock_sdk, _mock_creds):
+    instance = MagicMock()
+    mock_sdk.return_value = instance
+    instance.sites.list.return_value = [MagicMock(site_name="Site 1")]
+
+    app = create_app()
+    with app.test_client() as client:
+        resp = client.get("/studies/TEST/sites")
+        assert resp.status_code == 200
+        assert "Site 1" in resp.get_data(as_text=True)
+
+
+@patch.dict(os.environ, {"IMEDNET_API_KEY": "key", "IMEDNET_SECURITY_KEY": "sec"})
+@patch("imednet.webui.resolve_credentials", return_value=("key", "sec", "STUDY"))
+@patch("imednet.webui.ImednetSDK")
+def test_list_users(mock_sdk, _mock_creds):
+    instance = MagicMock()
+    mock_sdk.return_value = instance
+    instance.users.list.return_value = [MagicMock(user_name="User1")]
+
+    app = create_app()
+    with app.test_client() as client:
+        resp = client.get("/users")
+        assert resp.status_code == 200
+        assert "User1" in resp.get_data(as_text=True)
+
+
+@patch.dict(os.environ, {"IMEDNET_API_KEY": "key", "IMEDNET_SECURITY_KEY": "sec"})
+@patch("imednet.webui.resolve_credentials", return_value=("key", "sec", "STUDY"))
+@patch("imednet.webui.QueryManagementWorkflow")
+@patch("imednet.webui.ImednetSDK")
+def test_list_open_queries(mock_sdk, mock_qm_cls, _mock_creds):
+    instance = MagicMock()
+    mock_sdk.return_value = instance
+    qm_instance = MagicMock()
+    mock_qm_cls.return_value = qm_instance
+    qm_instance.get_open_queries.return_value = [MagicMock(description="Q1")]
+
+    app = create_app()
+    with app.test_client() as client:
+        resp = client.get("/studies/TEST/queries/open")
+        assert resp.status_code == 200
+        assert "Q1" in resp.get_data(as_text=True)
+    qm_instance.get_open_queries.assert_called_once_with("TEST")
+
+
+@patch.dict(os.environ, {"IMEDNET_API_KEY": "key", "IMEDNET_SECURITY_KEY": "sec"})
+@patch("imednet.webui.resolve_credentials", return_value=("key", "sec", "STUDY"))
+@patch("imednet.webui.RegisterSubjectsWorkflow")
+@patch("imednet.webui.ImednetSDK")
+def test_register_subjects(mock_sdk, mock_wf_cls, _mock_creds):
+    instance = MagicMock()
+    mock_sdk.return_value = instance
+    wf_instance = MagicMock()
+    mock_wf_cls.return_value = wf_instance
+
+    app = create_app()
+    with app.test_client() as client:
+        resp = client.post(
+            "/studies/TEST/register-subjects",
+            data={"data": "[]"},
+        )
+        assert resp.status_code == 302
+    wf_instance.register_subjects.assert_called_once()


### PR DESCRIPTION
## Summary
- expose query management workflow via CLI
- expose subject registration workflow via CLI
- add web UI pages for queries and registration
- create tests for the new CLI commands and routes
- clarify pre-commit usage in AGENTS

## Testing
- `poetry run pre-commit run --files imednet/cli.py imednet/webui.py imednet/templates/base.html imednet/templates/credentials.html imednet/templates/queries.html imednet/templates/register_subjects.html imednet/templates/sites.html imednet/templates/studies.html imednet/templates/subjects.html imednet/templates/users.html pyproject.toml tests/test_cli.py tests/test_webui.py`
- `poetry run pre-commit run --files AGENTS.md`
- `poetry run pytest --cov=imednet`

------
https://chatgpt.com/codex/tasks/task_e_6841d9ca1634832c890c2048b2dd643d