### PR TITLE
Add credential validation workflow

### DIFF
--- a/imednet/sdk.py
+++ b/imednet/sdk.py
@@ -26,6 +26,7 @@ from .endpoints.subjects import SubjectsEndpoint
 from .endpoints.users import UsersEndpoint
 from .endpoints.variables import VariablesEndpoint
 from .endpoints.visits import VisitsEndpoint
+from .workflows.credential_validation import CredentialValidationWorkflow
 
 # Import workflow classes
 from .workflows.data_extraction import DataExtractionWorkflow
@@ -48,6 +49,7 @@ class Workflows:
         self.record_update = RecordUpdateWorkflow(sdk_instance)
         self.subject_data = SubjectDataWorkflow(sdk_instance)
         self.site_progress = SiteProgressWorkflow(sdk_instance)
+        self.credential_validation = CredentialValidationWorkflow(sdk_instance)
 
 
 class ImednetSDK:

--- a/imednet/workflows/__init__.py
+++ b/imednet/workflows/__init__.py
@@ -8,6 +8,7 @@
 # from .subject_data import get_subject_data
 
 # --- Correct workflow class/function imports ---
+from .credential_validation import CredentialValidationWorkflow
 from .job_monitoring import JobMonitoringWorkflow
 from .query_management import QueryManagementWorkflow
 from .record_mapper import RecordMapper
@@ -34,6 +35,7 @@ __all__ = [
     "RecordUpdateWorkflow",
     "RegisterSubjectsWorkflow",
     "SiteProgressWorkflow",
+    "CredentialValidationWorkflow",
     "SubjectDataWorkflow",
     "get_study_structure",
 ]

--- a/imednet/workflows/credential_validation.py
+++ b/imednet/workflows/credential_validation.py
@@ -1,0 +1,28 @@
+"""Workflow for validating authentication credentials."""
+
+from __future__ import annotations
+
+import os
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:  # pragma: no cover - for import cycle only
+    from ..sdk import ImednetSDK
+
+
+class CredentialValidationWorkflow:
+    """Check API and study keys using the ``studies`` endpoint."""
+
+    def __init__(self, sdk: "ImednetSDK") -> None:
+        self._sdk = sdk
+
+    def validate(self, study_key: str) -> bool:
+        """Return ``True`` if ``study_key`` exists in ``studies.list``."""
+        studies = self._sdk.studies.list()
+        return any(s.study_key == study_key for s in studies)
+
+    def validate_environment(self) -> bool:
+        """Validate credentials using ``IMEDNET_STUDY_KEY`` from the environment."""
+        study_key = os.getenv("IMEDNET_STUDY_KEY")
+        if not study_key:
+            raise ValueError("IMEDNET_STUDY_KEY environment variable is not set.")
+        return self.validate(study_key)

--- a/tests/unit/workflows/test_credential_validation.py
+++ b/tests/unit/workflows/test_credential_validation.py
@@ -1,0 +1,31 @@
+from unittest.mock import MagicMock
+
+import pytest
+from imednet.models.studies import Study
+from imednet.workflows.credential_validation import CredentialValidationWorkflow
+
+
+def test_validate_environment_found(monkeypatch):
+    sdk = MagicMock()
+    sdk.studies.list.return_value = [
+        Study.model_validate({"studyKey": "ABC"}),
+        Study.model_validate({"studyKey": "XYZ"}),
+    ]
+    monkeypatch.setenv("IMEDNET_STUDY_KEY", "XYZ")
+    workflow = CredentialValidationWorkflow(sdk)
+    assert workflow.validate_environment() is True
+
+
+def test_validate_environment_missing(monkeypatch):
+    sdk = MagicMock()
+    workflow = CredentialValidationWorkflow(sdk)
+    monkeypatch.delenv("IMEDNET_STUDY_KEY", raising=False)
+    with pytest.raises(ValueError):
+        workflow.validate_environment()
+
+
+def test_validate_false_when_not_found(monkeypatch):
+    sdk = MagicMock()
+    sdk.studies.list.return_value = [Study.model_validate({"studyKey": "ABC"})]
+    workflow = CredentialValidationWorkflow(sdk)
+    assert workflow.validate("XYZ") is False


### PR DESCRIPTION
## Summary
- add a workflow to validate environment credentials via studies endpoint
- expose the workflow through the SDK
- include unit tests for the workflow

## Testing
- `pre-commit run --files imednet/workflows/credential_validation.py imednet/workflows/__init__.py imednet/sdk.py tests/unit/workflows/test_credential_validation.py`
- `pytest -q --cov=imednet`

------
https://chatgpt.com/codex/tasks/task_e_68473a5bfd28832c85aae1c7fad22d41