### PR TITLE
Update changelog step in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,3 +42,9 @@ jobs:
       - name: Unit tests
         run: |
           poetry run pytest -q --cov=imednet --cov-report=xml
+      - name: Update changelog (non-blocking)
+        # Run the updater for convenience but allow the job to continue if it
+        # modifies CHANGELOG.md since the changes aren't committed in CI.
+        run: poetry run python scripts/update_changelog.py
+        continue-on-error: true
+


### PR DESCRIPTION
## Summary
- avoid failing CI when the changelog updater modifies `CHANGELOG.md`
- explain why the update step does not block the workflow

## Testing
- `poetry run pre-commit run --all-files`
- `poetry run pre-commit run --files .github/workflows/ci.yml`
- `poetry run pytest --cov=imednet`