### PR TITLE
Add coding review workflow

### DIFF
--- a/docs/imednet.workflows.rst
+++ b/docs/imednet.workflows.rst
@@ -20,6 +20,14 @@ imednet.workflows.query\_management module
    :undoc-members:
    :show-inheritance:
 
+imednet.workflows.coding\_review module
+--------------------------------------
+
+.. automodule:: imednet.workflows.coding_review
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
 imednet.workflows.record\_mapper module
 ---------------------------------------
 

--- a/docs/workflows/coding_review.rst
+++ b/docs/workflows/coding_review.rst
@@ -1,0 +1,15 @@
+Coding Review Workflow
+=====================
+
+The :class:`~imednet.workflows.coding_review.CodingReviewWorkflow` provides
+utilities to inspect codings within a study and highlight potential issues.
+
+Functions include:
+
+* ``list_codings`` - retrieve codings using optional filter criteria.
+* ``get_uncoded_items`` - return items where no code has been assigned.
+* ``get_inconsistent_codings`` - detect variable/value pairs coded with multiple
+  different codes.
+
+These helpers build upon the ``codings`` endpoint to simplify quality checks
+for medical coding data.

--- a/imednet/workflows/coding_review.py
+++ b/imednet/workflows/coding_review.py
@@ -1,0 +1,64 @@
+"""Workflow utilities for reviewing coding completeness and consistency."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, Union
+
+from ..models import Coding
+from ..utils.filters import build_filter_string
+
+if TYPE_CHECKING:  # pragma: no cover - for type checking only
+    from ..sdk import ImednetSDK
+
+
+class CodingReviewWorkflow:
+    """Helpers for retrieving codings and identifying issues."""
+
+    def __init__(self, sdk: "ImednetSDK") -> None:
+        self._sdk = sdk
+
+    def list_codings(
+        self,
+        study_key: str,
+        coding_filter: Optional[Dict[str, Union[Any, Tuple[str, Any], List[Any]]]] = None,
+        **kwargs: Any,
+    ) -> List[Coding]:
+        """Return codings for a study using optional filter criteria."""
+        filter_str = build_filter_string(coding_filter) if coding_filter else None
+        return self._sdk.codings.list(study_key, filter=filter_str, **kwargs)
+
+    def get_uncoded_items(
+        self,
+        study_key: str,
+        coding_filter: Optional[Dict[str, Union[Any, Tuple[str, Any], List[Any]]]] = None,
+        **kwargs: Any,
+    ) -> List[Coding]:
+        """Return codings missing a code value."""
+        codings = self.list_codings(study_key, coding_filter, **kwargs)
+        return [c for c in codings if not c.code]
+
+    def get_inconsistent_codings(
+        self,
+        study_key: str,
+        coding_filter: Optional[Dict[str, Union[Any, Tuple[str, Any], List[Any]]]] = None,
+        **kwargs: Any,
+    ) -> List[Coding]:
+        """Return codings where the same variable/value pair has multiple codes."""
+        codings = self.list_codings(study_key, coding_filter, **kwargs)
+        groups: Dict[Tuple[str, str], List[Coding]] = {}
+        for coding in codings:
+            key = (coding.variable, coding.value)
+            groups.setdefault(key, []).append(coding)
+
+        inconsistent: List[Coding] = []
+        for items in groups.values():
+            codes = {c.code for c in items if c.code}
+            if len(codes) > 1:
+                inconsistent.extend(items)
+
+        return inconsistent
+
+
+# Integration:
+# - Import :class:`CodingReviewWorkflow` from ``imednet.workflows`` or initialize
+#   directly via ``sdk.workflows`` when available.

--- a/tests/workflows/test_coding_review.py
+++ b/tests/workflows/test_coding_review.py
@@ -1,0 +1,52 @@
+from unittest.mock import MagicMock, patch
+
+from imednet.models.codings import Coding
+from imednet.workflows.coding_review import CodingReviewWorkflow
+
+
+def _make_coding(coding_id: int, variable: str, value: str, code: str) -> Coding:
+    return Coding(coding_id=coding_id, variable=variable, value=value, code=code)
+
+
+def test_list_codings_builds_filter_and_calls_sdk():
+    sdk = MagicMock()
+    sdk.codings.list.return_value = []
+    wf = CodingReviewWorkflow(sdk)
+
+    with patch("imednet.workflows.coding_review.build_filter_string", return_value="foo") as bfs:
+        result = wf.list_codings("ST", {"a": 1}, page_size=10)
+
+    sdk.codings.list.assert_called_once_with("ST", filter="foo", page_size=10)
+    bfs.assert_called_once_with({"a": 1})
+    assert result == []
+
+
+def test_get_uncoded_items_filters_empty_codes():
+    sdk = MagicMock()
+    codings = [
+        _make_coding(1, "AE", "Headache", ""),
+        _make_coding(2, "AE", "Headache", "A1"),
+        _make_coding(3, "AE", "Nausea", ""),
+    ]
+    sdk.codings.list.return_value = codings
+    wf = CodingReviewWorkflow(sdk)
+
+    result = wf.get_uncoded_items("ST")
+
+    assert result == [codings[0], codings[2]]
+
+
+def test_get_inconsistent_codings_detects_multiple_codes():
+    sdk = MagicMock()
+    codings = [
+        _make_coding(1, "AE", "Headache", "A1"),
+        _make_coding(2, "AE", "Headache", "B2"),
+        _make_coding(3, "AE", "Nausea", "A1"),
+    ]
+    sdk.codings.list.return_value = codings
+    wf = CodingReviewWorkflow(sdk)
+
+    result = wf.get_inconsistent_codings("ST")
+
+    assert codings[0] in result and codings[1] in result
+    assert codings[2] not in result


### PR DESCRIPTION
## Summary
- implement `CodingReviewWorkflow`
- test new workflow
- document coding review helper
- expose coding review docs in workflow module list

## Testing
- `pre-commit run --files imednet/workflows/coding_review.py docs/workflows/coding_review.rst docs/imednet.workflows.rst tests/workflows/test_coding_review.py`
- `pytest --cov=imednet`

------
https://chatgpt.com/codex/tasks/task_e_6843695e67bc832ca0b1580e4077c69c