### PR TITLE
Add job monitoring workflow

### DIFF
--- a/docs/imednet.workflows.rst
+++ b/docs/imednet.workflows.rst
@@ -52,6 +52,22 @@ imednet.workflows.subject\_data module
    :undoc-members:
    :show-inheritance:
 
+imednet.workflows.job_monitoring module
+--------------------------------------
+
+.. automodule:: imednet.workflows.job_monitoring
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Example usage
+~~~~~~~~~~~~~
+
+.. code-block:: python
+
+   sdk = ImednetSDK(api_key="KEY", security_key="SEC")
+   job = sdk.workflows.job_monitoring.wait_for_job("STUDY", "batch123")
+
 Module contents
 ---------------
 

--- a/imednet/sdk.py
+++ b/imednet/sdk.py
@@ -29,6 +29,7 @@ from .endpoints.visits import VisitsEndpoint
 
 # Import workflow classes
 from .workflows.data_extraction import DataExtractionWorkflow
+from .workflows.job_monitoring import JobMonitoringWorkflow
 from .workflows.query_management import QueryManagementWorkflow
 from .workflows.record_mapper import RecordMapper
 from .workflows.record_update import RecordUpdateWorkflow
@@ -40,6 +41,7 @@ class Workflows:
 
     def __init__(self, sdk_instance: "ImednetSDK"):
         self.data_extraction = DataExtractionWorkflow(sdk_instance)
+        self.job_monitoring = JobMonitoringWorkflow(sdk_instance)
         self.query_management = QueryManagementWorkflow(sdk_instance)
         self.record_mapper = RecordMapper(sdk_instance)
         self.record_update = RecordUpdateWorkflow(sdk_instance)

--- a/imednet/workflows/__init__.py
+++ b/imednet/workflows/__init__.py
@@ -8,6 +8,7 @@
 # from .subject_data import get_subject_data
 
 # --- Correct workflow class/function imports ---
+from .job_monitoring import JobMonitoringWorkflow
 from .query_management import QueryManagementWorkflow
 from .record_mapper import RecordMapper
 from .record_update import RecordUpdateWorkflow
