### PR TITLE
Add workflow examples

### DIFF
--- a/imednet/examples/get_subject_data.py
+++ b/imednet/examples/get_subject_data.py
@@ -1,0 +1,31 @@
+import os
+
+from imednet.sdk import ImednetSDK
+from imednet.workflows.subject_data import SubjectDataWorkflow
+
+"""Example for retrieving comprehensive subject information using
+:class:`SubjectDataWorkflow`.
+
+The script requires the subject key via ``IMEDNET_SUBJECT_KEY`` and prints the
+aggregated data including visits, records, and queries.
+"""
+
+api_key = os.getenv("IMEDNET_API_KEY")
+security_key = os.getenv("IMEDNET_SECURITY_KEY")
+base_url = os.getenv("IMEDNET_BASE_URL")
+study_key = os.getenv("IMEDNET_STUDY_KEY", "your_study_key_here")
+subject_key = os.getenv("IMEDNET_SUBJECT_KEY", "your_subject_key_here")
+
+if not api_key or not security_key:
+    raise RuntimeError(
+        "IMEDNET_API_KEY and IMEDNET_SECURITY_KEY environment variables must be set."
+    )
+
+sdk = ImednetSDK(api_key=api_key, security_key=security_key, base_url=base_url)
+workflow = SubjectDataWorkflow(sdk)
+
+try:
+    data = workflow.get_all_subject_data(study_key, subject_key)
+    print(data.model_dump())
+except Exception as e:
+    print(f"Error retrieving subject data: {e}")

--- a/imednet/examples/manage_queries.py
+++ b/imednet/examples/manage_queries.py
@@ -1,0 +1,44 @@
+import os
+
+from imednet.sdk import ImednetSDK
+from imednet.workflows.query_management import QueryManagementWorkflow
+
+"""Example for using :class:`QueryManagementWorkflow` to inspect queries.
+
+This script fetches open queries for the configured study and shows how to
+retrieve queries for a specific subject and summarize query states.
+
+Environment variables required:
+    - ``IMEDNET_API_KEY`` and ``IMEDNET_SECURITY_KEY`` for authentication.
+    - ``IMEDNET_STUDY_KEY`` identifying the study to inspect.
+Optional variables:
+    - ``IMEDNET_SUBJECT_KEY`` to fetch queries for a specific subject.
+    - ``IMEDNET_BASE_URL`` if using a non-default iMednet URL.
+"""
+
+api_key = os.getenv("IMEDNET_API_KEY")
+security_key = os.getenv("IMEDNET_SECURITY_KEY")
+base_url = os.getenv("IMEDNET_BASE_URL")
+study_key = os.getenv("IMEDNET_STUDY_KEY", "your_study_key_here")
+subject_key = os.getenv("IMEDNET_SUBJECT_KEY")
+
+if not api_key or not security_key:
+    raise RuntimeError(
+        "IMEDNET_API_KEY and IMEDNET_SECURITY_KEY environment variables must be set."
+    )
+
+sdk = ImednetSDK(api_key=api_key, security_key=security_key, base_url=base_url)
+workflow = QueryManagementWorkflow(sdk)
+
+try:
+    open_queries = workflow.get_open_queries(study_key)
+    print(f"Found {len(open_queries)} open queries for study '{study_key}'.")
+
+    if subject_key:
+        subj_queries = workflow.get_queries_for_subject(study_key, subject_key)
+        print(f"Subject {subject_key} has {len(subj_queries)} queries.")
+
+    counts = workflow.get_query_state_counts(study_key)
+    print("Query state counts:", counts)
+except Exception as e:
+    print(f"Error retrieving queries: {e}")

