### PR TITLE
Add core utility and endpoint tests

### DIFF
--- a/tests/unit/test_cli_utils.py
+++ b/tests/unit/test_cli_utils.py
@@ -1,0 +1,13 @@
+import pytest
+import typer
+from imednet.cli import parse_filter_args
+
+
+def test_parse_filter_args_returns_dict():
+    result = parse_filter_args(["age=30", "active=true"])
+    assert result == {"age": 30, "active": True}
+
+
+def test_parse_filter_args_invalid_format():
+    with pytest.raises(typer.Exit):
+        parse_filter_args(["badformat"])

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -1,0 +1,37 @@
+import httpx
+import pytest
+
+from imednet.core.client import Client
+from imednet.core.exceptions import NotFoundError
+
+
+class DummyHttpxClient:
+    def __init__(self, response):
+        self.response = response
+        self.request_args = None
+
+    def request(self, method, url, **kwargs):
+        self.request_args = (method, url, kwargs)
+        return self.response
+
+    def close(self):
+        pass
+
+
+def test_client_get_success(monkeypatch):
+    resp = httpx.Response(200, json={"ok": True})
+    client = Client("k", "s", base_url="http://test")
+    dummy = DummyHttpxClient(resp)
+    monkeypatch.setattr(client, "_client", dummy)
+    r = client.get("/foo")
+    assert r.status_code == 200
+    assert dummy.request_args[0] == "GET"
+
+
+def test_client_request_raises_api_error(monkeypatch):
+    resp = httpx.Response(404, json={"error": "nope"})
+    client = Client("k", "s", base_url="http://test")
+    dummy = DummyHttpxClient(resp)
+    monkeypatch.setattr(client, "_client", dummy)
+    with pytest.raises(NotFoundError):
+        client.get("/missing")

--- a/tests/unit/test_endpoints.py
+++ b/tests/unit/test_endpoints.py
@@ -1,0 +1,50 @@
+import pytest
+import httpx
+
+from imednet.endpoints.studies import StudiesEndpoint
+from imednet.core.context import Context
+
+
+class DummyClient:
+    def __init__(self, response_data):
+        self.response_data = response_data
+        self.last_path = None
+
+    def get(self, path, params=None):
+        self.last_path = path
+        return httpx.Response(200, json={"data": self.response_data})
+
+
+class DummyPaginator:
+    def __init__(self, *_args, **_kwargs):
+        self.items = [{"studyKey": "S1"}, {"studyKey": "S2"}]
+
+    def __iter__(self):
+        return iter(self.items)
+
+
+def test_studies_list(monkeypatch):
+    ctx = Context()
+    client = DummyClient([])
+
+    monkeypatch.setattr("imednet.endpoints.studies.Paginator", DummyPaginator)
+    ep = StudiesEndpoint(client, ctx)
+    studies = ep.list()
+    assert [s.study_key for s in studies] == ["S1", "S2"]
+
+
+def test_studies_get_success():
+    ctx = Context()
+    client = DummyClient([{"studyKey": "ABC"}])
+    ep = StudiesEndpoint(client, ctx)
+    study = ep.get("ABC")
+    assert study.study_key == "ABC"
+    assert client.last_path.endswith("/ABC")
+
+
+def test_studies_get_missing():
+    ctx = Context()
+    client = DummyClient([])
+    ep = StudiesEndpoint(client, ctx)
+    with pytest.raises(ValueError):
+        ep.get("MISSING")

--- a/tests/unit/test_exceptions.py
+++ b/tests/unit/test_exceptions.py
@@ -1,0 +1,8 @@
+from imednet.core.exceptions import ApiError
+
+
+def test_api_error_str_includes_details():
+    err = ApiError({'detail': 'oops'}, status_code=404)
+    text = str(err)
+    assert 'Status Code: 404' in text
+    assert "{'detail': 'oops'}" in text

--- a/tests/unit/test_paginator.py
+++ b/tests/unit/test_paginator.py
@@ -1,0 +1,30 @@
+import httpx
+
+from imednet.core.paginator import Paginator
+
+
+class DummyClient:
+    def __init__(self, responses):
+        self._responses = responses
+        self.calls = []
+
+    def get(self, path, params=None):
+        call_num = len(self.calls)
+        self.calls.append((path, params))
+        return self._responses[call_num]
+
+
+def make_response(items, total_pages):
+    return httpx.Response(200, json={'data': items, 'pagination': {'totalPages': total_pages}})
+
+
+def test_paginator_iterates_through_pages():
+    responses = [
+        make_response([1, 2], 2),
+        make_response([3], 2),
+    ]
+    client = DummyClient(responses)
+    paginator = Paginator(client, '/items', page_size=2)
+    assert list(paginator) == [1, 2, 3]
+    assert client.calls[0][1]['page'] == 0
+    assert client.calls[1][1]['page'] == 1

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -1,0 +1,26 @@
+from datetime import datetime
+
+from imednet.utils.filters import build_filter_string
+from imednet.utils.dates import parse_iso_datetime, format_iso_datetime
+
+
+class TestFilters:
+    def test_build_filter_string_basic(self):
+        result = build_filter_string({'name': 'John', 'age': ('>', 20)})
+        assert result == 'name==John;age>20'
+
+    def test_build_filter_string_list(self):
+        result = build_filter_string({'type': ['A', 'B']})
+        assert result == 'type==A,type==B'
+
+
+class TestDates:
+    def test_parse_iso_datetime_z_suffix(self):
+        dt = parse_iso_datetime('2020-01-01T12:00:00Z')
+        assert dt.tzinfo
+        assert dt.isoformat() == '2020-01-01T12:00:00+00:00'
+
+    def test_format_iso_datetime_naive(self):
+        dt = datetime(2020, 1, 1, 12, 0, 0)
+        formatted = format_iso_datetime(dt)
+        assert formatted == '2020-01-01T12:00:00Z'

--- a/tests/unit/test_validators.py
+++ b/tests/unit/test_validators.py
@@ -1,0 +1,22 @@
+import pytest
+from imednet.models.validators import parse_bool, parse_int_or_default, parse_str_or_default
+
+
+class TestValidators:
+    def test_parse_bool_various_inputs(self):
+        assert parse_bool(True) is True
+        assert parse_bool('true') is True
+        assert parse_bool('FALSE') is False
+        assert parse_bool('random') is False
+        assert parse_bool(1) is True
+
+    def test_parse_int_or_default(self):
+        assert parse_int_or_default('10') == 10
+        assert parse_int_or_default(None, default=5) == 5
+        assert parse_int_or_default('bad') == 0
+        with pytest.raises(ValueError):
+            parse_int_or_default('bad', strict=True)
+
+    def test_parse_str_or_default(self):
+        assert parse_str_or_default('abc') == 'abc'
+        assert parse_str_or_default(None) == ''


### PR DESCRIPTION
## Summary
- add unit tests for utils: dates, filters
- add tests for validator helpers
- cover Client HTTP interactions
- add paginator and studies endpoint tests
- exercise CLI filter parsing

## Testing
- `pytest -q`
- `pytest --cov=imednet -q`

------
https://chatgpt.com/codex/tasks/task_e_68471bd68c7c832ca13765b54d4bd710