@@ -27,6 +28,7 @@ __all__ = [
     #
     # Updated:
     "QueryManagementWorkflow",
+    "JobMonitoringWorkflow",
     "RecordMapper",
     "RecordUpdateWorkflow",
     "RegisterSubjectsWorkflow",

--- a/imednet/workflows/job_monitoring.py
+++ b/imednet/workflows/job_monitoring.py
@@ -1,0 +1,60 @@
+"""Utilities for monitoring asynchronous iMednet jobs."""
+
+from __future__ import annotations
+
+import time
+from typing import TYPE_CHECKING, Any, Callable, Optional
+
+from ..models import Job
+
+if TYPE_CHECKING:
+    from ..sdk import ImednetSDK
+
+
+TERMINAL_STATES = {"COMPLETED", "FAILED", "CANCELLED"}
+
+
+class JobMonitoringWorkflow:
+    """Workflow helper for polling job status until completion."""
+
+    def __init__(self, sdk: "ImednetSDK") -> None:
+        self._sdk = sdk
+
+    def wait_for_job(
+        self,
+        study_key: str,
+        batch_id: str,
+        *,
+        timeout: int = 300,
+        poll_interval: int = 5,
+        notify: Optional[Callable[[Job], Any]] = None,
+    ) -> Job:
+        """Wait for a job to reach a terminal state.
+
+        Args:
+            study_key: Study identifier.
+            batch_id: Batch identifier of the job.
+            timeout: Maximum time in seconds to wait.
+            poll_interval: Seconds between polling attempts.
+            notify: Optional callback invoked with the latest ``Job`` after each poll.
+
+        Returns:
+            The final ``Job`` state.
+
+        Raises:
+            TimeoutError: If the job does not reach a terminal state before ``timeout``.
+        """
+
+        start = time.monotonic()
+        while True:
+            job = self._sdk.jobs.get(study_key, batch_id)
+            if notify:
+                notify(job)
+            if job.state.upper() in TERMINAL_STATES:
+                return job
+            if time.monotonic() - start >= timeout:
+                raise TimeoutError(
+                    f"Timeout ({timeout}s) waiting for job '{batch_id}' to complete. "
+                    f"Last state: {job.state}"
+                )
+            time.sleep(poll_interval)

--- a/tests/unit/test_job_monitoring.py
+++ b/tests/unit/test_job_monitoring.py
@@ -1,0 +1,69 @@
+from unittest.mock import MagicMock
+
+import pytest
+from imednet.models.jobs import Job
+from imednet.workflows import job_monitoring as jm
+from imednet.workflows.job_monitoring import JobMonitoringWorkflow
+
+
+def test_wait_for_job_success(monkeypatch):
+    sdk = MagicMock()
+    states = ["PENDING", "IN_PROGRESS", "COMPLETED"]
+
+    def fake_get(study_key: str, batch_id: str) -> Job:
+        return Job(jobId="1", batchId=batch_id, state=states.pop(0))
+
+    sdk.jobs.get.side_effect = fake_get
+
+    sleeps = []
+    monkeypatch.setattr(jm.time, "sleep", lambda t: sleeps.append(t))
+
+    workflow = JobMonitoringWorkflow(sdk)
+    job = workflow.wait_for_job("S", "B", timeout=10, poll_interval=1)
+
+    assert job.state == "COMPLETED"
+    assert sleeps == [1, 1]
+
+
+def test_wait_for_job_timeout(monkeypatch):
+    sdk = MagicMock()
+    sdk.jobs.get.return_value = Job(jobId="1", batchId="B", state="RUNNING")
+
+    counter = {"i": 0}
+
+    def fake_monotonic() -> int:
+        counter["i"] += 1
+        return counter["i"]
+
+    monkeypatch.setattr(jm.time, "monotonic", fake_monotonic)
+    monkeypatch.setattr(jm.time, "sleep", lambda t: None)
+
+    workflow = JobMonitoringWorkflow(sdk)
+    with pytest.raises(TimeoutError):
+        workflow.wait_for_job("S", "B", timeout=2, poll_interval=1)
+
+    assert sdk.jobs.get.call_count >= 2
+
+
+def test_wait_for_job_notify_and_interval(monkeypatch):
+    sdk = MagicMock()
+    states = ["PENDING", "COMPLETED"]
+
+    def fake_get(study_key: str, batch_id: str) -> Job:
+        return Job(jobId="1", batchId=batch_id, state=states.pop(0))
+
+    sdk.jobs.get.side_effect = fake_get
+
+    sleeps = []
+    monkeypatch.setattr(jm.time, "sleep", lambda t: sleeps.append(t))
+
+    notifications = []
+
+    workflow = JobMonitoringWorkflow(sdk)
+    job = workflow.wait_for_job(
+        "S", "B", timeout=10, poll_interval=2, notify=lambda j: notifications.append(j.state)
+    )
+
+    assert job.state == "COMPLETED"
+    assert notifications == ["PENDING", "COMPLETED"]
+    assert sleeps == [2]


### PR DESCRIPTION
## Summary
- add utilities for polling asynchronous jobs
- wire up `JobMonitoringWorkflow` in the SDK
- expose workflow from package `__init__`
- document the new workflow and provide an example
- test job waiting logic and callback handling

## Testing
- `black --check imednet/sdk.py imednet/workflows/__init__.py imednet/workflows/job_monitoring.py tests/unit/test_job_monitoring.py`
- `ruff check imednet/sdk.py imednet/workflows/__init__.py imednet/workflows/job_monitoring.py tests/unit/test_job_monitoring.py`
- `mypy imednet/sdk.py imednet/workflows/job_monitoring.py tests/unit/test_job_monitoring.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68472665ebb8832ca805caef836f4482