### PR TITLE
Add method for Vault field metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ This file is automatically updated by the release process.
 - Removed the Flask-based web UI and associated templates to focus on the CLI.
 - Added helper `collect_required_fields_and_picklists` for retrieving required
   fields and picklist options from Vault.
+- Added method `VeevaVaultClient.collect_required_fields_and_picklists` for
+  fetching required fields and picklists directly from the client.
 - Added configurable `default_page_size` for SDK pagination.
 
 ### Fixed


### PR DESCRIPTION
## Summary
- add `VeevaVaultClient.collect_required_fields_and_picklists` and supporting `get_object_type_configuration`
- expose helper function to call the new method
- test new class method and update existing tests
- document change in changelog

## Testing
- `poetry run pre-commit run --all-files`
- `poetry run pre-commit run --files CHANGELOG.md imednet/veeva/vault.py tests/test_veeva_vault.py`
- `poetry run pytest --cov=imednet`

------
https://chatgpt.com/codex/tasks/task_e_684362da38f8832cb0c2b9cb7f316bc2