### PR TITLE
Add credential prompt in web UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,11 @@ imednet-web
 
 Ensure the same environment variables are set as for the CLI. The web app lists
 available studies and allows drilling down into subjects for each study.
+If the required credentials or password aren't provided, the interface will
+prompt you to enter them and store them securely for future use. The password
+is retained in your browser session (and temporarily in the
+`IMEDNET_CRED_PASSWORD` environment variable) so subsequent requests can load
+the saved credentials.
 
 ## Documentation
 


### PR DESCRIPTION
## Summary
- prompt for credentials when environment or stored credentials are missing
- store credential password in user session and environment after save
- document credential session storage in README
- test password stored in session

## Testing
- `poetry run pre-commit run --files README.md imednet/webui.py tests/test_webui.py`
- `poetry run pytest --cov=imednet`


------