### PR TITLE
Add tests for async endpoints

### DIFF
--- a/tests/unit/test_async_endpoint_codings.py
+++ b/tests/unit/test_async_endpoint_codings.py
@@ -1,0 +1,44 @@
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from imednet.endpoints.async_codings import AsyncCodingsEndpoint
+
+
+@pytest.fixture
+def endpoint():
+    client = MagicMock()
+    ctx = MagicMock()
+    ctx.default_study_key = "DEF"
+    return AsyncCodingsEndpoint(client, ctx)
+
+
+@pytest.mark.asyncio
+@patch("imednet.endpoints.async_codings.AsyncPaginator")
+@patch("imednet.endpoints.async_codings.Coding")
+@patch("imednet.endpoints.async_codings.build_filter_string")
+async def test_list(mock_build, mock_model, mock_pag, endpoint):
+    mock_build.return_value = "x=y"
+    mock_pag.return_value.__aiter__.return_value = [{"id": 1}]
+    mock_model.from_json.side_effect = lambda x: x
+
+    result = await endpoint.list(study_key="S1", x="y")
+    assert result == [{"id": 1}]
+    assert mock_build.called
+    assert mock_pag.called
+
+
+@pytest.mark.asyncio
+@patch("imednet.endpoints.async_codings.Coding")
+async def test_get(mock_model, endpoint):
+    mock_model.from_json.return_value = {"id": 2}
+    endpoint._client.get = AsyncMock(return_value=MagicMock(json=lambda: {"data": [{"id": 2}]}))
+
+    result = await endpoint.get("S1", "2")
+    assert result == {"id": 2}
+
+
+@pytest.mark.asyncio
+async def test_list_no_study_key(endpoint):
+    endpoint._ctx.default_study_key = None
+    with pytest.raises(KeyError):
+        await endpoint.list()

--- a/tests/unit/test_async_endpoint_jobs.py
+++ b/tests/unit/test_async_endpoint_jobs.py
@@ -1,0 +1,28 @@
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from imednet.endpoints.async_jobs import AsyncJobsEndpoint
+
+
+@pytest.fixture
+def endpoint():
+    client = MagicMock()
+    ctx = MagicMock()
+    return AsyncJobsEndpoint(client, ctx)
+
+
+@pytest.mark.asyncio
+@patch("imednet.endpoints.async_jobs.Job")
+async def test_get(mock_job, endpoint):
+    mock_job.from_json.return_value = {"batch": "1"}
+    endpoint._client.get = AsyncMock(return_value=MagicMock(json=lambda: {"batch": "1"}))
+
+    result = await endpoint.get("S1", "1")
+    assert result == {"batch": "1"}
+
+
+@pytest.mark.asyncio
+async def test_get_not_found(endpoint):
+    endpoint._client.get = AsyncMock(return_value=MagicMock(json=lambda: {}))
+    with pytest.raises(ValueError):
+        await endpoint.get("S1", "MISSING")

--- a/tests/unit/test_async_endpoint_users.py
+++ b/tests/unit/test_async_endpoint_users.py
@@ -1,0 +1,41 @@
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from imednet.endpoints.async_users import AsyncUsersEndpoint
+
+
+@pytest.fixture
+def endpoint():
+    client = MagicMock()
+    ctx = MagicMock()
+    ctx.default_study_key = "DEF"
+    return AsyncUsersEndpoint(client, ctx)
+
+
+@pytest.mark.asyncio
+@patch("imednet.endpoints.async_users.AsyncPaginator")
+@patch("imednet.endpoints.async_users.User")
+async def test_list(mock_user, mock_pag, endpoint):
+    mock_pag.return_value.__aiter__.return_value = [{"id": "u"}]
+    mock_user.from_json.side_effect = lambda x: x
+
+    result = await endpoint.list("S1", include_inactive=True)
+    assert result == [{"id": "u"}]
+    assert mock_pag.called
+
+
+@pytest.mark.asyncio
+@patch("imednet.endpoints.async_users.User")
+async def test_get(mock_user, endpoint):
+    mock_user.from_json.return_value = {"id": "u"}
+    endpoint._client.get = AsyncMock(return_value=MagicMock(json=lambda: {"data": [{"id": "u"}]}))
+
+    result = await endpoint.get("S1", "u")
+    assert result == {"id": "u"}
+
+
+@pytest.mark.asyncio
+async def test_list_missing_study_key(endpoint):
+    endpoint._ctx.default_study_key = None
+    with pytest.raises(ValueError):
+        await endpoint.list()

