### PR TITLE
Add SitePerformance workflow

### DIFF
--- a/docs/imednet.workflows.rst
+++ b/docs/imednet.workflows.rst
@@ -57,6 +57,14 @@ imednet.workflows.enrollment_dashboard module
 
 .. automodule:: imednet.workflows.enrollment_dashboard
 
+imednet.workflows.site_performance module
+----------------------------------------
+
+.. automodule:: imednet.workflows.site_performance
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
 imednet.workflows.visit\_completion module
 -----------------------------------------
 

--- a/docs/workflows/site_performance.rst
+++ b/docs/workflows/site_performance.rst
@@ -1,0 +1,23 @@
+Site Performance Workflow
+=========================
+
+The :class:`~imednet.workflows.site_performance.SitePerformanceWorkflow` helps
+summarize enrollment and query metrics for each site in a study.
+
+Example usage::
+
+   from imednet.sdk import ImednetSDK
+   from imednet.workflows.site_performance import SitePerformanceWorkflow
+
+   sdk = ImednetSDK(api_key="<API_KEY>", security_key="<SECURITY_KEY>")
+   workflow = SitePerformanceWorkflow(sdk)
+   metrics = workflow.get_site_metrics("MY_STUDY")
+   print(metrics)
+
+``metrics`` is a :class:`pandas.DataFrame` with columns:
+
+- ``site_id`` – numeric site identifier
+- ``site_name`` – name of the site
+- ``site_enrollment_status`` – current enrollment status
+- ``subject_count`` – number of subjects registered at the site
+- ``open_query_count`` – count of open queries linked to subjects at the site

--- a/imednet/workflows/__init__.py
+++ b/imednet/workflows/__init__.py
@@ -12,6 +12,7 @@ from .query_management import QueryManagementWorkflow
 from .record_mapper import RecordMapper
 from .record_update import RecordUpdateWorkflow
 from .register_subjects import RegisterSubjectsWorkflow
+from .site_performance import SitePerformanceWorkflow
 from .study_structure import get_study_structure
 from .subject_data import SubjectDataWorkflow
 from .visit_completion import VisitCompletionWorkflow
