### PR TITLE
Fix filter passing in workflows

### DIFF
--- a/imednet/cli.py
+++ b/imednet/cli.py
@@ -203,7 +203,8 @@ def list_subjects(
         filter_str = build_filter_string(parsed_filter) if parsed_filter else None
 
         print(f"Fetching subjects for study '{study_key}'...")
-        subjects_list = sdk.subjects.list(study_key, filter=filter_str)
+        list_kwargs = {"filter": filter_str} if filter_str else {}
+        subjects_list = sdk.subjects.list(study_key, **list_kwargs)
         if subjects_list:
             print(f"Found {len(subjects_list)} subjects:")
             print(subjects_list)

--- a/imednet/workflows/data_extraction.py
+++ b/imednet/workflows/data_extraction.py
@@ -76,9 +76,13 @@ class DataExtractionWorkflow:
 
         record_filter_str = build_filter_string(final_record_filter_dict)
 
+        list_kwargs: Dict[str, Any] = {}
+        if record_filter_str:
+            list_kwargs["filter"] = record_filter_str
+
         records = self._sdk.records.list(
             study_key,
-            filter=record_filter_str if record_filter_str else None,
+            **list_kwargs,
         )
 
         # Client-side filtering fallback
@@ -128,10 +132,13 @@ class DataExtractionWorkflow:
         filter_str = build_filter_string(final_filter_dict)
 
         # Fetch record revisions
+        list_kwargs: Dict[str, Any] = {**date_kwargs}
+        if filter_str:
+            list_kwargs["filter"] = filter_str
+
         revisions = self._sdk.record_revisions.list(
             study_key,
-            filter=filter_str if filter_str else None,
-            **date_kwargs,
+            **list_kwargs,
         )
         return revisions
 

--- a/imednet/workflows/query_management.py
+++ b/imednet/workflows/query_management.py
@@ -46,8 +46,12 @@ class QueryManagementWorkflow:
         # Build filter string from dictionary
         filter_str = build_filter_string(additional_filter) if additional_filter else None
 
+        list_kwargs: Dict[str, Any] = {**kwargs}
+        if filter_str:
+            list_kwargs["filter"] = filter_str
+
         # Fetch potentially relevant queries
-        all_matching_queries = self._sdk.queries.list(study_key, filter=filter_str, **kwargs)
+        all_matching_queries = self._sdk.queries.list(study_key, **list_kwargs)
 
         open_queries: List[Query] = []
         for query in all_matching_queries:
@@ -92,9 +96,11 @@ class QueryManagementWorkflow:
 
         filter_str = build_filter_string(final_filter_dict)
 
-        return self._sdk.queries.list(
-            study_key, filter=filter_str if filter_str else None, **kwargs
-        )
+        list_kwargs: Dict[str, Any] = {**kwargs}
+        if filter_str:
+            list_kwargs["filter"] = filter_str
+
+        return self._sdk.queries.list(study_key, **list_kwargs)
 
     def get_queries_by_site(
         self,
@@ -123,9 +129,11 @@ class QueryManagementWorkflow:
 
         filter_str = build_filter_string(final_filter_dict)
 
-        return self._sdk.queries.list(
-            study_key, filter=filter_str if filter_str else None, **kwargs
-        )
+        list_kwargs: Dict[str, Any] = {**kwargs}
+        if filter_str:
+            list_kwargs["filter"] = filter_str
+
+        return self._sdk.queries.list(study_key, **list_kwargs)
 
     def get_query_state_counts(self, study_key: str, **kwargs: Any) -> Dict[str, int]:
         """

--- a/imednet/workflows/record_mapper.py
+++ b/imednet/workflows/record_mapper.py
@@ -105,9 +105,11 @@ class RecordMapper:
         filter_str = build_filter_string(record_filter_dict) if record_filter_dict else None
 
         try:
-            recs_all: List[RecordModel] = self.sdk.records.list(
-                study_key=study_key, filter=filter_str
-            )
+            list_kwargs: Dict[str, Any] = {}
+            if filter_str:
+                list_kwargs["filter"] = filter_str
+
+            recs_all: List[RecordModel] = self.sdk.records.list(study_key=study_key, **list_kwargs)
         except Exception as e:
             logger.error(f"Failed to fetch records for study '{study_key}': {e}")
             return pd.DataFrame()  # Return empty on fetch failure

--- a/tests/unit/workflows/test_data_extraction.py
+++ b/tests/unit/workflows/test_data_extraction.py
@@ -1,0 +1,16 @@
+from unittest.mock import MagicMock
+
+from imednet.models.records import Record
+from imednet.workflows.data_extraction import DataExtractionWorkflow
+
+
+def test_extract_records_by_criteria_omits_none_filter() -> None:
+    sdk = MagicMock()
+    record = Record.model_validate({"recordId": 1})
+    sdk.records.list.return_value = [record]
+
+    wf = DataExtractionWorkflow(sdk)
+    result = wf.extract_records_by_criteria("STUDY")
+
+    assert result == [record]
+    sdk.records.list.assert_called_once_with("STUDY")

--- a/tests/unit/workflows/test_query_management.py
+++ b/tests/unit/workflows/test_query_management.py
@@ -1,0 +1,21 @@
+from unittest.mock import MagicMock
+
+from imednet.models.queries import Query, QueryComment
+from imednet.workflows.query_management import QueryManagementWorkflow
+
+
+def test_get_open_queries_omits_none_filter() -> None:
+    sdk = MagicMock()
+    query = Query.model_validate(
+        {
+            "annotationId": 1,
+            "queryComments": [QueryComment.model_validate({"sequence": 1, "closed": False})],
+        }
+    )
+    sdk.queries.list.return_value = [query]
+
+    wf = QueryManagementWorkflow(sdk)
+    result = wf.get_open_queries("STUDY")
+
+    assert result == [query]
+    sdk.queries.list.assert_called_once_with("STUDY")


### PR DESCRIPTION
## Summary
- avoid sending `filter=None` in workflows
- update CLI subject list to skip empty filters
- add regression tests for workflows

## Testing
- `poetry run pre-commit run --files imednet/cli.py imednet/workflows/data_extraction.py imednet/workflows/query_management.py imednet/workflows/record_mapper.py tests/unit/workflows/test_query_management.py tests/unit/workflows/test_data_extraction.py`
- `poetry run pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68474d2937d8832c82d247e646fe186c