### PR TITLE
Add helper to gather Vault required fields and picklists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ This file is automatically updated by the release process.
 - Documented a new "Design Principles" section in `AGENTS.md` encouraging
   modular, DRY, and SOLID code.
 - Added helper `validate_record_for_upsert` for Veeva Vault record validation.
+- Added helper `collect_required_fields_and_picklists` for retrieving required
+  fields and picklist options from Vault.
 
 ### Fixed
 

--- a/imednet/veeva/__init__.py
+++ b/imednet/veeva/__init__.py
@@ -3,6 +3,7 @@
 from .vault import (
     MappingInterface,
     VeevaVaultClient,
+    collect_required_fields_and_picklists,
     get_required_fields_and_picklists,
     validate_record_for_upsert,
 )
@@ -11,5 +12,6 @@ __all__ = [
     "VeevaVaultClient",
     "MappingInterface",
     "get_required_fields_and_picklists",
+    "collect_required_fields_and_picklists",
     "validate_record_for_upsert",
 ]


### PR DESCRIPTION
## Summary
- add `collect_required_fields_and_picklists` with supporting client methods
- expose helper from the veeva package
- test required field and picklist lookup behaviour
- document helper in the changelog

## Testing
- `poetry run pre-commit run --files CHANGELOG.md imednet/veeva/__init__.py imednet/veeva/vault.py tests/test_veeva_vault.py`
- `poetry run pytest --cov=imednet`

------