### PR TITLE
Add visit tracking workflow

### DIFF
--- a/docs/workflows/visit_tracking.rst
+++ b/docs/workflows/visit_tracking.rst
@@ -1,0 +1,16 @@
+Visit Tracking Workflow
+=======================
+
+The ``VisitTrackingWorkflow`` aggregates visit completion for all subjects in a study.
+It uses :class:`~imednet.workflows.visit_completion.VisitCompletionWorkflow` to
+compute each subject's progress and returns the results keyed by subject key.
+
+Example usage::
+
+   from imednet.sdk import ImednetSDK
+   from imednet.workflows.visit_tracking import VisitTrackingWorkflow
+
+   sdk = ImednetSDK(api_key="<API_KEY>", security_key="<SECURITY_KEY>")
+   workflow = VisitTrackingWorkflow(sdk)
+   progress = workflow.summary_by_subject("MY_STUDY")
+   print(progress)

--- a/imednet/workflows/visit_tracking.py
+++ b/imednet/workflows/visit_tracking.py
@@ -1,0 +1,26 @@
+"""Workflow utilities for tracking visit completion across subjects."""
+
+from typing import TYPE_CHECKING, Dict
+
+from .visit_completion import VisitCompletionWorkflow
+
+if TYPE_CHECKING:  # pragma: no cover - imported for type checking only
+    from ..sdk import ImednetSDK
+
+
+class VisitTrackingWorkflow:
+    """Aggregate visit completion information for multiple subjects."""
+
+    def __init__(self, sdk: "ImednetSDK") -> None:
+        self._sdk = sdk
+        self._subject_tracker = VisitCompletionWorkflow(sdk)
+
+    def summary_by_subject(self, study_key: str) -> Dict[str, Dict[str, Dict[str, str]]]:
+        """Return visit completion progress for every subject in the study."""
+        subjects = self._sdk.subjects.list(study_key)
+        summary: Dict[str, Dict[str, Dict[str, str]]] = {}
+        for subj in subjects:
+            summary[subj.subject_key] = self._subject_tracker.get_subject_progress(
+                study_key, subj.subject_key
+            )
+        return summary

--- a/tests/workflows/test_visit_tracking.py
+++ b/tests/workflows/test_visit_tracking.py
@@ -1,0 +1,61 @@
+from unittest.mock import MagicMock, patch
+
+import pytest
+from imednet.models.subjects import Subject
+from imednet.workflows.visit_tracking import VisitTrackingWorkflow
+
+
+@pytest.fixture
+def mock_sdk():
+    return MagicMock()
+
+
+def test_summary_by_subject(mock_sdk):
+    subject1 = Subject(
+        study_key="ST",
+        subject_id=1,
+        subject_oid="SO1",
+        subject_key="SUBJ1",
+        subject_status="",
+        site_id=1,
+        site_name="",
+        deleted=False,
+        enrollment_start_date="2024-01-01T00:00:00",
+        date_created="2024-01-01T00:00:00",
+        date_modified="2024-01-01T00:00:00",
+        keywords=[],
+    )
+    subject2 = Subject(
+        study_key="ST",
+        subject_id=2,
+        subject_oid="SO2",
+        subject_key="SUBJ2",
+        subject_status="",
+        site_id=1,
+        site_name="",
+        deleted=False,
+        enrollment_start_date="2024-01-01T00:00:00",
+        date_created="2024-01-01T00:00:00",
+        date_modified="2024-01-01T00:00:00",
+        keywords=[],
+    )
+    mock_sdk.subjects.list.return_value = [subject1, subject2]
+
+    with patch("imednet.workflows.visit_tracking.VisitCompletionWorkflow") as mock_vc_cls:
+        vc_instance = MagicMock()
+        vc_instance.get_subject_progress.side_effect = [
+            {"Visit": {"F1": "COMPLETE"}},
+            {"Visit": {"F1": "MISSING"}},
+        ]
+        mock_vc_cls.return_value = vc_instance
+
+        workflow = VisitTrackingWorkflow(mock_sdk)
+        result = workflow.summary_by_subject("STUDY1")
+
+        expected = {
+            "SUBJ1": {"Visit": {"F1": "COMPLETE"}},
+            "SUBJ2": {"Visit": {"F1": "MISSING"}},
+        }
+        assert result == expected
+        mock_sdk.subjects.list.assert_called_once_with("STUDY1")
+        assert vc_instance.get_subject_progress.call_count == 2


### PR DESCRIPTION
## Summary
- add VisitTrackingWorkflow that summarizes visit completion for all subjects
- test VisitTrackingWorkflow
- document the workflow

## Testing
- `poetry run pre-commit run --all-files`
- `poetry run pre-commit run --files imednet/workflows/visit_tracking.py tests/workflows/test_visit_tracking.py docs/workflows/visit_tracking.rst`
- `poetry run pytest --cov=imednet`


------
https://chatgpt.com/codex/tasks/task_e_6843695db204832cb656d7363a9e66ae