--- a/imednet/examples/map_records.py
+++ b/imednet/examples/map_records.py
@@ -1,0 +1,32 @@
+import os
+
+from imednet.sdk import ImednetSDK
+from imednet.workflows.record_mapper import RecordMapper
+
+"""Example for converting study records to a pandas DataFrame using
+:class:`RecordMapper`.
+
+The script fetches all records for the configured study and prints the first few
+rows of the resulting DataFrame. Set ``IMEDNET_VISIT_KEY`` to limit the records
+to a specific visit.
+"""
+
+api_key = os.getenv("IMEDNET_API_KEY")
+security_key = os.getenv("IMEDNET_SECURITY_KEY")
+base_url = os.getenv("IMEDNET_BASE_URL")
+study_key = os.getenv("IMEDNET_STUDY_KEY", "your_study_key_here")
+visit_key = os.getenv("IMEDNET_VISIT_KEY")
+
+if not api_key or not security_key:
+    raise RuntimeError(
+        "IMEDNET_API_KEY and IMEDNET_SECURITY_KEY environment variables must be set."
+    )
+
+sdk = ImednetSDK(api_key=api_key, security_key=security_key, base_url=base_url)
+mapper = RecordMapper(sdk)
+
+try:
+    df = mapper.dataframe(study_key, visit_key=visit_key)
+    print(df.head())
+except Exception as e:
+    print(f"Error mapping records: {e}")

--- a/imednet/examples/site_progress_report.py
+++ b/imednet/examples/site_progress_report.py
@@ -1,0 +1,29 @@
+import os
+
+from imednet.sdk import ImednetSDK
+from imednet.workflows.site_progress import SiteProgressWorkflow
+
+"""Generate a progress summary for all sites in a study using
+:class:`SiteProgressWorkflow`. The script prints metrics such as subjects
+enrolled, visits completed, and open queries per site.
+"""
+
+api_key = os.getenv("IMEDNET_API_KEY")
+security_key = os.getenv("IMEDNET_SECURITY_KEY")
+base_url = os.getenv("IMEDNET_BASE_URL")
+study_key = os.getenv("IMEDNET_STUDY_KEY", "your_study_key_here")
+
+if not api_key or not security_key:
+    raise RuntimeError(
+        "IMEDNET_API_KEY and IMEDNET_SECURITY_KEY environment variables must be set."
+    )
+
+sdk = ImednetSDK(api_key=api_key, security_key=security_key, base_url=base_url)
+workflow = SiteProgressWorkflow(sdk)
+
+try:
+    progress = workflow.get_site_progress(study_key)
+    for site in progress:
+        print(site.model_dump())
+except Exception as e:
+    print(f"Error retrieving site progress: {e}")

--- a/imednet/examples/update_records.py
+++ b/imednet/examples/update_records.py
@@ -1,0 +1,44 @@
+import json
+import os
+
+from imednet.sdk import ImednetSDK
+from imednet.workflows.record_update import RecordUpdateWorkflow
+
+"""Example for submitting record batches with :class:`RecordUpdateWorkflow`.
+
+This script reads a JSON file containing record data and submits it to the
+configured study. By default it waits for the job to complete and prints the
+final job state.
+
+The expected JSON structure is a list of record dictionaries compatible with the
+``records.create`` endpoint. Provide the path to the file in the
+``RECORD_UPDATE_FILE`` environment variable.
+"""
+
+api_key = os.getenv("IMEDNET_API_KEY")
+security_key = os.getenv("IMEDNET_SECURITY_KEY")
+base_url = os.getenv("IMEDNET_BASE_URL")
+study_key = os.getenv("IMEDNET_STUDY_KEY", "your_study_key_here")
+file_path = os.getenv("RECORD_UPDATE_FILE", "record_update_input/sample_records.json")
+
+if not api_key or not security_key:
+    raise RuntimeError(
+        "IMEDNET_API_KEY and IMEDNET_SECURITY_KEY environment variables must be set."
+    )
+
+sdk = ImednetSDK(api_key=api_key, security_key=security_key, base_url=base_url)
+workflow = RecordUpdateWorkflow(sdk)
+
+try:
+    with open(file_path, "r", encoding="utf-8") as f:
+        records = json.load(f)
+
+    job = workflow.submit_record_batch(
+        study_key=study_key,
+        records_data=records,
+        wait_for_completion=True,
+        timeout=300,
+    )
+    print(f"Batch {job.batch_id} finished with state: {job.state}")
+except Exception as e:
+    print(f"Error submitting records: {e}")

