### PR TITLE
Add Veeva Vault record validation helper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ This file is automatically updated by the release process.
 - Created `TEST_PLAN.md` outlining steps to achieve 90% test coverage.
 - Documented a new "Design Principles" section in `AGENTS.md` encouraging
   modular, DRY, and SOLID code.
+- Added helper `validate_record_for_upsert` for Veeva Vault record validation.
 
 ### Fixed
 

--- a/imednet/veeva/__init__.py
+++ b/imednet/veeva/__init__.py
@@ -1,5 +1,15 @@
 """Veeva Vault integration helpers."""
 
-from .vault import MappingInterface, VeevaVaultClient
+from .vault import (
+    MappingInterface,
+    VeevaVaultClient,
+    get_required_fields_and_picklists,
+    validate_record_for_upsert,
+)
 
-__all__ = ["VeevaVaultClient", "MappingInterface"]
+__all__ = [
+    "VeevaVaultClient",
+    "MappingInterface",
+    "get_required_fields_and_picklists",
+    "validate_record_for_upsert",
+]

--- a/tests/test_veeva_vault.py
+++ b/tests/test_veeva_vault.py
@@ -1,7 +1,11 @@
 from unittest.mock import Mock, patch
 
 import pytest
-from imednet.veeva import MappingInterface, VeevaVaultClient
+from imednet.veeva import (
+    MappingInterface,
+    VeevaVaultClient,
+    validate_record_for_upsert,
+)
 
 
 def _client() -> VeevaVaultClient:
@@ -77,3 +81,53 @@ def test_mapping_interface():
     assert options == {"x": ["a", "b"], "y": ["a", "b"]}
     mapped = interface.apply_mapping({"x": 1, "z": 2}, {"x": "a"})
     assert mapped == {"a": 1, "z": 2}
+
+
+def _metadata():
+    return {
+        "fields": [
+            {"name": "name__v", "required": True},
+            {
+                "name": "status__v",
+                "required": True,
+                "picklist": {
+                    "values": [{"name": "New"}, {"name": "Closed"}],
+                    "defaultValue": "New",
+                },
+            },
+            {
+                "name": "category__v",
+                "picklist": {"values": [{"name": "A"}, {"name": "B"}]},
+            },
+        ]
+    }
+
+
+def test_validate_record_for_upsert_success():
+    client = _client()
+    with patch.object(client, "get_object_metadata", return_value=_metadata()):
+        record = {"name__v": "test", "status__v": "Closed"}
+        result = validate_record_for_upsert(client, "prod__c", record)
+        assert result == record
+
+
+def test_validate_record_for_upsert_missing_required():
+    client = _client()
+    with patch.object(client, "get_object_metadata", return_value=_metadata()):
+        with pytest.raises(ValueError):
+            validate_record_for_upsert(client, "prod__c", {"status__v": "New"})
+
+
+def test_validate_record_for_upsert_invalid_picklist():
+    client = _client()
+    with patch.object(client, "get_object_metadata", return_value=_metadata()):
+        with pytest.raises(ValueError):
+            validate_record_for_upsert(client, "prod__c", {"name__v": "test", "status__v": "Bad"})
+
+
+def test_validate_record_for_upsert_autofill_default():
+    client = _client()
+    with patch.object(client, "get_object_metadata", return_value=_metadata()):
+        record = {"name__v": "test"}
+        result = validate_record_for_upsert(client, "prod__c", record)
+        assert result["status__v"] == "New"


### PR DESCRIPTION
## Summary
- add `get_required_fields_and_picklists` and `validate_record_for_upsert`
- expose new helpers in `imednet.veeva`
- extend Veeva Vault tests for validation helpers
- document the new helper in `CHANGELOG`

## Testing
- `poetry run pre-commit run --files imednet/veeva/vault.py tests/test_veeva_vault.py CHANGELOG.md imednet/veeva/__init__.py`
- `poetry run pytest --cov=imednet`

------