--- a/tests/unit/test_async_endpoint_variables.py
+++ b/tests/unit/test_async_endpoint_variables.py
@@ -1,0 +1,37 @@
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from imednet.endpoints.async_variables import AsyncVariablesEndpoint
+
+
+@pytest.fixture
+def endpoint():
+    client = MagicMock()
+    ctx = MagicMock()
+    ctx.default_study_key = "DEF"
+    return AsyncVariablesEndpoint(client, ctx)
+
+
+@pytest.mark.asyncio
+@patch("imednet.endpoints.async_variables.AsyncPaginator")
+@patch("imednet.endpoints.async_variables.Variable")
+@patch("imednet.endpoints.async_variables.build_filter_string")
+async def test_list(mock_build, mock_model, mock_pag, endpoint):
+    mock_build.return_value = "a=b"
+    mock_pag.return_value.__aiter__.return_value = [{"id": 3}]
+    mock_model.from_json.side_effect = lambda x: x
+
+    result = await endpoint.list(study_key="S1", a="b")
+    assert result == [{"id": 3}]
+    assert mock_build.called
+    assert mock_pag.called
+
+
+@pytest.mark.asyncio
+@patch("imednet.endpoints.async_variables.Variable")
+async def test_get(mock_model, endpoint):
+    mock_model.from_json.return_value = {"id": 4}
+    endpoint._client.get = AsyncMock(return_value=MagicMock(json=lambda: {"data": [{"id": 4}]}))
+
+    result = await endpoint.get("S1", 4)
+    assert result == {"id": 4}

--- a/tests/unit/test_endpoint_records.py
+++ b/tests/unit/test_endpoint_records.py
@@ -1,0 +1,42 @@
+from unittest.mock import Mock, patch
+
+import pytest
+from imednet.endpoints.records import RecordsEndpoint
+
+
+@pytest.fixture
+def endpoint():
+    client = Mock()
+    ctx = Mock()
+    ctx.default_study_key = "DEF"
+    return RecordsEndpoint(client, ctx)
+
+
+@patch("imednet.endpoints.records.Paginator")
+@patch("imednet.endpoints.records.Record")
+@patch("imednet.endpoints.records.build_filter_string")
+def test_list(mock_build, mock_record, mock_pag, endpoint):
+    mock_build.return_value = "f=b"
+    mock_pag.return_value = [{"id": 1}]
+    mock_record.from_json.side_effect = lambda x: x
+
+    result = endpoint.list(study_key="S1", f="b")
+    assert result == [{"id": 1}]
+    assert mock_build.called
+    assert mock_pag.called
+
+
+@patch("imednet.endpoints.records.Record")
+def test_get(mock_record, endpoint):
+    endpoint._client.get.return_value.json.return_value = {"data": [{"id": 2}]}
+    mock_record.from_json.return_value = {"id": 2}
+    result = endpoint.get("S1", 2)
+    assert result == {"id": 2}
+
+
+@patch("imednet.endpoints.records.Job")
+def test_create(mock_job, endpoint):
+    endpoint._client.post.return_value.json.return_value = {"job": 1}
+    mock_job.from_json.return_value = {"job": 1}
+    result = endpoint.create("S1", [{"foo": "bar"}], email_notify=True)
+    assert result == {"job": 1}


### PR DESCRIPTION
## Summary
- add coverage for async codings, variables, jobs and users
- test the synchronous records endpoint

## Testing
- `poetry run pre-commit run --files tests/unit/test_async_endpoint_codings.py tests/unit/test_async_endpoint_variables.py tests/unit/test_async_endpoint_jobs.py tests/unit/test_async_endpoint_users.py tests/unit/test_endpoint_records.py`
- `poetry run pytest --cov=imednet`

------
https://chatgpt.com/codex/tasks/task_e_68435d190bc4832ca7e6b4ad6863a516