### PR TITLE
feat: default CLI study key from environment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Features and Improvements
 
+- CLI commands now default to using the `IMEDNET_STUDY_KEY` environment
+  variable for the study key. A new `--study-key` option allows overriding it.
+
 - Added PyPI, code style (Black), linter (Ruff), and typing (Mypy) badges to `README.md`.
 - Added `pandas` to development dependencies for workflow features.
 - Created `TEST_PLAN.md` outlining steps to achieve 90% test coverage.

--- a/README.md
+++ b/README.md
@@ -81,17 +81,20 @@ except Exception as e:
 
 ### Using the Command Line Interface (CLI)
 
-After installing the package (`pip install imednet-python-sdk`) and setting the environment variables as shown above, you can use the `imednet` command:
+After installing the package (`pip install imednet-python-sdk`) and setting the environment variables as shown above, you can use the `imednet` command. Most commands automatically read the study key from the `IMEDNET_STUDY_KEY` environment variable, but you can override it with the `--study-key` option:
 
 ```powershell
 # List available studies
 imednet studies list
 
-# List sites for a specific study (replace STUDY_KEY)
-imednet sites list STUDY_KEY
+# List sites for a specific study
+imednet sites list
 
-# List subjects for a specific study, filtering by status (replace STUDY_KEY)
-imednet subjects list STUDY_KEY --filter "subject_status=Screened"
+# Override the study key for a single command
+imednet sites list --study-key MYSTUDY
+
+# List subjects for a specific study, filtering by status
+imednet subjects list --filter "subject_status=Screened"
 
 # Get help for a specific command
 imednet subjects list --help 

--- a/tests/unit/test_cli_study_key.py
+++ b/tests/unit/test_cli_study_key.py
@@ -1,0 +1,12 @@
+import pytest
+import typer
+from imednet.cli import require_study_key
+
+
+def test_require_study_key_returns_value() -> None:
+    assert require_study_key("ABC") == "ABC"
+
+
+def test_require_study_key_missing_exits() -> None:
+    with pytest.raises(typer.Exit):
+        require_study_key(None)


### PR DESCRIPTION
## Summary
- read study key from IMEDNET_STUDY_KEY envvar in CLI
- add helper for ensuring study key is provided
- document new behaviour in README
- note change in changelog
- test study key helper

## Testing
- `poetry run pre-commit run --files CHANGELOG.md README.md imednet/cli.py tests/unit/test_cli_study_key.py`
- `poetry run pytest -q --cov=imednet`

------
https://chatgpt.com/codex/tasks/task_e_6847491d4918832c9239127a19a4297a