### PR TITLE
Add Veeva Vault metadata helper

### DIFF
--- a/imednet/veeva/vault.py
+++ b/imednet/veeva/vault.py
@@ -58,12 +58,53 @@ class VeevaVaultClient:
         resp.raise_for_status()
         return resp.json().get("data", [])
 
+    def get_picklist_values(self, picklist_name: str) -> List[Dict[str, Any]]:
+        """Return values for a specific picklist."""
+        url = f"/api/{self.api_version}/metadata/picklists/{picklist_name}"
+        resp = self._client.get(url, headers=self._headers())
+        resp.raise_for_status()
+        data = resp.json().get("data", {})
+        if isinstance(data, dict):
+            return data.get("values", [])
+        return data
+
     def get_object_metadata(self, object_name: str) -> Dict[str, Any]:
         """Return metadata for a specific object."""
         url = f"/api/{self.api_version}/metadata/objects/{object_name}"
         resp = self._client.get(url, headers=self._headers())
         resp.raise_for_status()
         return resp.json().get("data", {})
+
+    def describe_object(self, object_name: str, object_type: str | None = None) -> Dict[str, Any]:
+        """Return required fields and picklist values for an object."""
+        metadata = self.get_object_metadata(object_name)
+        fields = list(metadata.get("fields", []))
+
+        if object_type:
+            url = f"/api/{self.api_version}/configuration/{object_name}.{object_type}"
+            resp = self._client.get(url, headers=self._headers())
+            resp.raise_for_status()
+            type_fields = resp.json().get("data", {}).get("fields", [])
+            fields.extend(type_fields)
+
+        required: set[str] = set()
+        picklists: Dict[str, List[Any]] = {}
+
+        for field in fields:
+            name = field.get("name")
+            if not name:
+                continue
+            if field.get("required"):
+                required.add(name)
+            if field.get("type", "").lower() == "picklist":
+                picklist_name = field.get("picklist") or field.get("picklist_name")
+                if picklist_name:
+                    picklists[name] = self.get_picklist_values(picklist_name)
+
+        return {
+            "required_fields": sorted(required),
+            "picklists": picklists,
+        }
 
     def upsert_object(self, object_name: str, record: Mapping[str, Any]) -> Dict[str, Any]:
         """Create or update a record for the given object."""


### PR DESCRIPTION
## Summary
- add `get_picklist_values` and `describe_object` helpers
- test required field collection and picklist lookup

## Testing
- `poetry run pre-commit run --files imednet/veeva/vault.py tests/test_veeva_vault.py`
- `poetry run pytest --cov=imednet`

------
https://chatgpt.com/codex/tasks/task_e_6843072bb32c832c9ebe85349d5d3bc5