### PR TITLE
Add docs build make target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,5 @@
+.PHONY: docs
+
+docs:
+	poetry install --with dev
+	poetry run sphinx-build -b html docs docs/_build/html

--- a/README.md
+++ b/README.md
@@ -102,9 +102,18 @@ imednet subjects list --help
 
 ## Documentation
 
-The documentation is no longer automatically deployed or published online. To view the documentation, you must build it locally using Sphinx. The output will be in `docs/_build/html`.
+The documentation is no longer automatically deployed or published online. To
+view the documentation, you must build it locally using Sphinx. The output will
+be in `docs/_build/html`.
 
-To build the documentation locally:
+You can build the docs using the included Makefile target:
+
+```bash
+make docs
+```
+
+This installs the development dependencies and runs the Sphinx build. If you
+prefer, you can run the commands manually:
 
 ```bash
 poetry install --with dev

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -33,7 +33,6 @@ release = "0.1.0"
 extensions = [
     "sphinx.ext.autodoc",
     "sphinx.ext.viewcode",
-    "sphinx_autodoc_typehints",
 ]
 
 # Templates and static paths


### PR DESCRIPTION
## Summary
- add Makefile with `docs` target to build the Sphinx documentation
- update README to mention `make docs` as an easier alternative
- drop `sphinx_autodoc_typehints` extension so docs build with pydantic v2

## Testing
- `make docs`
- `poetry run pytest --cov=imednet`


------
https://chatgpt.com/codex/tasks/task_e_684724c28d90832c8f01f5357a59675c