### PR TITLE
Add visit completion workflow and CLI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ This file is automatically updated by the release process.
 - Added helper `collect_required_fields_and_picklists` for retrieving required
   fields and picklist options from Vault.
 - Added configurable `default_page_size` for SDK pagination.
+- Added `VisitCompletionWorkflow` and CLI command `workflows visit-completion` to
+  summarize visit progress for a subject.
 
 ### Fixed
 

--- a/docs/imednet.workflows.rst
+++ b/docs/imednet.workflows.rst
@@ -52,6 +52,14 @@ imednet.workflows.subject\_data module
    :undoc-members:
    :show-inheritance:
 
+imednet.workflows.visit\_completion module
+-----------------------------------------
+
+.. automodule:: imednet.workflows.visit_completion
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
 Module contents
 ---------------
 

--- a/imednet/cli.py
+++ b/imednet/cli.py
@@ -28,6 +28,7 @@ from .utils.filters import build_filter_string
 from .workflows.data_extraction import DataExtractionWorkflow
 from .workflows.query_management import QueryManagementWorkflow
 from .workflows.register_subjects import RegisterSubjectsWorkflow
+from .workflows.visit_completion import VisitCompletionWorkflow
 
 # Load environment variables from .env file if it exists
 load_dotenv()
@@ -371,6 +372,26 @@ def register_subjects_cmd(
         result = workflow.register_subjects(
             study_key=study_key, subjects=subjects, email_notify=email_notify
         )
+        print(result)
+    except ApiError as e:
+        print(f"[bold red]API Error:[/bold red] {e}")
+        raise typer.Exit(code=1)
+    except Exception as e:
+        print(f"[bold red]An unexpected error occurred:[/bold red] {e}")
+        raise typer.Exit(code=1)
+
+
+@workflows_app.command("visit-completion")
+def visit_completion_cmd(
+    ctx: typer.Context,
+    study_key: str = typer.Argument(..., help="The key identifying the study."),
+    subject_key: str = typer.Argument(..., help="The key identifying the subject."),
+) -> None:
+    """Summarize visit completion for a subject."""
+    sdk = get_sdk(ctx)
+    workflow = VisitCompletionWorkflow(sdk)
+    try:
+        result = workflow.get_subject_progress(study_key, subject_key)
         print(result)
     except ApiError as e:
         print(f"[bold red]API Error:[/bold red] {e}")

--- a/imednet/workflows/__init__.py
+++ b/imednet/workflows/__init__.py
@@ -14,6 +14,7 @@ from .record_update import RecordUpdateWorkflow
 from .register_subjects import RegisterSubjectsWorkflow
 from .study_structure import get_study_structure
 from .subject_data import SubjectDataWorkflow
+from .visit_completion import VisitCompletionWorkflow
 
 __all__ = [
     # Original (commented out):
@@ -31,5 +32,6 @@ __all__ = [
     "RecordUpdateWorkflow",
     "RegisterSubjectsWorkflow",
     "SubjectDataWorkflow",
+    "VisitCompletionWorkflow",
     "get_study_structure",
 ]

--- a/imednet/workflows/visit_completion.py
+++ b/imednet/workflows/visit_completion.py
@@ -1,0 +1,36 @@
+"""Workflow for summarizing visit completion for a subject."""
+
+from typing import TYPE_CHECKING, Dict
+
+from ..utils.filters import build_filter_string
+from .study_structure import get_study_structure
+
+if TYPE_CHECKING:  # pragma: no cover - import for type checking only
+    from ..sdk import ImednetSDK
+
+
+class VisitCompletionWorkflow:
+    """Provide utilities for assessing visit completion for a subject."""
+
+    def __init__(self, sdk: "ImednetSDK") -> None:
+        self._sdk = sdk
+
+    def get_subject_progress(self, study_key: str, subject_key: str) -> Dict[str, Dict[str, str]]:
+        """Return record status for all expected visit/forms for a subject."""
+        structure = get_study_structure(self._sdk, study_key)
+        filter_str = build_filter_string({"subject_key": subject_key})
+        records = self._sdk.records.list(study_key, filter=filter_str)
+
+        record_status_map: Dict[tuple[int, int], str] = {}
+        for rec in records:
+            record_status_map[(rec.interval_id, rec.form_id)] = rec.record_status
+
+        progress: Dict[str, Dict[str, str]] = {}
+        for interval in structure.intervals:
+            form_progress: Dict[str, str] = {}
+            for form in interval.forms:
+                status = record_status_map.get((interval.interval_id, form.form_id), "MISSING")
+                form_progress[form.form_key] = status
+            progress[interval.interval_name] = form_progress
+
+        return progress

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -16,6 +16,7 @@ from imednet.cli import (
     query_state_counts_cmd,
     register_subjects_cmd,
     save_credentials_cmd,
+    visit_completion_cmd,
 )
 from imednet.core.exceptions import ApiError
 
@@ -270,6 +271,21 @@ def test_register_subjects_cmd(mock_get_sdk, tmp_path):
         register_subjects_cmd(ctx, "STUDY1", data_file, None)
 
         workflow_instance.register_subjects.assert_called_once()
+
+
+@patch("imednet.cli.get_sdk")
+def test_visit_completion_cmd(mock_get_sdk):
+    mock_sdk = MagicMock()
+    mock_get_sdk.return_value = mock_sdk
+    workflow_instance = MagicMock()
+    with patch("imednet.cli.VisitCompletionWorkflow") as mock_wf_cls:
+        mock_wf_cls.return_value = workflow_instance
+
+        ctx = MagicMock()
+        ctx.obj = {}
+        visit_completion_cmd(ctx, "STUDY1", "SUBJ1")
+
+        workflow_instance.get_subject_progress.assert_called_once_with("STUDY1", "SUBJ1")
 
 
 @patch("imednet.cli.store_creds")

--- a/tests/workflows/test_visit_completion.py
+++ b/tests/workflows/test_visit_completion.py
@@ -1,0 +1,72 @@
+from unittest.mock import MagicMock, patch
+
+import pytest
+from imednet.models.records import Record
+from imednet.models.study_structure import FormStructure, IntervalStructure, StudyStructure
+from imednet.workflows.visit_completion import VisitCompletionWorkflow
+
+
+@pytest.fixture
+def mock_sdk():
+    return MagicMock()
+
+
+def test_get_subject_progress(mock_sdk):
+    structure = StudyStructure(
+        study_key="STUDY1",
+        intervals=[
+            IntervalStructure(
+                interval_id=1,
+                interval_name="Visit 1",
+                interval_sequence=1,
+                interval_description="",
+                interval_group_name="",
+                disabled=False,
+                date_created="2024-01-01T00:00:00",
+                date_modified="2024-01-01T00:00:00",
+                forms=[
+                    FormStructure(
+                        form_id=10,
+                        form_key="FORM1",
+                        form_name="Form 1",
+                        form_type="CRF",
+                        revision=1,
+                        disabled=False,
+                        epro_form=False,
+                        allow_copy=False,
+                        date_created="2024-01-01T00:00:00",
+                        date_modified="2024-01-01T00:00:00",
+                        variables=[],
+                    )
+                ],
+            )
+        ],
+    )
+    record = Record(
+        study_key="STUDY1",
+        interval_id=1,
+        form_id=10,
+        form_key="FORM1",
+        site_id=1,
+        record_id=1,
+        record_oid="R1",
+        record_type="SCHEDULED",
+        record_status="COMPLETE",
+        deleted=False,
+        date_created="2024-01-01T00:00:00",
+        date_modified="2024-01-01T00:00:00",
+        subject_id=1,
+        subject_oid="S1",
+        subject_key="SUBJ1",
+        visit_id=1,
+        parent_record_id=0,
+        keywords=[],
+        record_data={},
+    )
+
+    with patch("imednet.workflows.visit_completion.get_study_structure", return_value=structure):
+        mock_sdk.records.list.return_value = [record]
+        wf = VisitCompletionWorkflow(mock_sdk)
+        result = wf.get_subject_progress("STUDY1", "SUBJ1")
+        assert result == {"Visit 1": {"FORM1": "COMPLETE"}}
+        mock_sdk.records.list.assert_called_once()


### PR DESCRIPTION
## Summary
- add `VisitCompletionWorkflow` for summarizing form status by visit
- expose workflow in public API and CLI
- document new workflow in Sphinx docs
- test the new workflow and CLI command

## Testing
- `poetry run pre-commit run --all-files`
- `poetry run pre-commit run --files CHANGELOG.md docs/imednet.workflows.rst imednet/cli.py imednet/workflows/__init__.py imednet/workflows/visit_completion.py tests/test_cli.py tests/workflows/test_visit_completion.py`
- `poetry run pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6843638fbcc4832c8c68cff34d10b922