### PR TITLE
Add Veeva Vault integration module

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ See the [Changelog](CHANGELOG.md) for release history.
 - Automatic pagination
 - Data models for requests and responses
 - Workflow utilities for data extraction and mapping
+- Integration helpers for Veeva Vault APIs
 
 ## Installation
 

--- a/imednet/veeva/__init__.py
+++ b/imednet/veeva/__init__.py
@@ -1,0 +1,5 @@
+"""Veeva Vault integration helpers."""
+
+from .vault import MappingInterface, VeevaVaultClient
+
+__all__ = ["VeevaVaultClient", "MappingInterface"]

--- a/imednet/veeva/vault.py
+++ b/imednet/veeva/vault.py
@@ -1,0 +1,89 @@
+"""Simple client and mapping helpers for Veeva Vault API."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, Iterable, List, Mapping
+
+import httpx
+
+
+class VeevaVaultClient:
+    """HTTP client wrapper for interacting with the Veeva Vault API."""
+
+    DEFAULT_BASE_URL = "https://{vault}.veevavault.com"
+
+    def __init__(
+        self,
+        vault: str,
+        client_id: str,
+        client_secret: str,
+        username: str,
+        password: str,
+        base_url: str | None = None,
+        api_version: str = "v21.3",
+    ) -> None:
+        self.vault = vault
+        self.client_id = client_id
+        self.client_secret = client_secret
+        self.username = username
+        self.password = password
+        self.base_url = base_url or self.DEFAULT_BASE_URL.format(vault=vault)
+        self.api_version = api_version
+        self._access_token: str | None = None
+        self._client = httpx.Client(base_url=self.base_url)
+
+    def authenticate(self) -> None:
+        """Authenticate and store the access token."""
+        token_url = "/auth/oauth2/token"
+        data = {
+            "grant_type": "password",
+            "client_id": self.client_id,
+            "client_secret": self.client_secret,
+            "username": self.username,
+            "password": self.password,
+        }
+        response = self._client.post(token_url, data=data)
+        response.raise_for_status()
+        self._access_token = response.json().get("access_token")
+
+    def _headers(self) -> Dict[str, str]:
+        if not self._access_token:
+            raise RuntimeError("Client is not authenticated")
+        return {"Authorization": f"Bearer {self._access_token}"}
+
+    def get_picklists(self) -> List[Dict[str, Any]]:
+        """Return available picklists."""
+        url = f"/api/{self.api_version}/metadata/picklists"
+        resp = self._client.get(url, headers=self._headers())
+        resp.raise_for_status()
+        return resp.json().get("data", [])
+
+    def get_object_metadata(self, object_name: str) -> Dict[str, Any]:
+        """Return metadata for a specific object."""
+        url = f"/api/{self.api_version}/metadata/objects/{object_name}"
+        resp = self._client.get(url, headers=self._headers())
+        resp.raise_for_status()
+        return resp.json().get("data", {})
+
+    def upsert_object(self, object_name: str, record: Mapping[str, Any]) -> Dict[str, Any]:
+        """Create or update a record for the given object."""
+        url = f"/api/{self.api_version}/objects/{object_name}"
+        resp = self._client.post(url, headers=self._headers(), json=record)
+        resp.raise_for_status()
+        return resp.json().get("data", {})
+
+
+class MappingInterface:
+    """Utility helpers for mapping iMednet data to Vault objects."""
+
+    def __init__(self, veeva_fields: Iterable[str]) -> None:
+        self.veeva_fields = list(veeva_fields)
+
+    def dropdown_options(self, imednet_fields: Iterable[str]) -> Dict[str, List[str]]:
+        """Return dropdown options for UI selection."""
+        return {field: self.veeva_fields for field in imednet_fields}
+
+    @staticmethod
+    def apply_mapping(record: Mapping[str, Any], mapping: Mapping[str, str]) -> Dict[str, Any]:
+        """Return a new dict with fields renamed using the provided mapping."""
+        return {mapping.get(k, k): v for k, v in record.items()}

--- a/tests/test_veeva_vault.py
+++ b/tests/test_veeva_vault.py
@@ -1,0 +1,79 @@
+from unittest.mock import Mock, patch
+
+import pytest
+from imednet.veeva import MappingInterface, VeevaVaultClient
+
+
+def _client() -> VeevaVaultClient:
+    return VeevaVaultClient(
+        vault="testvault",
+        client_id="cid",
+        client_secret="secret",
+        username="user",
+        password="pass",
+    )
+
+
+def test_authenticate():
+    client = _client()
+    with patch.object(client._client, "post") as mock_post:
+        mock_resp = Mock()
+        mock_resp.json.return_value = {"access_token": "token"}
+        mock_resp.raise_for_status.return_value = None
+        mock_post.return_value = mock_resp
+        client.authenticate()
+        assert client._access_token == "token"
+        mock_post.assert_called_once()
+
+
+def test_headers_without_auth():
+    client = _client()
+    with pytest.raises(RuntimeError):
+        client._headers()
+
+
+def test_get_picklists():
+    client = _client()
+    client._access_token = "token"
+    with patch.object(client._client, "get") as mock_get:
+        mock_resp = Mock()
+        mock_resp.json.return_value = {"data": [1]}
+        mock_resp.raise_for_status.return_value = None
+        mock_get.return_value = mock_resp
+        result = client.get_picklists()
+        assert result == [1]
+        mock_get.assert_called_once()
+
+
+def test_get_object_metadata():
+    client = _client()
+    client._access_token = "token"
+    with patch.object(client._client, "get") as mock_get:
+        mock_resp = Mock()
+        mock_resp.json.return_value = {"data": {"fields": []}}
+        mock_resp.raise_for_status.return_value = None
+        mock_get.return_value = mock_resp
+        result = client.get_object_metadata("obj")
+        assert result == {"fields": []}
+        mock_get.assert_called_once()
+
+
+def test_upsert_object():
+    client = _client()
+    client._access_token = "token"
+    with patch.object(client._client, "post") as mock_post:
+        mock_resp = Mock()
+        mock_resp.json.return_value = {"data": {"id": "1"}}
+        mock_resp.raise_for_status.return_value = None
+        mock_post.return_value = mock_resp
+        result = client.upsert_object("obj", {"field": "val"})
+        assert result == {"id": "1"}
+        mock_post.assert_called_once()
+
+
+def test_mapping_interface():
+    interface = MappingInterface(["a", "b"])
+    options = interface.dropdown_options(["x", "y"])
+    assert options == {"x": ["a", "b"], "y": ["a", "b"]}
+    mapped = interface.apply_mapping({"x": 1, "z": 2}, {"x": "a"})
+    assert mapped == {"a": 1, "z": 2}


### PR DESCRIPTION
## Summary
- add `VeevaVaultClient` for basic Vault REST actions
- provide `MappingInterface` helpers for mapping iMednet data
- document integration capability in README
- test new module

## Testing
- `poetry run pre-commit run --all-files`
- `poetry run pre-commit run --files README.md imednet/veeva/vault.py imednet/veeva/__init__.py tests/test_veeva_vault.py`
- `poetry run pytest --cov=imednet`


------
https://chatgpt.com/codex/tasks/task_e_6842319a8224832ca989bc5e9ebce10c