--- a/imednet/examples/validate_credentials.py
+++ b/imednet/examples/validate_credentials.py
@@ -1,0 +1,42 @@
+import os
+
+from imednet.sdk import ImednetSDK
+from imednet.workflows.credential_validation import CredentialValidationWorkflow
+
+"""Example for validating credentials using the CredentialValidationWorkflow.
+
+This script initializes the SDK with API credentials and uses the
+``CredentialValidationWorkflow`` to verify that the study key provided exists
+in the list of accessible studies. It also demonstrates validating credentials
+from the ``IMEDNET_STUDY_KEY`` environment variable using the
+``validate_environment`` method.
+
+Prerequisites:
+    - Set ``IMEDNET_API_KEY`` and ``IMEDNET_SECURITY_KEY`` environment variables.
+    - Optionally set ``IMEDNET_BASE_URL`` and ``IMEDNET_STUDY_KEY``.
+"""
+
+api_key = os.getenv("IMEDNET_API_KEY")
+security_key = os.getenv("IMEDNET_SECURITY_KEY")
+base_url = os.getenv("IMEDNET_BASE_URL")  # Optional
+study_key = os.getenv("IMEDNET_STUDY_KEY", "your_study_key_here")
+
+if not api_key or not security_key:
+    raise RuntimeError(
+        "IMEDNET_API_KEY and IMEDNET_SECURITY_KEY environment variables must be set."
+    )
+
+try:
+    sdk = ImednetSDK(api_key=api_key, security_key=security_key, base_url=base_url)
+    workflow = CredentialValidationWorkflow(sdk)
+
+    if workflow.validate(study_key):
+        print(f"Credentials are valid for study '{study_key}'.")
+    else:
+        print(f"Study '{study_key}' not found. Check the study key or credentials.")
+
+    # Validate using the IMEDNET_STUDY_KEY environment variable (raises ValueError if unset)
+    if workflow.validate_environment():
+        print("Environment credentials validated successfully.")
+except Exception as e:
+    print(f"Error validating credentials: {e}")

--- a/imednet/examples/wait_for_job.py
+++ b/imednet/examples/wait_for_job.py
@@ -1,0 +1,47 @@
+import os
+
+from imednet.sdk import ImednetSDK
+from imednet.workflows.job_monitoring import JobMonitoringWorkflow
+
+"""Example demonstrating :class:`JobMonitoringWorkflow`.
+
+Provide a study key and batch ID to poll job status until completion. The current
+state is printed at each poll interval.
+
+Required environment variables:
+    - ``IMEDNET_API_KEY`` and ``IMEDNET_SECURITY_KEY``
+    - ``IMEDNET_STUDY_KEY`` identifying the study
+    - ``IMEDNET_BATCH_ID`` identifying the job batch
+Optional variable ``IMEDNET_BASE_URL`` may be set for non-default environments.
+"""
+
+api_key = os.getenv("IMEDNET_API_KEY")
+security_key = os.getenv("IMEDNET_SECURITY_KEY")
+base_url = os.getenv("IMEDNET_BASE_URL")
+study_key = os.getenv("IMEDNET_STUDY_KEY", "your_study_key_here")
+batch_id = os.getenv("IMEDNET_BATCH_ID", "your_batch_id_here")
+
+if not api_key or not security_key:
+    raise RuntimeError(
+        "IMEDNET_API_KEY and IMEDNET_SECURITY_KEY environment variables must be set."
+    )
+
+sdk = ImednetSDK(api_key=api_key, security_key=security_key, base_url=base_url)
+workflow = JobMonitoringWorkflow(sdk)
+
+
+def notify(job):
+    print(f"Job {job.batch_id} state: {job.state}")
+
+
+try:
+    final_job = workflow.wait_for_job(
+        study_key=study_key,
+        batch_id=batch_id,
+        timeout=300,
+        poll_interval=10,
+        notify=notify,
+    )
+    print(f"Job completed with state: {final_job.state}")
+except Exception as e:
+    print(f"Error monitoring job: {e}")


### PR DESCRIPTION
## Summary
- add examples for QueryManagementWorkflow, JobMonitoringWorkflow, RecordMapper, RecordUpdateWorkflow, SiteProgressWorkflow and SubjectDataWorkflow

## Testing
- `pre-commit run --files imednet/examples/manage_queries.py imednet/examples/wait_for_job.py imednet/examples/map_records.py imednet/examples/update_records.py imednet/examples/site_progress_report.py imednet/examples/get_subject_data.py`
- `pytest -q --cov=imednet`


------
https://chatgpt.com/codex/tasks/task_e_684746fcc058832c9e4c86f4c531d8c8