### PR TITLE
Add async endpoints for SDK

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,11 @@ async def main():
 asyncio.run(main())
 ```
 
+`AsyncImednetSDK` exposes the same endpoints as the synchronous SDK:
+`studies`, `forms`, `sites`, `subjects`, `records`, `codings`,
+`intervals`, `jobs`, `queries`, `record_revisions`, `users`, `variables`, and
+`visits`.
+
 ### Using the Command Line Interface (CLI)
 
 After installing the package (`pip install imednet-python-sdk`) and setting the environment variables as shown above, you can use the `imednet` command. The CLI groups functionality into several subcommands:

--- a/docs/imednet.endpoints.rst
+++ b/docs/imednet.endpoints.rst
@@ -116,6 +116,74 @@ imednet.endpoints.visits module
    :undoc-members:
    :show-inheritance:
 
+Async endpoint modules
+----------------------
+
+.. automodule:: imednet.endpoints.async_codings
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+.. automodule:: imednet.endpoints.async_forms
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+.. automodule:: imednet.endpoints.async_intervals
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+.. automodule:: imednet.endpoints.async_jobs
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+.. automodule:: imednet.endpoints.async_queries
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+.. automodule:: imednet.endpoints.async_record_revisions
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+.. automodule:: imednet.endpoints.async_records
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+.. automodule:: imednet.endpoints.async_sites
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+.. automodule:: imednet.endpoints.async_studies
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+.. automodule:: imednet.endpoints.async_subjects
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+.. automodule:: imednet.endpoints.async_users
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+.. automodule:: imednet.endpoints.async_variables
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+.. automodule:: imednet.endpoints.async_visits
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
 Module contents
 ---------------
 

--- a/imednet/async_sdk.py
+++ b/imednet/async_sdk.py
@@ -6,7 +6,19 @@ from typing import Optional
 
 from .core.async_client import AsyncClient
 from .core.context import Context
+from .endpoints.async_codings import AsyncCodingsEndpoint
+from .endpoints.async_forms import AsyncFormsEndpoint
+from .endpoints.async_intervals import AsyncIntervalsEndpoint
+from .endpoints.async_jobs import AsyncJobsEndpoint
+from .endpoints.async_queries import AsyncQueriesEndpoint
+from .endpoints.async_record_revisions import AsyncRecordRevisionsEndpoint
+from .endpoints.async_records import AsyncRecordsEndpoint
+from .endpoints.async_sites import AsyncSitesEndpoint
 from .endpoints.async_studies import AsyncStudiesEndpoint
+from .endpoints.async_subjects import AsyncSubjectsEndpoint
+from .endpoints.async_users import AsyncUsersEndpoint
+from .endpoints.async_variables import AsyncVariablesEndpoint
+from .endpoints.async_visits import AsyncVisitsEndpoint
 
 
 class AsyncImednetSDK:
@@ -31,6 +43,18 @@ class AsyncImednetSDK:
             backoff_factor=backoff_factor,
         )
         self.studies = AsyncStudiesEndpoint(self._client, self.ctx)
+        self.forms = AsyncFormsEndpoint(self._client, self.ctx)
+        self.sites = AsyncSitesEndpoint(self._client, self.ctx)
+        self.subjects = AsyncSubjectsEndpoint(self._client, self.ctx)
+        self.records = AsyncRecordsEndpoint(self._client, self.ctx)
+        self.codings = AsyncCodingsEndpoint(self._client, self.ctx)
+        self.intervals = AsyncIntervalsEndpoint(self._client, self.ctx)
+        self.jobs = AsyncJobsEndpoint(self._client, self.ctx)
+        self.queries = AsyncQueriesEndpoint(self._client, self.ctx)
+        self.record_revisions = AsyncRecordRevisionsEndpoint(self._client, self.ctx)
+        self.users = AsyncUsersEndpoint(self._client, self.ctx)
+        self.variables = AsyncVariablesEndpoint(self._client, self.ctx)
+        self.visits = AsyncVisitsEndpoint(self._client, self.ctx)
 
     async def __aenter__(self) -> "AsyncImednetSDK":
         return self

--- a/imednet/endpoints/async_codings.py
+++ b/imednet/endpoints/async_codings.py
@@ -1,0 +1,43 @@
+"""Async endpoint for managing codings in a study."""
+
+from typing import Any, Dict, List, Optional
+
+from imednet.core.async_client import AsyncClient
+from imednet.core.async_paginator import AsyncPaginator
+from imednet.endpoints.base import BaseEndpoint
+from imednet.models.codings import Coding
+from imednet.utils.filters import build_filter_string
+
+
+class AsyncCodingsEndpoint(BaseEndpoint[AsyncClient]):
+    """Async API endpoint for interacting with codings."""
+
+    path = "/api/v1/edc/studies"
+
+    def __init__(self, client: AsyncClient, ctx) -> None:
+        super().__init__(client, ctx)
+
+    async def list(self, study_key: Optional[str] = None, **filters: Any) -> List[Coding]:
+        filters = self._auto_filter(filters)
+        if study_key:
+            filters["studyKey"] = study_key
+
+        study = filters.pop("studyKey")
+        if not study:
+            raise ValueError("Study key must be provided or set in the context")
+
+        params: Dict[str, Any] = {}
+        if filters:
+            params["filter"] = build_filter_string(filters)
+
+        path = self._build_path(study, "codings")
+        paginator = AsyncPaginator(self._client, path, params=params)
+        return [Coding.from_json(item) async for item in paginator]
+
+    async def get(self, study_key: str, coding_id: str) -> Coding:
+        path = self._build_path(study_key, "codings", coding_id)
+        response = await self._client.get(path)
+        raw = response.json().get("data", [])
+        if not raw:
+            raise ValueError(f"Coding {coding_id} not found in study {study_key}")
+        return Coding.from_json(raw[0])

--- a/imednet/endpoints/async_forms.py
+++ b/imednet/endpoints/async_forms.py
@@ -1,0 +1,43 @@
+"""Async endpoint for managing forms (eCRFs) in a study."""
+
+from typing import Any, Dict, List, Optional
+
+from imednet.core.async_client import AsyncClient
+from imednet.core.async_paginator import AsyncPaginator
+from imednet.endpoints.base import BaseEndpoint
+from imednet.models.forms import Form
+from imednet.utils.filters import build_filter_string
+
+
+class AsyncFormsEndpoint(BaseEndpoint[AsyncClient]):
+    """Async API endpoint for interacting with forms (eCRFs)."""
+
+    path = "/api/v1/edc/studies"
+
+    def __init__(self, client: AsyncClient, ctx) -> None:
+        super().__init__(client, ctx)
+
+    async def list(self, study_key: Optional[str] = None, **filters: Any) -> List[Form]:
+        filters = self._auto_filter(filters)
+        if study_key:
+            filters["studyKey"] = study_key
+
+        study = filters.pop("studyKey")
+        if not study:
+            raise ValueError("Study key must be provided or set in the context")
+
+        params: Dict[str, Any] = {}
+        if filters:
+            params["filter"] = build_filter_string(filters)
+
+        path = self._build_path(study, "forms")
+        paginator = AsyncPaginator(self._client, path, params=params, page_size=500)
+        return [Form.from_json(item) async for item in paginator]
+
+    async def get(self, study_key: str, form_id: int) -> Form:
+        path = self._build_path(study_key, "forms", form_id)
+        response = await self._client.get(path)
+        raw = response.json().get("data", [])
+        if not raw:
+            raise ValueError(f"Form {form_id} not found in study {study_key}")
+        return Form.from_json(raw[0])

--- a/imednet/endpoints/async_intervals.py
+++ b/imednet/endpoints/async_intervals.py
@@ -1,0 +1,39 @@
+"""Async endpoint for managing intervals in a study."""
+
+from typing import Any, Dict, List, Optional
+
+from imednet.core.async_client import AsyncClient
+from imednet.core.async_paginator import AsyncPaginator
+from imednet.endpoints.base import BaseEndpoint
+from imednet.models.intervals import Interval
+from imednet.utils.filters import build_filter_string
+
+
+class AsyncIntervalsEndpoint(BaseEndpoint[AsyncClient]):
+    """Async API endpoint for interacting with intervals."""
+
+    path = "/api/v1/edc/studies"
+
+    def __init__(self, client: AsyncClient, ctx) -> None:
+        super().__init__(client, ctx)
+
+    async def list(self, study_key: Optional[str] = None, **filters: Any) -> List[Interval]:
+        filters = self._auto_filter(filters)
+        if study_key:
+            filters["studyKey"] = study_key
+
+        params: Dict[str, Any] = {}
+        if filters:
+            params["filter"] = build_filter_string(filters)
+
+        path = self._build_path(filters.get("studyKey", ""), "intervals")
+        paginator = AsyncPaginator(self._client, path, params=params, page_size=500)
+        return [Interval.from_json(item) async for item in paginator]
+
+    async def get(self, study_key: str, interval_id: int) -> Interval:
+        path = self._build_path(study_key, "intervals", interval_id)
+        response = await self._client.get(path)
+        raw = response.json().get("data", [])
+        if not raw:
+            raise ValueError(f"Interval {interval_id} not found in study {study_key}")
+        return Interval.from_json(raw[0])

--- a/imednet/endpoints/async_jobs.py
+++ b/imednet/endpoints/async_jobs.py
@@ -1,0 +1,22 @@
+"""Async endpoint for checking job status in a study."""
+
+from imednet.core.async_client import AsyncClient
+from imednet.endpoints.base import BaseEndpoint
+from imednet.models.jobs import Job
+
+
+class AsyncJobsEndpoint(BaseEndpoint[AsyncClient]):
+    """Async API endpoint for retrieving job details."""
+
+    path = "/api/v1/edc/studies"
+
+    def __init__(self, client: AsyncClient, ctx) -> None:
+        super().__init__(client, ctx)
+
+    async def get(self, study_key: str, batch_id: str) -> Job:
+        endpoint = self._build_path(study_key, "jobs", batch_id)
+        response = await self._client.get(endpoint)
+        data = response.json()
+        if not data:
+            raise ValueError(f"Job {batch_id} not found in study {study_key}")
+        return Job.from_json(data)

--- a/imednet/endpoints/async_queries.py
+++ b/imednet/endpoints/async_queries.py
@@ -1,0 +1,39 @@
+"""Async endpoint for managing queries in a study."""
+
+from typing import Any, Dict, List, Optional
+
+from imednet.core.async_client import AsyncClient
+from imednet.core.async_paginator import AsyncPaginator
+from imednet.endpoints.base import BaseEndpoint
+from imednet.models.queries import Query
+from imednet.utils.filters import build_filter_string
+
+
+class AsyncQueriesEndpoint(BaseEndpoint[AsyncClient]):
+    """Async API endpoint for interacting with queries."""
+
+    path = "/api/v1/edc/studies"
+
+    def __init__(self, client: AsyncClient, ctx) -> None:
+        super().__init__(client, ctx)
+
+    async def list(self, study_key: Optional[str] = None, **filters: Any) -> List[Query]:
+        filters = self._auto_filter(filters)
+        if study_key:
+            filters["studyKey"] = study_key
+
+        params: Dict[str, Any] = {}
+        if filters:
+            params["filter"] = build_filter_string(filters)
+
+        path = self._build_path(filters.get("studyKey", ""), "queries")
+        paginator = AsyncPaginator(self._client, path, params=params)
+        return [Query.from_json(item) async for item in paginator]
+
+    async def get(self, study_key: str, annotation_id: int) -> Query:
+        path = self._build_path(study_key, "queries", annotation_id)
+        response = await self._client.get(path)
+        raw = response.json().get("data", [])
+        if not raw:
+            raise ValueError(f"Query {annotation_id} not found in study {study_key}")
+        return Query.from_json(raw[0])

--- a/imednet/endpoints/async_record_revisions.py
+++ b/imednet/endpoints/async_record_revisions.py
@@ -1,0 +1,39 @@
+"""Async endpoint for retrieving record revision history in a study."""
+
+from typing import Any, Dict, List, Optional
+
+from imednet.core.async_client import AsyncClient
+from imednet.core.async_paginator import AsyncPaginator
+from imednet.endpoints.base import BaseEndpoint
+from imednet.models.record_revisions import RecordRevision
+from imednet.utils.filters import build_filter_string
+
+
+class AsyncRecordRevisionsEndpoint(BaseEndpoint[AsyncClient]):
+    """Async API endpoint for accessing record revision history."""
+
+    path = "/api/v1/edc/studies"
+
+    def __init__(self, client: AsyncClient, ctx) -> None:
+        super().__init__(client, ctx)
+
+    async def list(self, study_key: Optional[str] = None, **filters: Any) -> List[RecordRevision]:
+        filters = self._auto_filter(filters)
+        if study_key:
+            filters["studyKey"] = study_key
+
+        params: Dict[str, Any] = {}
+        if filters:
+            params["filter"] = build_filter_string(filters)
+
+        path = self._build_path(filters.get("studyKey", ""), "recordRevisions")
+        paginator = AsyncPaginator(self._client, path, params=params)
+        return [RecordRevision.from_json(item) async for item in paginator]
+
+    async def get(self, study_key: str, record_revision_id: int) -> RecordRevision:
+        path = self._build_path(study_key, "recordRevisions", record_revision_id)
+        response = await self._client.get(path)
+        raw = response.json().get("data", [])
+        if not raw:
+            raise ValueError(f"Record revision {record_revision_id} not found in study {study_key}")
+        return RecordRevision.from_json(raw[0])

--- a/imednet/endpoints/async_records.py
+++ b/imednet/endpoints/async_records.py
@@ -1,0 +1,64 @@
+"""Async endpoint for managing records (eCRF instances) in a study."""
+
+from typing import Any, Dict, List, Optional, Union
+
+from imednet.core.async_client import AsyncClient
+from imednet.core.async_paginator import AsyncPaginator
+from imednet.endpoints.base import BaseEndpoint
+from imednet.models.jobs import Job
+from imednet.models.records import Record
+from imednet.utils.filters import build_filter_string
+
+
+class AsyncRecordsEndpoint(BaseEndpoint[AsyncClient]):
+    """Async API endpoint for interacting with records."""
+
+    path = "/api/v1/edc/studies"
+
+    def __init__(self, client: AsyncClient, ctx) -> None:
+        super().__init__(client, ctx)
+
+    async def list(
+        self,
+        study_key: Optional[str] = None,
+        record_data_filter: Optional[str] = None,
+        **filters: Any,
+    ) -> List[Record]:
+        filters = self._auto_filter(filters)
+        if study_key:
+            filters["studyKey"] = study_key
+
+        params: Dict[str, Any] = {}
+        if filters:
+            params["filter"] = build_filter_string(filters)
+        if record_data_filter:
+            params["recordDataFilter"] = record_data_filter
+
+        path = self._build_path(filters.get("studyKey", ""), "records")
+        paginator = AsyncPaginator(self._client, path, params=params)
+        return [Record.from_json(item) async for item in paginator]
+
+    async def get(self, study_key: str, record_id: Union[str, int]) -> Record:
+        path = self._build_path(study_key, "records", record_id)
+        response = await self._client.get(path)
+        raw = response.json().get("data", [])
+        if not raw:
+            raise ValueError(f"Record {record_id} not found in study {study_key}")
+        return Record.from_json(raw[0])
+
+    async def create(
+        self,
+        study_key: str,
+        records_data: List[Dict[str, Any]],
+        email_notify: Union[bool, str, None] = None,
+    ) -> Job:
+        path = self._build_path(study_key, "records")
+        headers = {}
+        if email_notify is not None:
+            if isinstance(email_notify, str):
+                headers["x-email-notify"] = email_notify
+            else:
+                headers["x-email-notify"] = str(email_notify).lower()
+
+        response = await self._client.post(path, json=records_data, headers=headers)
+        return Job.from_json(response.json())

--- a/imednet/endpoints/async_sites.py
+++ b/imednet/endpoints/async_sites.py
@@ -1,0 +1,43 @@
+"""Async endpoint for managing sites in a study."""
+
+from typing import Any, Dict, List, Optional
+
+from imednet.core.async_client import AsyncClient
+from imednet.core.async_paginator import AsyncPaginator
+from imednet.endpoints.base import BaseEndpoint
+from imednet.models.sites import Site
+from imednet.utils.filters import build_filter_string
+
+
+class AsyncSitesEndpoint(BaseEndpoint[AsyncClient]):
+    """Async API endpoint for interacting with study sites."""
+
+    path = "/api/v1/edc/studies"
+
+    def __init__(self, client: AsyncClient, ctx) -> None:
+        super().__init__(client, ctx)
+
+    async def list(self, study_key: Optional[str] = None, **filters: Any) -> List[Site]:
+        filters = self._auto_filter(filters)
+        if study_key:
+            filters["studyKey"] = study_key
+
+        study = filters.pop("studyKey")
+        if not study:
+            raise ValueError("Study key must be provided or set in the context")
+
+        params: Dict[str, Any] = {}
+        if filters:
+            params["filter"] = build_filter_string(filters)
+
+        path = self._build_path(study, "sites")
+        paginator = AsyncPaginator(self._client, path, params=params)
+        return [Site.from_json(item) async for item in paginator]
+
+    async def get(self, study_key: str, site_id: int) -> Site:
+        path = self._build_path(study_key, "sites", site_id)
+        response = await self._client.get(path)
+        raw = response.json().get("data", [])
+        if not raw:
+            raise ValueError(f"Site {site_id} not found in study {study_key}")
+        return Site.from_json(raw[0])

--- a/imednet/endpoints/async_subjects.py
+++ b/imednet/endpoints/async_subjects.py
@@ -1,0 +1,39 @@
+"""Async endpoint for managing subjects in a study."""
+
+from typing import Any, Dict, List, Optional
+
+from imednet.core.async_client import AsyncClient
+from imednet.core.async_paginator import AsyncPaginator
+from imednet.endpoints.base import BaseEndpoint
+from imednet.models.subjects import Subject
+from imednet.utils.filters import build_filter_string
+
+
+class AsyncSubjectsEndpoint(BaseEndpoint[AsyncClient]):
+    """Async API endpoint for interacting with study subjects."""
+
+    path = "/api/v1/edc/studies"
+
+    def __init__(self, client: AsyncClient, ctx) -> None:
+        super().__init__(client, ctx)
+
+    async def list(self, study_key: Optional[str] = None, **filters: Any) -> List[Subject]:
+        filters = self._auto_filter(filters)
+        if study_key:
+            filters["studyKey"] = study_key
+
+        params: Dict[str, Any] = {}
+        if filters:
+            params["filter"] = build_filter_string(filters)
+
+        path = self._build_path(filters.get("studyKey", ""), "subjects")
+        paginator = AsyncPaginator(self._client, path, params=params)
+        return [Subject.from_json(item) async for item in paginator]
+
+    async def get(self, study_key: str, subject_key: str) -> Subject:
+        path = self._build_path(study_key, "subjects", subject_key)
+        response = await self._client.get(path)
+        raw = response.json().get("data", [])
+        if not raw:
+            raise ValueError(f"Subject {subject_key} not found in study {study_key}")
+        return Subject.from_json(raw[0])

--- a/imednet/endpoints/async_users.py
+++ b/imednet/endpoints/async_users.py
@@ -1,0 +1,38 @@
+"""Async endpoint for managing users in a study."""
+
+from typing import Any, Dict, List, Optional, Union
+
+from imednet.core.async_client import AsyncClient
+from imednet.core.async_paginator import AsyncPaginator
+from imednet.endpoints.base import BaseEndpoint
+from imednet.models.users import User
+
+
+class AsyncUsersEndpoint(BaseEndpoint[AsyncClient]):
+    """Async API endpoint for interacting with study users."""
+
+    path = "/api/v1/edc/studies"
+
+    def __init__(self, client: AsyncClient, ctx) -> None:
+        super().__init__(client, ctx)
+
+    async def list(
+        self, study_key: Optional[str] = None, include_inactive: bool = False
+    ) -> List[User]:
+        study_key = study_key or self._ctx.default_study_key
+        if not study_key:
+            raise ValueError("Study key must be provided or set in the context")
+
+        params: Dict[str, Any] = {"includeInactive": str(include_inactive).lower()}
+
+        path = self._build_path(study_key, "users")
+        paginator = AsyncPaginator(self._client, path, params=params)
+        return [User.from_json(item) async for item in paginator]
+
+    async def get(self, study_key: str, user_id: Union[str, int]) -> User:
+        path = self._build_path(study_key, "users", user_id)
+        response = await self._client.get(path)
+        raw = response.json().get("data", [])
+        if not raw:
+            raise ValueError(f"User {user_id} not found in study {study_key}")
+        return User.from_json(raw[0])

--- a/imednet/endpoints/async_variables.py
+++ b/imednet/endpoints/async_variables.py
@@ -1,0 +1,43 @@
+"""Async endpoint for managing variables in a study."""
+
+from typing import Any, Dict, List, Optional
+
+from imednet.core.async_client import AsyncClient
+from imednet.core.async_paginator import AsyncPaginator
+from imednet.endpoints.base import BaseEndpoint
+from imednet.models.variables import Variable
+from imednet.utils.filters import build_filter_string
+
+
+class AsyncVariablesEndpoint(BaseEndpoint[AsyncClient]):
+    """Async API endpoint for interacting with variables."""
+
+    path = "/api/v1/edc/studies"
+
+    def __init__(self, client: AsyncClient, ctx) -> None:
+        super().__init__(client, ctx)
+
+    async def list(self, study_key: Optional[str] = None, **filters: Any) -> List[Variable]:
+        filters = self._auto_filter(filters)
+        if study_key:
+            filters["studyKey"] = study_key
+
+        study = filters.pop("studyKey")
+        if not study:
+            raise ValueError("Study key must be provided or set in the context")
+
+        params: Dict[str, Any] = {}
+        if filters:
+            params["filter"] = build_filter_string(filters)
+
+        path = self._build_path(study, "variables")
+        paginator = AsyncPaginator(self._client, path, params=params, page_size=500)
+        return [Variable.from_json(item) async for item in paginator]
+
+    async def get(self, study_key: str, variable_id: int) -> Variable:
+        path = self._build_path(study_key, "variables", variable_id)
+        response = await self._client.get(path)
+        raw = response.json().get("data", [])
+        if not raw:
+            raise ValueError(f"Variable {variable_id} not found in study {study_key}")
+        return Variable.from_json(raw[0])

--- a/imednet/endpoints/async_visits.py
+++ b/imednet/endpoints/async_visits.py
@@ -1,0 +1,39 @@
+"""Async endpoint for managing visits in a study."""
+
+from typing import Any, Dict, List, Optional
+
+from imednet.core.async_client import AsyncClient
+from imednet.core.async_paginator import AsyncPaginator
+from imednet.endpoints.base import BaseEndpoint
+from imednet.models.visits import Visit
+from imednet.utils.filters import build_filter_string
+
+
+class AsyncVisitsEndpoint(BaseEndpoint[AsyncClient]):
+    """Async API endpoint for interacting with visits."""
+
+    path = "/api/v1/edc/studies"
+
+    def __init__(self, client: AsyncClient, ctx) -> None:
+        super().__init__(client, ctx)
+
+    async def list(self, study_key: Optional[str] = None, **filters: Any) -> List[Visit]:
+        filters = self._auto_filter(filters)
+        if study_key:
+            filters["studyKey"] = study_key
+
+        params: Dict[str, Any] = {}
+        if filters:
+            params["filter"] = build_filter_string(filters)
+
+        path = self._build_path(filters.get("studyKey", ""), "visits")
+        paginator = AsyncPaginator(self._client, path, params=params)
+        return [Visit.from_json(item) async for item in paginator]
+
+    async def get(self, study_key: str, visit_id: int) -> Visit:
+        path = self._build_path(study_key, "visits", visit_id)
+        response = await self._client.get(path)
+        raw = response.json().get("data", [])
+        if not raw:
+            raise ValueError(f"Visit {visit_id} not found in study {study_key}")
+        return Visit.from_json(raw[0])

--- a/tests/unit/test_async_endpoint_forms.py
+++ b/tests/unit/test_async_endpoint_forms.py
@@ -1,0 +1,35 @@
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from imednet.endpoints.async_forms import AsyncFormsEndpoint
+
+
+@pytest.fixture
+def endpoint():
+    client = MagicMock()
+    ctx = MagicMock()
+    return AsyncFormsEndpoint(client, ctx)
+
+
+@pytest.mark.asyncio
+@patch("imednet.endpoints.async_forms.AsyncPaginator")
+@patch("imednet.endpoints.async_forms.Form")
+@patch("imednet.endpoints.async_forms.build_filter_string")
+async def test_list(mock_build, mock_form, mock_pag, endpoint):
+    mock_build.return_value = "foo=bar"
+    mock_pag.return_value.__aiter__.return_value = [{"id": 1}]
+    mock_form.from_json.side_effect = lambda x: x
+
+    result = await endpoint.list(study_key="S1", foo="bar")
+    assert result == [{"id": 1}]
+    assert mock_build.called
+    assert mock_pag.called
+
+
+@pytest.mark.asyncio
+@patch("imednet.endpoints.async_forms.Form")
+async def test_get(mock_form, endpoint):
+    mock_form.from_json.return_value = {"id": 123}
+    endpoint._client.get = AsyncMock(return_value=MagicMock(json=lambda: {"data": [{"id": 123}]}))
+    result = await endpoint.get("S1", 123)
+    assert result == {"id": 123}

--- a/tests/unit/test_async_endpoint_records.py
+++ b/tests/unit/test_async_endpoint_records.py
@@ -1,0 +1,44 @@
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from imednet.endpoints.async_records import AsyncRecordsEndpoint
+
+
+@pytest.fixture
+def endpoint():
+    client = MagicMock()
+    ctx = MagicMock()
+    return AsyncRecordsEndpoint(client, ctx)
+
+
+@pytest.mark.asyncio
+@patch("imednet.endpoints.async_records.AsyncPaginator")
+@patch("imednet.endpoints.async_records.Record")
+@patch("imednet.endpoints.async_records.build_filter_string")
+async def test_list(mock_build, mock_record, mock_pag, endpoint):
+    mock_build.return_value = "a=b"
+    mock_pag.return_value.__aiter__.return_value = [{"id": 1}]
+    mock_record.from_json.side_effect = lambda x: x
+
+    result = await endpoint.list(study_key="S1", a="b")
+    assert result == [{"id": 1}]
+    assert mock_build.called
+    assert mock_pag.called
+
+
+@pytest.mark.asyncio
+@patch("imednet.endpoints.async_records.Record")
+async def test_get(mock_record, endpoint):
+    mock_record.from_json.return_value = {"id": 4}
+    endpoint._client.get = AsyncMock(return_value=MagicMock(json=lambda: {"data": [{"id": 4}]}))
+    result = await endpoint.get("S1", 4)
+    assert result == {"id": 4}
+
+
+@pytest.mark.asyncio
+@patch("imednet.endpoints.async_records.Job")
+async def test_create(mock_job, endpoint):
+    mock_job.from_json.return_value = {"batch": "1"}
+    endpoint._client.post = AsyncMock(return_value=MagicMock(json=lambda: {"batch": "1"}))
+    result = await endpoint.create("S1", [{"foo": "bar"}])
+    assert result == {"batch": "1"}

--- a/tests/unit/test_async_endpoint_sites.py
+++ b/tests/unit/test_async_endpoint_sites.py
@@ -1,0 +1,35 @@
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from imednet.endpoints.async_sites import AsyncSitesEndpoint
+
+
+@pytest.fixture
+def endpoint():
+    client = MagicMock()
+    ctx = MagicMock()
+    return AsyncSitesEndpoint(client, ctx)
+
+
+@pytest.mark.asyncio
+@patch("imednet.endpoints.async_sites.AsyncPaginator")
+@patch("imednet.endpoints.async_sites.Site")
+@patch("imednet.endpoints.async_sites.build_filter_string")
+async def test_list(mock_build, mock_site, mock_pag, endpoint):
+    mock_build.return_value = "f=b"
+    mock_pag.return_value.__aiter__.return_value = [{"id": 1}]
+    mock_site.from_json.side_effect = lambda x: x
+
+    result = await endpoint.list(study_key="S1", f="b")
+    assert result == [{"id": 1}]
+    assert mock_build.called
+    assert mock_pag.called
+
+
+@pytest.mark.asyncio
+@patch("imednet.endpoints.async_sites.Site")
+async def test_get(mock_site, endpoint):
+    mock_site.from_json.return_value = {"id": 2}
+    endpoint._client.get = AsyncMock(return_value=MagicMock(json=lambda: {"data": [{"id": 2}]}))
+    result = await endpoint.get("S1", 2)
+    assert result == {"id": 2}

--- a/tests/unit/test_async_endpoint_subjects.py
+++ b/tests/unit/test_async_endpoint_subjects.py
@@ -1,0 +1,35 @@
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from imednet.endpoints.async_subjects import AsyncSubjectsEndpoint
+
+
+@pytest.fixture
+def endpoint():
+    client = MagicMock()
+    ctx = MagicMock()
+    return AsyncSubjectsEndpoint(client, ctx)
+
+
+@pytest.mark.asyncio
+@patch("imednet.endpoints.async_subjects.AsyncPaginator")
+@patch("imednet.endpoints.async_subjects.Subject")
+@patch("imednet.endpoints.async_subjects.build_filter_string")
+async def test_list(mock_build, mock_subject, mock_pag, endpoint):
+    mock_build.return_value = "x=y"
+    mock_pag.return_value.__aiter__.return_value = [{"id": "s"}]
+    mock_subject.from_json.side_effect = lambda x: x
+
+    result = await endpoint.list(study_key="S1", x="y")
+    assert result == [{"id": "s"}]
+    assert mock_build.called
+    assert mock_pag.called
+
+
+@pytest.mark.asyncio
+@patch("imednet.endpoints.async_subjects.Subject")
+async def test_get(mock_subject, endpoint):
+    mock_subject.from_json.return_value = {"id": "S"}
+    endpoint._client.get = AsyncMock(return_value=MagicMock(json=lambda: {"data": [{"id": "S"}]}))
+    result = await endpoint.get("S1", "S")
+    assert result == {"id": "S"}


### PR DESCRIPTION
## Summary
- implement async endpoints mirroring sync versions
- expose them via `AsyncImednetSDK`
- document async endpoints in README and docs
- add unit tests for new async endpoints

## Testing
- `poetry run pre-commit run --all-files`
- `poetry run pre-commit run --files README.md docs/imednet.endpoints.rst imednet/async_sdk.py imednet/endpoints/async_codings.py imednet/endpoints/async_forms.py imednet/endpoints/async_intervals.py imednet/endpoints/async_jobs.py imednet/endpoints/async_queries.py imednet/endpoints/async_record_revisions.py imednet/endpoints/async_records.py imednet/endpoints/async_sites.py imednet/endpoints/async_subjects.py imednet/endpoints/async_users.py imednet/endpoints/async_variables.py imednet/endpoints/async_visits.py tests/unit/test_async_endpoint_forms.py tests/unit/test_async_endpoint_records.py tests/unit/test_async_endpoint_sites.py tests/unit/test_async_endpoint_subjects.py`
- `poetry run pytest --cov=imednet`


------
https://chatgpt.com/codex/tasks/task_e_68435632559c832c874bff33b623ca6b