### PR TITLE
Fix workflows sending None filters

### DIFF
--- a/imednet/cli.py
+++ b/imednet/cli.py
@@ -13,7 +13,6 @@ from .core.exceptions import ApiError
 from .sdk import ImednetSDK
 
 # Import the public filter utility
-from .utils.filters import build_filter_string
 from .workflows.credential_validation import CredentialValidationWorkflow
 from .workflows.data_extraction import DataExtractionWorkflow
 from .workflows.job_monitoring import JobMonitoringWorkflow
@@ -198,12 +197,10 @@ def list_subjects(
     sdk = get_sdk()
     try:
         # parse_filter_args now correctly accepts Optional[List[str]]
-        parsed_filter = parse_filter_args(subject_filter)
-        # Use the imported public build_filter_string utility
-        filter_str = build_filter_string(parsed_filter) if parsed_filter else None
+        parsed_filter = parse_filter_args(subject_filter) or {}
 
         print(f"Fetching subjects for study '{study_key}'...")
-        subjects_list = sdk.subjects.list(study_key, filter=filter_str)
+        subjects_list = sdk.subjects.list(study_key, **parsed_filter)
         if subjects_list:
             print(f"Found {len(subjects_list)} subjects:")
             print(subjects_list)

--- a/imednet/workflows/data_extraction.py
+++ b/imednet/workflows/data_extraction.py
@@ -3,7 +3,6 @@
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, Union
 
 from ..models import Record, RecordRevision
-from ..utils.filters import build_filter_string
 
 if TYPE_CHECKING:
     from ..sdk import ImednetSDK
@@ -44,8 +43,7 @@ class DataExtractionWorkflow:
         """
         matching_subject_keys: Optional[List[str]] = None
         if subject_filter:
-            subject_filter_str = build_filter_string(subject_filter)
-            subjects = self._sdk.subjects.list(study_key, filter=subject_filter_str)
+            subjects = self._sdk.subjects.list(study_key, **subject_filter)
             matching_subject_keys = [s.subject_key for s in subjects]
             if not matching_subject_keys:
                 return []
@@ -56,8 +54,7 @@ class DataExtractionWorkflow:
             # Client-side filtering for subject_key on visits is still needed
             # as build_filter_string doesn't handle complex AND/OR structures easily
             # from separate filter dictionaries.
-            visit_filter_str = build_filter_string(visit_filter)
-            visits = self._sdk.visits.list(study_key, filter=visit_filter_str)
+            visits = self._sdk.visits.list(study_key, **visit_filter)
 
             if matching_subject_keys:
                 visits = [v for v in visits if v.subject_key in matching_subject_keys]
@@ -68,17 +65,15 @@ class DataExtractionWorkflow:
                 return []
 
         # Build the final record filter dictionary
-        final_record_filter_dict = dict(record_filter) if record_filter else {}
+        final_record_filter_dict: Dict[str, Any] = dict(record_filter) if record_filter else {}
         final_record_filter_dict.update(other_filters)  # Add other_filters here
 
         # Client-side filtering is used below for subject/visit matching,
         # so no need to add complex 'in' clauses here even if build_filter_string supported it.
 
-        record_filter_str = build_filter_string(final_record_filter_dict)
-
         records = self._sdk.records.list(
-            study_key,
-            filter=record_filter_str if record_filter_str else None,
+            study_key=study_key,
+            **final_record_filter_dict,
         )
 
         # Client-side filtering fallback
@@ -124,13 +119,10 @@ class DataExtractionWorkflow:
         if end_date:
             date_kwargs["end_date"] = end_date
 
-        # Build the filter string
-        filter_str = build_filter_string(final_filter_dict)
-
         # Fetch record revisions
         revisions = self._sdk.record_revisions.list(
             study_key,
-            filter=filter_str if filter_str else None,
+            **final_filter_dict,
             **date_kwargs,
         )
         return revisions

--- a/imednet/workflows/query_management.py
+++ b/imednet/workflows/query_management.py
@@ -3,7 +3,6 @@
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, Union
 
 from ..models import Query
-from ..utils.filters import build_filter_string
 
 if TYPE_CHECKING:
     from ..sdk import ImednetSDK
@@ -43,11 +42,12 @@ class QueryManagementWorkflow:
         Returns:
             A list of open Query objects matching the criteria.
         """
-        # Build filter string from dictionary
-        filter_str = build_filter_string(additional_filter) if additional_filter else None
+        # Prepare combined filter kwargs
+        list_kwargs = dict(additional_filter or {})
+        list_kwargs.update(kwargs)
 
         # Fetch potentially relevant queries
-        all_matching_queries = self._sdk.queries.list(study_key, filter=filter_str, **kwargs)
+        all_matching_queries = self._sdk.queries.list(study_key, **list_kwargs)
 
         open_queries: List[Query] = []
         for query in all_matching_queries:
@@ -90,11 +90,9 @@ class QueryManagementWorkflow:
             # Simple merge, assumes no key conflicts. API filter string uses ';' (AND) by default.
             final_filter_dict.update(additional_filter)
 
-        filter_str = build_filter_string(final_filter_dict)
+        list_kwargs = {**final_filter_dict, **kwargs}
 
-        return self._sdk.queries.list(
-            study_key, filter=filter_str if filter_str else None, **kwargs
-        )
+        return self._sdk.queries.list(study_key, **list_kwargs)
 
     def get_queries_by_site(
         self,
@@ -121,11 +119,9 @@ class QueryManagementWorkflow:
             # Simple merge, assumes no key conflicts. API filter string uses ';' (AND) by default.
             final_filter_dict.update(additional_filter)
 
-        filter_str = build_filter_string(final_filter_dict)
+        list_kwargs = {**final_filter_dict, **kwargs}
 
-        return self._sdk.queries.list(
-            study_key, filter=filter_str if filter_str else None, **kwargs
-        )
+        return self._sdk.queries.list(study_key, **list_kwargs)
 
     def get_query_state_counts(self, study_key: str, **kwargs: Any) -> Dict[str, int]:
         """

--- a/imednet/workflows/record_mapper.py
+++ b/imednet/workflows/record_mapper.py
@@ -1,12 +1,11 @@
 import logging
-from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, Type, Union  # Add TYPE_CHECKING
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Type  # Add TYPE_CHECKING
 
 import pandas as pd
 from pydantic import BaseModel, Field, ValidationError, create_model
 
 from imednet.endpoints.records import Record as RecordModel
 from imednet.endpoints.variables import Variable as VariableModel
-from imednet.utils.filters import build_filter_string
 
 # Add conditional import
 if TYPE_CHECKING:
@@ -89,7 +88,7 @@ class RecordMapper:
         )
 
         # 3. Fetch records for the study with server-side filtering
-        record_filter_dict: Dict[str, Union[Any, Tuple[str, Any], List[Any]]] = {}
+        record_filter_dict: Dict[str, Any] = {}
         if visit_key is not None:
             # Assuming visit_key corresponds to visit_id which is an int in the model
             # If visit_key can be something else, adjust filter key accordingly
@@ -102,11 +101,9 @@ class RecordMapper:
                     "Fetching all records."
                 )
 
-        filter_str = build_filter_string(record_filter_dict) if record_filter_dict else None
-
         try:
             recs_all: List[RecordModel] = self.sdk.records.list(
-                study_key=study_key, filter=filter_str
+                study_key=study_key, **record_filter_dict
             )
         except Exception as e:
             logger.error(f"Failed to fetch records for study '{study_key}': {e}")

--- a/imednet/workflows/subject_data.py
+++ b/imednet/workflows/subject_data.py
@@ -5,7 +5,6 @@ from typing import TYPE_CHECKING, Any, Dict, List, Optional
 from pydantic import BaseModel, Field
 
 from ..models import Query, Record, Subject, Visit
-from ..utils.filters import build_filter_string
 
 if TYPE_CHECKING:
     from ..sdk import ImednetSDK
@@ -48,21 +47,20 @@ class SubjectDataWorkflow:
         """
         results = SubjectComprehensiveData(subject_details=None)
         subject_filter_dict: Dict[str, Any] = {"subject_key": subject_key}
-        subject_filter_str = build_filter_string(subject_filter_dict)
 
         # Fetch Subject Details
-        subject_list = self._sdk.subjects.list(study_key, filter=subject_filter_str)
+        subject_list = self._sdk.subjects.list(study_key, **subject_filter_dict)
         if subject_list:
             results.subject_details = subject_list[0]
 
         # Fetch Visits
-        results.visits = self._sdk.visits.list(study_key, filter=subject_filter_str)
+        results.visits = self._sdk.visits.list(study_key, **subject_filter_dict)
 
         # Fetch Records
-        results.records = self._sdk.records.list(study_key, filter=subject_filter_str)
+        results.records = self._sdk.records.list(study_key, **subject_filter_dict)
 
         # Fetch Queries
-        results.queries = self._sdk.queries.list(study_key, filter=subject_filter_str)
+        results.queries = self._sdk.queries.list(study_key, **subject_filter_dict)
 
         return results
 


### PR DESCRIPTION
## Summary
- avoid passing `filter=None` in query management workflow
- send workflow filter dictionaries as keyword arguments
- update CLI to pass parsed filters as kwargs

## Testing
- `poetry run pre-commit run --files imednet/cli.py imednet/workflows/data_extraction.py imednet/workflows/query_management.py imednet/workflows/record_mapper.py imednet/workflows/subject_data.py`
- `poetry run pytest -q --cov=imednet`

------
https://chatgpt.com/codex/tasks/task_e_68474e0f6eb4832c94be7eb01d607c62