### PR TITLE
Update changelog step in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,3 +42,7 @@ jobs:
       - name: Unit tests
         run: |
           poetry run pytest -q --cov=imednet --cov-report=xml
+      - name: Update changelog (non-blocking)
+        run: poetry run python scripts/update_changelog.py
+        continue-on-error: true
+


### PR DESCRIPTION
## Summary
- avoid failing CI when the changelog updater modifies `CHANGELOG.md`

## Testing
- `poetry run pre-commit run --files .github/workflows/ci.yml`
- `poetry run pytest --cov=imednet` *(fails: pandas import error)*

------
https://chatgpt.com/codex/tasks/task_e_684230890838832c8c56a1983a7026a0