### PR TITLE
Add credential profile manager

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Exposed all workflow helpers through new CLI subcommands.
 - Added a Tkinter-based desktop UI (`imednet-ui`) for running workflows with
   encrypted credential storage.
+- Support multiple named credential profiles with CLI `--profile` option and
+  UI selector.
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -100,6 +100,19 @@ imednet subjects list --filter "subject_status=Screened"
 imednet subjects list --help
 ```
 
+### Credential Profiles
+
+The SDK now supports storing multiple named credential profiles. Use the
+`ProfileManager` class or the desktop UI to create and switch between profiles
+without re-entering keys. The CLI accepts a global `--profile` option (or the
+`IMEDNET_PROFILE` environment variable) to run commands under a specific
+profile:
+
+```bash
+# Run using credentials saved under the "test" profile
+imednet --profile test studies list
+```
+
 ### Using the Desktop UI
 
 Install the optional UI dependencies and run the `imednet-ui` command:

--- a/imednet/ui/__init__.py
+++ b/imednet/ui/__init__.py
@@ -1,6 +1,6 @@
 """Desktop UI for the iMednet SDK."""
 
-from .credential_manager import CredentialManager
+from .credential_manager import CredentialManager, ProfileManager
 from .desktop import ImednetDesktopApp, run
 
-__all__ = ["CredentialManager", "ImednetDesktopApp", "run"]
+__all__ = ["CredentialManager", "ProfileManager", "ImednetDesktopApp", "run"]

--- a/imednet/ui/credential_manager.py
+++ b/imednet/ui/credential_manager.py
@@ -44,3 +44,78 @@ class CredentialManager:
         payload = self._fernet.decrypt(token)
         data = json.loads(payload.decode("utf-8"))
         return data
+
+
+class ProfileManager:
+    """Manage multiple named credential profiles using encryption."""
+
+    def __init__(self, path: Optional[Path] = None, key: Optional[bytes] = None) -> None:
+        self.path = path or Path.home() / ".imednet_profiles"
+        if key is None:
+            key_file = self.path.with_suffix(".key")
+            if key_file.exists():
+                key = key_file.read_bytes()
+            else:
+                key = Fernet.generate_key()
+                key_file.write_bytes(key)
+        self._fernet = Fernet(key)
+
+    def _read(self) -> dict:
+        if not self.path.exists():
+            return {"current": None, "profiles": {}}
+        token = self.path.read_bytes()
+        data = json.loads(self._fernet.decrypt(token).decode("utf-8"))
+        if "profiles" not in data:
+            data = {"current": None, "profiles": {"default": data}}
+        return data
+
+    def _write(self, data: dict) -> None:
+        token = self._fernet.encrypt(json.dumps(data).encode("utf-8"))
+        self.path.write_bytes(token)
+
+    def save_profile(
+        self,
+        name: str,
+        api_key: str,
+        security_key: str,
+        base_url: Optional[str] = None,
+        study_key: Optional[str] = None,
+    ) -> None:
+        data = self._read()
+        data.setdefault("profiles", {})[name] = {
+            "api_key": api_key,
+            "security_key": security_key,
+            "base_url": base_url,
+            "study_key": study_key,
+        }
+        self._write(data)
+
+    def load_profile(self, name: Optional[str] = None) -> Optional[dict[str, str | None]]:
+        data = self._read()
+        name = name or data.get("current")
+        if not name:
+            return None
+        return data.get("profiles", {}).get(name)
+
+    def delete_profile(self, name: str) -> None:
+        data = self._read()
+        if name in data.get("profiles", {}):
+            del data["profiles"][name]
+            if data.get("current") == name:
+                data["current"] = None
+            self._write(data)
+
+    def list_profiles(self) -> list[str]:
+        data = self._read()
+        return list(data.get("profiles", {}).keys())
+
+    def set_current(self, name: str) -> None:
+        data = self._read()
+        if name not in data.get("profiles", {}):
+            raise KeyError(name)
+        data["current"] = name
+        self._write(data)
+
+    def current(self) -> Optional[str]:
+        data = self._read()
+        return data.get("current")

--- a/tests/unit/ui/test_profiles.py
+++ b/tests/unit/ui/test_profiles.py
@@ -1,0 +1,29 @@
+from pathlib import Path
+
+from cryptography.fernet import Fernet
+from imednet.ui.credential_manager import ProfileManager
+
+
+def test_profile_manager_crud(tmp_path: Path) -> None:
+    path = tmp_path / "profiles"
+    key = Fernet.generate_key()
+    mgr = ProfileManager(path=path, key=key)
+
+    mgr.save_profile("foo", "a", "b")
+    mgr.save_profile("bar", "c", "d")
+
+    assert set(mgr.list_profiles()) == {"foo", "bar"}
+
+    mgr.set_current("foo")
+    assert mgr.current() == "foo"
+
+    loaded = mgr.load_profile()
+    assert loaded == {
+        "api_key": "a",
+        "security_key": "b",
+        "base_url": None,
+        "study_key": None,
+    }
+
+    mgr.delete_profile("foo")
+    assert "foo" not in mgr.list_profiles()


### PR DESCRIPTION
## Summary
- manage multiple credential profiles
- expose `ProfileManager` from the UI package
- allow CLI to select profiles with `--profile`
- extend desktop UI with profile dropdown
- document profile usage
- test profile manager functionality

## Testing
- `poetry run pre-commit run --files CHANGELOG.md README.md imednet/cli.py imednet/ui/__init__.py imednet/ui/credential_manager.py imednet/ui/desktop.py tests/unit/ui/test_profiles.py`
- `poetry run pytest -q --cov=imednet`

------
https://chatgpt.com/codex/tasks/task_e_684798788b20832cad78642bc8a02859