### PR TITLE
Fix changelog updater

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,3 +42,7 @@ jobs:
       - name: Unit tests
         run: |
           poetry run pytest -q --cov=imednet --cov-report=xml
+      - name: Check changelog
+        run: |
+          poetry run python scripts/update_changelog.py
+          git diff --quiet --exit-code CHANGELOG.md


### PR DESCRIPTION
## Summary
- avoid duplicate changelog entries
- skip errors when no tags exist
- validate CHANGELOG.md in CI

## Testing
- `poetry run pre-commit run --files .github/workflows/ci.yml`
- `poetry run pytest --cov=imednet`


------
https://chatgpt.com/codex/tasks/task_e_684230890838832c8c56a1983a7026a0