### PR TITLE
Add web UI parity with CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,25 +108,42 @@ asyncio.run(main())
 
 ### Using the Command Line Interface (CLI)
 
-After installing the package (`pip install imednet-python-sdk`) and setting the environment variables as shown above, you can use the `imednet` command:
+After installing the package (`pip install imednet-python-sdk`) and setting the environment variables as shown above, you can use the `imednet` command. The CLI groups functionality into several subcommands:
+```bash
+# Manage stored credentials
+imednet credentials save
 
-```powershell
-# List available studies
+# Study and site information
 imednet studies list
+imednet sites list <STUDY_KEY>
 
-# List sites for a specific study (replace STUDY_KEY)
-imednet sites list STUDY_KEY
+# Subject management with optional filtering
+imednet subjects list <STUDY_KEY> --filter "subject_status=Screened"
 
-# List subjects for a specific study, filtering by status (replace STUDY_KEY)
-imednet subjects list STUDY_KEY --filter "subject_status=Screened"
+# User listing with inactive toggle
+imednet users list <STUDY_KEY> --include-inactive
+
+# Query management
+imednet queries open <STUDY_KEY>
+imednet queries counts <STUDY_KEY>
+
+# Data workflows
+imednet workflows extract-records <STUDY_KEY> \
+    --record-filter form_key=AE \
+    --subject-filter subject_status=Screened
+imednet workflows register-subjects <STUDY_KEY> subjects.json
 
 # Get help for a specific command
-imednet subjects list --help 
+imednet subjects list --help
 ```
 
 - See the full API reference in the [HTML docs](docs/_build/html/index.html).
 - More examples, such as `get_open_queries.py`, can be found in the
   `imednet/examples/` directory.
+
+The accompanying web UI (`imednet-web`) mirrors these capabilities, providing
+forms for filters and workflow execution so you can perform the same tasks in
+your browser.
 
 ### Using the Web UI
 

--- a/imednet/templates/extract_records.html
+++ b/imednet/templates/extract_records.html
@@ -1,0 +1,26 @@
+{% extends 'base.html' %}
+{% block content %}
+<h1>Extract Records for {{ study_key }}</h1>
+<form method="post" class="mb-3">
+  <div class="mb-2">
+    <label class="form-label">Record Filter</label>
+    <input type="text" name="record_filter" class="form-control" placeholder="key=value;key2=value2">
+  </div>
+  <div class="mb-2">
+    <label class="form-label">Subject Filter</label>
+    <input type="text" name="subject_filter" class="form-control" placeholder="key=value">
+  </div>
+  <div class="mb-2">
+    <label class="form-label">Visit Filter</label>
+    <input type="text" name="visit_filter" class="form-control" placeholder="key=value">
+  </div>
+  <button type="submit" class="btn btn-primary">Run</button>
+</form>
+{% if records %}
+<ul class="list-group">
+  {% for rec in records %}
+  <li class="list-group-item">{{ rec.record_id }}</li>
+  {% endfor %}
+</ul>
+{% endif %}
+{% endblock %}

--- a/imednet/templates/queries.html
+++ b/imednet/templates/queries.html
@@ -6,4 +6,5 @@
   <li class="list-group-item">{{ q.description }}</li>
   {% endfor %}
 </ul>
+<a href="{{ url_for('query_state_counts', study_key=study_key) }}" class="btn btn-secondary mt-3">View Counts</a>
 {% endblock %}

--- a/imednet/templates/query_counts.html
+++ b/imednet/templates/query_counts.html
@@ -1,0 +1,9 @@
+{% extends 'base.html' %}
+{% block content %}
+<h1>Query Counts for {{ study_key }}</h1>
+<ul class="list-group">
+  <li class="list-group-item">Open: {{ counts.open }}</li>
+  <li class="list-group-item">Closed: {{ counts.closed }}</li>
+  <li class="list-group-item">Unknown: {{ counts.unknown }}</li>
+</ul>
+{% endblock %}

--- a/imednet/templates/subjects.html
+++ b/imednet/templates/subjects.html
@@ -1,10 +1,21 @@
 {% extends 'base.html' %}
 {% block content %}
 <h1>Subjects for {{ study_key }}</h1>
+<form method="get" class="mb-3">
+  <div class="input-group">
+    <input type="text" name="filter" class="form-control" placeholder="key=value" value="{{ filter_text }}">
+    <button type="submit" class="btn btn-primary">Filter</button>
+  </div>
+</form>
 <ul class="list-group">
   {% for subj in subjects %}
   <li class="list-group-item">{{ subj.subject_key }}</li>
   {% endfor %}
 </ul>
-<a href="{{ url_for('list_sites', study_key=study_key) }}" class="btn btn-secondary mt-3">View Sites</a>
+<div class="mt-3">
+  <a href="{{ url_for('list_sites', study_key=study_key) }}" class="btn btn-secondary">View Sites</a>
+  <a href="{{ url_for('extract_records', study_key=study_key) }}" class="btn btn-secondary">Extract Records</a>
+  <a href="{{ url_for('list_open_queries', study_key=study_key) }}" class="btn btn-secondary">Open Queries</a>
+  <a href="{{ url_for('query_state_counts', study_key=study_key) }}" class="btn btn-secondary">Query Counts</a>
+</div>
 {% endblock %}

--- a/imednet/templates/users.html
+++ b/imednet/templates/users.html
@@ -1,6 +1,13 @@
 {% extends 'base.html' %}
 {% block content %}
 <h1>Users</h1>
+<form method="get" class="mb-3">
+  <div class="form-check">
+    <input class="form-check-input" type="checkbox" name="include_inactive" value="1" id="inactive" {% if include_inactive %}checked{% endif %}>
+    <label class="form-check-label" for="inactive">Include Inactive</label>
+  </div>
+  <button type="submit" class="btn btn-primary mt-2">Refresh</button>
+</form>
 <ul class="list-group">
   {% for user in users %}
   <li class="list-group-item">{{ user.user_name }}</li>


### PR DESCRIPTION
## Summary
- enhance web UI with filter parsing logic
- support subject filtering and user inclusion toggles
- add query counts and record extraction pages
- update templates for new features
- document CLI capabilities and web UI parity

## Testing
- `poetry run pre-commit run --files imednet/webui.py imednet/templates/queries.html imednet/templates/subjects.html imednet/templates/users.html imednet/templates/extract_records.html imednet/templates/query_counts.html`
- `poetry run pre-commit run --files README.md`
- `poetry run pytest --cov=imednet`


------
https://chatgpt.com/codex/tasks/task_e_684211d5338c832caf9908df67038f6a