### PR TITLE
Add docs build step to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,5 +47,5 @@ jobs:
       - name: Build documentation
         run: |
           poetry install --with dev
-          sphinx-build -b html docs docs/_build/html
+          poetry run sphinx-build -b html docs docs/_build/html
 


### PR DESCRIPTION
## Summary
- build docs in CI

## Testing
- `poetry install --with dev`
- `poetry run pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68472a2ed87c832cabb578800ca172fd