### PR TITLE
Add credential profile management

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added a Tkinter-based desktop UI (`imednet-ui`) for running workflows with
   encrypted credential storage.
 - Desktop UI now supports saving and loading command parameter templates.
+- Added credential profile management with encryption for switching between
+  multiple saved profiles.
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ See the [Changelog](CHANGELOG.md) for release history.
 - Automatic pagination
 - Data models for requests and responses
 - Workflow utilities for data extraction and mapping
+- Encrypted credential profile management for the desktop UI
 
 ## Installation
 

--- a/docs/imednet.rst
+++ b/docs/imednet.rst
@@ -12,6 +12,7 @@ Subpackages
    imednet.models
    imednet.utils
    imednet.workflows
+   imednet.ui
 
 Submodules
 ----------

--- a/docs/imednet.ui.rst
+++ b/docs/imednet.ui.rst
@@ -1,0 +1,45 @@
+imednet.ui package
+==================
+
+Submodules
+----------
+
+imednet.ui.profile_manager module
+---------------------------------
+
+.. automodule:: imednet.ui.profile_manager
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+imednet.ui.credential_manager module
+------------------------------------
+
+.. automodule:: imednet.ui.credential_manager
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+imednet.ui.template_manager module
+----------------------------------
+
+.. automodule:: imednet.ui.template_manager
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+imednet.ui.desktop module
+-------------------------
+
+.. automodule:: imednet.ui.desktop
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Module contents
+---------------
+
+.. automodule:: imednet.ui
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/imednet/ui/__init__.py
+++ b/imednet/ui/__init__.py
@@ -2,6 +2,13 @@
 
 from .credential_manager import CredentialManager
 from .desktop import ImednetDesktopApp, run
+from .profile_manager import ProfileManager
 from .template_manager import TemplateManager
 
-__all__ = ["CredentialManager", "ImednetDesktopApp", "TemplateManager", "run"]
+__all__ = [
+    "CredentialManager",
+    "ImednetDesktopApp",
+    "TemplateManager",
+    "ProfileManager",
+    "run",
+]

--- a/imednet/ui/profile_manager.py
+++ b/imednet/ui/profile_manager.py
@@ -1,0 +1,98 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+from cryptography.fernet import Fernet
+
+
+class ProfileManager:
+    """Manage multiple sets of encrypted credentials."""
+
+    def __init__(self, path: Optional[Path] = None, key: Optional[bytes] = None) -> None:
+        self.path = path or Path.home() / ".imednet_profiles"
+        if key is None:
+            key_file = self.path.with_suffix(".key")
+            if key_file.exists():
+                key = key_file.read_bytes()
+            else:
+                key = Fernet.generate_key()
+                key_file.write_bytes(key)
+        self._fernet = Fernet(key)
+
+    def _load_all(self) -> Dict[str, Any]:
+        if not self.path.exists():
+            return {"active": None, "profiles": {}}
+        token = self.path.read_bytes()
+        data = json.loads(self._fernet.decrypt(token).decode("utf-8"))
+        if "profiles" not in data:
+            # migrate from empty structure
+            data = {"active": None, "profiles": {}}
+        return data
+
+    def _save_all(self, data: Dict[str, Any]) -> None:
+        token = self._fernet.encrypt(json.dumps(data).encode("utf-8"))
+        self.path.write_bytes(token)
+
+    def save_profile(
+        self,
+        name: str,
+        api_key: str,
+        security_key: str,
+        base_url: Optional[str] = None,
+        study_key: Optional[str] = None,
+    ) -> None:
+        data = self._load_all()
+        profiles = data.setdefault("profiles", {})
+        profiles[name] = {
+            "api_key": api_key,
+            "security_key": security_key,
+            "base_url": base_url,
+            "study_key": study_key,
+        }
+        self._save_all(data)
+
+    def load_profile(self, name: str) -> Optional[Dict[str, str | None]]:
+        data = self._load_all()
+        return data.get("profiles", {}).get(name)
+
+    def list_profiles(self) -> List[str]:
+        data = self._load_all()
+        return sorted(data.get("profiles", {}))
+
+    def delete_profile(self, name: str) -> None:
+        data = self._load_all()
+        profiles = data.get("profiles", {})
+        if name in profiles:
+            del profiles[name]
+            if data.get("active") == name:
+                data["active"] = None
+            self._save_all(data)
+
+    def rename_profile(self, old_name: str, new_name: str) -> None:
+        data = self._load_all()
+        profiles = data.get("profiles", {})
+        if old_name not in profiles:
+            raise KeyError(old_name)
+        profiles[new_name] = profiles.pop(old_name)
+        if data.get("active") == old_name:
+            data["active"] = new_name
+        self._save_all(data)
+
+    def set_active(self, name: str) -> None:
+        data = self._load_all()
+        if name not in data.get("profiles", {}):
+            raise KeyError(name)
+        data["active"] = name
+        self._save_all(data)
+
+    def get_active_name(self) -> Optional[str]:
+        data = self._load_all()
+        return data.get("active")
+
+    def load_active(self) -> Optional[Dict[str, str | None]]:
+        name = self.get_active_name()
+        if name is None:
+            return None
+        return self.load_profile(name)

--- a/tests/unit/ui/test_profiles.py
+++ b/tests/unit/ui/test_profiles.py
@@ -1,0 +1,42 @@
+from pathlib import Path
+
+from cryptography.fernet import Fernet
+from imednet.ui.profile_manager import ProfileManager
+
+
+def test_profile_crud(tmp_path: Path) -> None:
+    path = tmp_path / "profiles"
+    key = Fernet.generate_key()
+    mgr = ProfileManager(path=path, key=key)
+
+    mgr.save_profile("p1", "a", "b")
+    assert mgr.load_profile("p1") == {
+        "api_key": "a",
+        "security_key": "b",
+        "base_url": None,
+        "study_key": None,
+    }
+    assert mgr.list_profiles() == ["p1"]
+
+    mgr.rename_profile("p1", "p2")
+    assert mgr.list_profiles() == ["p2"]
+
+    mgr.delete_profile("p2")
+    assert mgr.list_profiles() == []
+
+
+def test_active_profile(tmp_path: Path) -> None:
+    path = tmp_path / "profiles"
+    key = Fernet.generate_key()
+    mgr = ProfileManager(path=path, key=key)
+
+    mgr.save_profile("p1", "a", "b")
+    mgr.save_profile("p2", "c", "d")
+    mgr.set_active("p2")
+    assert mgr.get_active_name() == "p2"
+    assert mgr.load_active() == {
+        "api_key": "c",
+        "security_key": "d",
+        "base_url": None,
+        "study_key": None,
+    }


### PR DESCRIPTION
## Summary
- enable encrypted credential profiles
- document new `ProfileManager` and UI package
- update README features
- note profile management in changelog
- include tests for profile manager

## Testing
- `pre-commit run --files CHANGELOG.md README.md docs/imednet.rst docs/imednet.ui.rst imednet/ui/__init__.py imednet/ui/profile_manager.py tests/unit/ui/test_profiles.py`
- `pytest -q --cov=imednet`
- `sphinx-build -b html docs docs/_build/html`


------
https://chatgpt.com/codex/tasks/task_e_68479bb33c3c832c9a6c2d8b1e6e1263