@@ -31,6 +32,7 @@ __all__ = [
     "RecordMapper",
     "RecordUpdateWorkflow",
     "RegisterSubjectsWorkflow",
+    "SitePerformanceWorkflow",
     "SubjectDataWorkflow",
     "VisitCompletionWorkflow",
     "get_study_structure",

--- a/imednet/workflows/site_performance.py
+++ b/imednet/workflows/site_performance.py
@@ -1,0 +1,48 @@
+"""Workflow for summarizing site-level performance metrics."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, Dict, List
+
+import pandas as pd
+
+from .query_management import QueryManagementWorkflow
+
+if TYPE_CHECKING:  # pragma: no cover - imported for type checking only
+    from ..sdk import ImednetSDK
+
+
+class SitePerformanceWorkflow:
+    """Provide methods for aggregating site-level metrics."""
+
+    def __init__(self, sdk: "ImednetSDK") -> None:
+        self._sdk = sdk
+        self._queries = QueryManagementWorkflow(sdk)
+
+    def get_site_metrics(self, study_key: str) -> pd.DataFrame:
+        """Return enrollment and query counts grouped by site."""
+        sites = self._sdk.sites.list(study_key)
+        subjects = self._sdk.subjects.list(study_key)
+        subject_lookup: Dict[int, Any] = {s.subject_id: s for s in subjects}
+        open_queries = self._queries.get_open_queries(study_key)
+
+        rows: List[Dict[str, Any]] = []
+        for site in sites:
+            subj_count = sum(1 for s in subjects if s.site_id == site.site_id)
+            open_count = sum(
+                1
+                for q in open_queries
+                if subject_lookup.get(q.subject_id)
+                and subject_lookup[q.subject_id].site_id == site.site_id
+            )
+            rows.append(
+                {
+                    "site_id": site.site_id,
+                    "site_name": site.site_name,
+                    "site_enrollment_status": site.site_enrollment_status,
+                    "subject_count": subj_count,
+                    "open_query_count": open_count,
+                }
+            )
+
+        return pd.DataFrame(rows)

--- a/tests/workflows/test_site_performance.py
+++ b/tests/workflows/test_site_performance.py
@@ -1,0 +1,102 @@
+from unittest.mock import MagicMock, patch
+
+import pandas as pd
+import pytest
+from imednet.models.queries import Query
+from imednet.models.sites import Site
+from imednet.models.subjects import Subject
+from imednet.workflows.site_performance import SitePerformanceWorkflow
+
+
+@pytest.fixture
+def mock_sdk():
+    sdk = MagicMock()
+    sdk.sites.list = MagicMock()
+    sdk.subjects.list = MagicMock()
+    return sdk
+
+
+def make_site(site_id: int, status: str = "Active") -> Site:
+    return Site(
+        study_key="ST",
+        site_id=site_id,
+        site_name=f"Site {site_id}",
+        site_enrollment_status=status,
+        date_created="2024-01-01T00:00:00",
+        date_modified="2024-01-01T00:00:00",
+    )
+
+
+def make_subject(subject_id: int, site_id: int) -> Subject:
+    return Subject(
+        study_key="ST",
+        subject_id=subject_id,
+        subject_oid=f"S{subject_id}",
+        subject_key=f"SUBJ{subject_id}",
+        subject_status="Enrolled",
+        site_id=site_id,
+        site_name=f"Site {site_id}",
+        deleted=False,
+        enrollment_start_date="2024-01-01T00:00:00",
+        date_created="2024-01-01T00:00:00",
+        date_modified="2024-01-01T00:00:00",
+        keywords=[],
+    )
+
+
+def make_query(subject_id: int) -> Query:
+    return Query(
+        study_key="ST",
+        subject_id=subject_id,
+        subject_oid=f"S{subject_id}",
+        annotation_type="",
+        annotation_id=1,
+        description="",
+        record_id=1,
+        variable="",
+        subject_key=f"SUBJ{subject_id}",
+        date_created="2024-01-01T00:00:00",
+        date_modified="2024-01-01T00:00:00",
+        query_comments=[],
+    )
+
+
+@patch("imednet.workflows.site_performance.QueryManagementWorkflow")
+def test_get_site_metrics(mock_qm_class, mock_sdk):
+    mock_sdk.sites.list.return_value = [make_site(1), make_site(2)]
+    mock_sdk.subjects.list.return_value = [
+        make_subject(1, 1),
+        make_subject(2, 1),
+        make_subject(3, 2),
+    ]
+
+    mock_qm = mock_qm_class.return_value
+    mock_qm.get_open_queries.return_value = [make_query(1), make_query(3)]
+
+    wf = SitePerformanceWorkflow(mock_sdk)
+    df = wf.get_site_metrics("ST")
+
+    assert isinstance(df, pd.DataFrame)
+    row1 = df[df["site_id"] == 1].iloc[0]
+    row2 = df[df["site_id"] == 2].iloc[0]
+
+    assert row1["subject_count"] == 2
+    assert row1["open_query_count"] == 1
+    assert row2["subject_count"] == 1
+    assert row2["open_query_count"] == 1
+    mock_qm.get_open_queries.assert_called_once_with("ST")
+
+
+@patch("imednet.workflows.site_performance.QueryManagementWorkflow")
+def test_get_site_metrics_unknown_subject(mock_qm_class, mock_sdk):
+    mock_sdk.sites.list.return_value = [make_site(1)]
+    mock_sdk.subjects.list.return_value = [make_subject(1, 1)]
+
+    mock_qm = mock_qm_class.return_value
+    # Query for subject not in the list should be ignored
+    mock_qm.get_open_queries.return_value = [make_query(999)]
+
+    wf = SitePerformanceWorkflow(mock_sdk)
+    df = wf.get_site_metrics("ST")
+
+    assert df.loc[0, "open_query_count"] == 0


### PR DESCRIPTION
## Summary
- add workflow for summarizing site enrollment and query metrics
- expose the new workflow from `imednet.workflows`
- document the new workflow and generate API docs
- test site performance aggregation logic

## Testing
- `poetry run pre-commit run --files imednet/workflows/site_performance.py imednet/workflows/__init__.py docs/imednet.workflows.rst docs/workflows/site_performance.rst tests/workflows/test_site_performance.py`
- `poetry run pytest --cov=imednet`

------
https://chatgpt.com/codex/tasks/task_e_6843695e40fc832c9ea48ecb723411e0