### PR TITLE
Add design principles to AGENTS

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,6 +21,20 @@
   poetry run pre-commit run --files <files you changed>
   ```
 
+## Design Principles
+- **Single Responsibility** – Keep each module or class focused on one concern. Prefer
+  composition over long multi-purpose classes.
+- **Open/Closed and Liskov** – Extend functionality with new subclasses or helper
+  functions without altering existing interfaces.
+- **Interface Segregation** – Expose small, well-defined interfaces instead of large
+  "god objects."
+- **Dependency Injection** – Pass dependencies into classes and functions rather
+  than instantiating them internally. This aids testing and reuse.
+- **DRY** – Reuse utilities and base classes. Factor shared routines into
+  `imednet.utils` or `core`.
+- **Testability** – Keep modules decoupled so they can be tested independently. Add
+  unit tests with new classes or functions.
+
 ## Testing
 - Run the test suite with coverage:
   ```bash

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ This file is automatically updated by the release process.
 - Added PyPI, code style (Black), linter (Ruff), and typing (Mypy) badges to `README.md`.
 - Added `pandas` to development dependencies for workflow features.
 - Created `TEST_PLAN.md` outlining steps to achieve 90% test coverage.
+- Documented a new "Design Principles" section in `AGENTS.md` encouraging
+  modular, DRY, and SOLID code.
 
 ### Fixed
 


### PR DESCRIPTION
## Summary
- document design principles promoting DRY and SOLID code in `AGENTS.md`
- note the new guidelines in the changelog

## Testing
- `poetry run pre-commit run --all-files`
- `poetry run pre-commit run --files AGENTS.md`
- `poetry run pytest --cov=imednet`

------
https://chatgpt.com/codex/tasks/task_e_68435028c024832c9a8f5919b6c3cd97