### PR TITLE
Add audit aggregation workflow

### DIFF
--- a/docs/imednet.workflows.rst
+++ b/docs/imednet.workflows.rst
@@ -65,6 +65,14 @@ imednet.workflows.visit\_completion module
    :undoc-members:
    :show-inheritance:
 
+imednet.workflows.audit\_aggregation module
+-------------------------------------------
+
+.. automodule:: imednet.workflows.audit_aggregation
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
 Module contents
 ---------------
 

--- a/docs/workflows/audit_aggregation.rst
+++ b/docs/workflows/audit_aggregation.rst
@@ -1,0 +1,31 @@
+AuditAggregationWorkflow
+========================
+
+The :class:`~imednet.workflows.audit_aggregation.AuditAggregationWorkflow`
+provides helper methods to summarize audit trail information from the
+``recordRevisions`` endpoint.
+
+Summary by user
+---------------
+
+``summary_by_user`` aggregates record revision counts for each user within a
+specified date range. The method fetches the revisions via the SDK and groups
+them client side.
+
+Example usage::
+
+   from imednet.sdk import ImednetSDK
+   from imednet.workflows.audit_aggregation import AuditAggregationWorkflow
+
+   sdk = ImednetSDK(api_key="<API>", security_key="<SEC>")
+   wf = AuditAggregationWorkflow(sdk)
+   counts = wf.summary_by_user(
+       study_key="MY_STUDY",
+       start_date="2024-01-01",
+       end_date="2024-01-31",
+       site_id=1,
+   )
+   print(counts)
+
+This returns a dictionary mapping each username to the number of revisions they
+performed during the period.

--- a/imednet/workflows/__init__.py
+++ b/imednet/workflows/__init__.py
@@ -8,6 +8,7 @@
 # from .subject_data import get_subject_data
 
 # --- Correct workflow class/function imports ---
+from .audit_aggregation import AuditAggregationWorkflow
 from .query_management import QueryManagementWorkflow
 from .record_mapper import RecordMapper
 from .record_update import RecordUpdateWorkflow
@@ -33,5 +34,6 @@ __all__ = [
     "RegisterSubjectsWorkflow",
     "SubjectDataWorkflow",
     "VisitCompletionWorkflow",
+    "AuditAggregationWorkflow",
     "get_study_structure",
 ]

--- a/imednet/workflows/audit_aggregation.py
+++ b/imednet/workflows/audit_aggregation.py
@@ -1,0 +1,50 @@
+"""Utility workflows for summarizing audit trail data."""
+
+from typing import TYPE_CHECKING, Any, Dict, Optional
+
+from ..utils.filters import build_filter_string
+
+if TYPE_CHECKING:  # pragma: no cover - imported for type checking only
+    from ..sdk import ImednetSDK
+
+
+class AuditAggregationWorkflow:
+    """Provide utilities for aggregating record revision information."""
+
+    def __init__(self, sdk: "ImednetSDK") -> None:
+        self._sdk = sdk
+
+    def summary_by_user(
+        self,
+        study_key: str,
+        start_date: Optional[str] = None,
+        end_date: Optional[str] = None,
+        **filters: Any,
+    ) -> Dict[str, int]:
+        """Return a count of record revisions grouped by user.
+
+        Args:
+            study_key: Identifier for the study.
+            start_date: Optional start date filter in ``YYYY-MM-DD`` format.
+            end_date: Optional end date filter in ``YYYY-MM-DD`` format.
+            **filters: Additional filter parameters for the audit trail request.
+
+        Returns:
+            Dictionary mapping each user to the number of record revisions they
+            performed in the given date range.
+        """
+        filter_str = build_filter_string(filters) if filters else None
+
+        revisions = self._sdk.record_revisions.list(
+            study_key,
+            page_size=None,
+            filter=filter_str,
+            start_date=start_date,
+            end_date=end_date,
+        )
+
+        summary: Dict[str, int] = {}
+        for rev in revisions:
+            summary[rev.user] = summary.get(rev.user, 0) + 1
+
+        return summary

--- a/tests/workflows/test_audit_aggregation.py
+++ b/tests/workflows/test_audit_aggregation.py
@@ -1,0 +1,43 @@
+from unittest.mock import MagicMock
+
+from imednet.models.record_revisions import RecordRevision
+from imednet.workflows.audit_aggregation import AuditAggregationWorkflow
+
+
+def test_summary_by_user_counts_revisions():
+    mock_sdk = MagicMock()
+    revisions = [
+        RecordRevision(user="alice"),
+        RecordRevision(user="bob"),
+        RecordRevision(user="alice"),
+    ]
+    mock_sdk.record_revisions.list.return_value = revisions
+
+    wf = AuditAggregationWorkflow(mock_sdk)
+    result = wf.summary_by_user("STUDY1", start_date="2024-01-01", end_date="2024-01-31", site_id=1)
+
+    mock_sdk.record_revisions.list.assert_called_once_with(
+        "STUDY1",
+        page_size=None,
+        filter="site_id==1",
+        start_date="2024-01-01",
+        end_date="2024-01-31",
+    )
+    assert result == {"alice": 2, "bob": 1}
+
+
+def test_summary_by_user_empty_result():
+    mock_sdk = MagicMock()
+    mock_sdk.record_revisions.list.return_value = []
+
+    wf = AuditAggregationWorkflow(mock_sdk)
+    result = wf.summary_by_user("STUDY1")
+
+    mock_sdk.record_revisions.list.assert_called_once_with(
+        "STUDY1",
+        page_size=None,
+        filter=None,
+        start_date=None,
+        end_date=None,
+    )
+    assert result == {}


### PR DESCRIPTION
## Summary
- implement `AuditAggregationWorkflow.summary_by_user`
- expose the workflow from `imednet.workflows`
- document usage under `docs/workflows/audit_aggregation.rst`
- test aggregation logic

## Testing
- `poetry run pre-commit run --files imednet/workflows/__init__.py imednet/workflows/audit_aggregation.py tests/workflows/test_audit_aggregation.py docs/imednet.workflows.rst docs/workflows/audit_aggregation.rst`
- `poetry run pytest --cov=imednet`

------
https://chatgpt.com/codex/tasks/task_e_6843695ff004832c8447518f73a8838f