### PR TITLE
Add missing type annotations

### DIFF
--- a/imednet/cli.py
+++ b/imednet/cli.py
@@ -84,7 +84,7 @@ def get_sdk() -> ImednetSDK:
 
 
 @app.callback()
-def main(ctx: typer.Context):
+def main(ctx: typer.Context) -> None:
     """
     iMednet SDK CLI. Configure authentication via environment variables:
     IMEDNET_API_KEY, IMEDNET_SECURITY_KEY, [IMEDNET_BASE_URL]
@@ -97,7 +97,9 @@ def main(ctx: typer.Context):
 
 
 # Change input type hint to Optional[List[str]]
-def parse_filter_args(filter_args: Optional[List[str]]) -> Optional[Dict[str, Any]]:
+def parse_filter_args(
+    filter_args: Optional[List[str]],
+) -> Optional[Dict[str, Any]]:
     """Parses a list of 'key=value' strings into a dictionary."""
     if not filter_args:  # Handle None input
         return None
@@ -131,7 +133,7 @@ app.add_typer(studies_app)
 
 
 @studies_app.command("list")
-def list_studies():
+def list_studies() -> None:
     """List available studies."""
     sdk = get_sdk()
     try:
@@ -158,7 +160,7 @@ app.add_typer(sites_app)
 @sites_app.command("list")
 def list_sites(
     study_key: Optional[str] = STUDY_KEY_OPTION,
-):
+) -> None:
     """List sites for a specific study."""
     study_key = require_study_key(study_key)
     sdk = get_sdk()
@@ -190,10 +192,9 @@ def list_subjects(
         None,
         "--filter",
         "-f",
-        help="Filter criteria (e.g., 'subject_status=Screened'). " "Repeat for multiple filters.",
+        help="Filter criteria (e.g., subject_status=Screened). " "Repeat for multiple filters.",
     ),
-):
-    """List subjects for a specific study, with optional filtering."""
+) -> None:
     study_key = require_study_key(study_key)
     sdk = get_sdk()
     try:
@@ -243,7 +244,7 @@ def extract_records(
         "--visit-filter",
         help="Visit filter criteria (e.g., 'visit_key=SCREENING'). " "Repeat for multiple filters.",
     ),
-):
+) -> None:
     """Extract records based on criteria spanning subjects, visits, and records."""
     study_key = require_study_key(study_key)
     sdk = get_sdk()
@@ -289,7 +290,7 @@ def extract_audit_trail(
         "--user-filter",
         help="User filter criteria (e.g., 'user_id=5'). Repeat for multiple filters.",
     ),
-):
+) -> None:
     """Extract record revision audit trail."""
     study_key = require_study_key(study_key)
     sdk = get_sdk()
@@ -352,7 +353,7 @@ def open_queries(
         "-f",
         help="Additional filter criteria. Repeat for multiple filters.",
     ),
-):
+) -> None:
     """List open queries for a study."""
     study_key = require_study_key(study_key)
     sdk = get_sdk()
@@ -371,7 +372,7 @@ def open_queries(
 
 
 @workflows_app.command("site-progress")
-def site_progress(study_key: Optional[str] = STUDY_KEY_OPTION):
+def site_progress(study_key: Optional[str] = STUDY_KEY_OPTION) -> None:
     """Show site progress metrics."""
     study_key = require_study_key(study_key)
     sdk = get_sdk()
@@ -393,7 +394,7 @@ def record_dataframe(
     study_key: Optional[str] = STUDY_KEY_OPTION,
     visit_key: Optional[str] = typer.Option(None, help="Optional visit key"),
     use_labels_as_columns: bool = typer.Option(True, help="Use variable labels"),
-):
+) -> None:
     """Output records as a CSV string."""
     study_key = require_study_key(study_key)
     sdk = get_sdk()
@@ -416,7 +417,7 @@ def record_dataframe(
 def subject_data(
     study_key: Optional[str] = STUDY_KEY_OPTION,
     subject_key: str = typer.Argument(..., help="Subject key"),
-):
+) -> None:
     """Retrieve all data related to a subject."""
     study_key = require_study_key(study_key)
     sdk = get_sdk()
@@ -434,7 +435,7 @@ def subject_data(
 
 
 @workflows_app.command("validate")
-def validate_credentials(study_key: Optional[str] = STUDY_KEY_OPTION):
+def validate_credentials(study_key: Optional[str] = STUDY_KEY_OPTION) -> None:
     """Validate API credentials against a study key."""
     study_key = require_study_key(study_key)
     sdk = get_sdk()
@@ -456,7 +457,7 @@ def register_subjects(
     study_key: Optional[str] = STUDY_KEY_OPTION,
     subjects_file: str = typer.Argument(..., help="Path to JSON file of subjects"),
     email_notify: Optional[str] = typer.Option(None, help="Notification email"),
-):
+) -> None:
     """Register multiple subjects from a JSON file."""
     study_key = require_study_key(study_key)
     sdk = get_sdk()
@@ -483,7 +484,7 @@ def submit_record_batch(
     study_key: Optional[str] = STUDY_KEY_OPTION,
     batch_file: str = typer.Argument(..., help="Path to JSON batch file"),
     wait_for_completion: bool = typer.Option(False, help="Wait for job to finish"),
-):
+) -> None:
     """Submit a batch of record updates from a JSON file."""
     study_key = require_study_key(study_key)
     sdk = get_sdk()
@@ -513,7 +514,7 @@ def submit_record_batch(
 
 
 @workflows_app.command("study-structure")
-def study_structure(study_key: Optional[str] = STUDY_KEY_OPTION):
+def study_structure(study_key: Optional[str] = STUDY_KEY_OPTION) -> None:
     """Retrieve the study structure definition."""
     study_key = require_study_key(study_key)
     sdk = get_sdk()
@@ -531,7 +532,7 @@ def study_structure(study_key: Optional[str] = STUDY_KEY_OPTION):
 
 # --- Original Hello Command (can be removed or kept for testing) ---
 @app.command()
-def hello(name: str = "World"):
+def hello(name: str = "World") -> None:
     """Says hello"""
     print(f"Hello {name}")
 

--- a/imednet/endpoints/codings.py
+++ b/imednet/endpoints/codings.py
@@ -62,3 +62,6 @@ class CodingsEndpoint(BaseEndpoint):
         if not raw:
             raise ValueError(f"Coding {coding_id} not found in study {study_key}")
         return Coding.from_json(raw[0])
+
+
+__all__ = ["CodingsEndpoint"]

--- a/imednet/endpoints/forms.py
+++ b/imednet/endpoints/forms.py
@@ -60,3 +60,6 @@ class FormsEndpoint(BaseEndpoint):
         if not raw:
             raise ValueError(f"Form {form_id} not found in study {study_key}")
         return Form.from_json(raw[0])
+
+
+__all__ = ["FormsEndpoint"]

--- a/imednet/endpoints/intervals.py
+++ b/imednet/endpoints/intervals.py
@@ -56,3 +56,6 @@ class IntervalsEndpoint(BaseEndpoint):
         if not raw:
             raise ValueError(f"Interval {interval_id} not found in study {study_key}")
         return Interval.from_json(raw[0])
+
+
+__all__ = ["IntervalsEndpoint"]

--- a/imednet/endpoints/jobs.py
+++ b/imednet/endpoints/jobs.py
@@ -32,3 +32,6 @@ class JobsEndpoint(BaseEndpoint):
         if not data:
             raise ValueError(f"Job {batch_id} not found in study {study_key}")
         return Job.from_json(data)
+
+
+__all__ = ["JobsEndpoint"]

--- a/imednet/endpoints/queries.py
+++ b/imednet/endpoints/queries.py
@@ -56,3 +56,6 @@ class QueriesEndpoint(BaseEndpoint):
         if not raw:
             raise ValueError(f"Query {annotation_id} not found in study {study_key}")
         return Query.from_json(raw[0])
+
+
+__all__ = ["QueriesEndpoint"]

--- a/imednet/endpoints/record_revisions.py
+++ b/imednet/endpoints/record_revisions.py
@@ -56,3 +56,6 @@ class RecordRevisionsEndpoint(BaseEndpoint):
         if not raw:
             raise ValueError(f"Record revision {record_revision_id} not found in study {study_key}")
         return RecordRevision.from_json(raw[0])
+
+
+__all__ = ["RecordRevisionsEndpoint"]

--- a/imednet/endpoints/records.py
+++ b/imednet/endpoints/records.py
@@ -92,3 +92,6 @@ class RecordsEndpoint(BaseEndpoint):
 
         response = self._client.post(path, json=records_data, headers=headers)
         return Job.from_json(response.json())
+
+
+__all__ = ["RecordsEndpoint"]

--- a/imednet/endpoints/sites.py
+++ b/imednet/endpoints/sites.py
@@ -60,3 +60,6 @@ class SitesEndpoint(BaseEndpoint):
         if not raw:
             raise ValueError(f"Site {site_id} not found in study {study_key}")
         return Site.from_json(raw[0])
+
+
+__all__ = ["SitesEndpoint"]

--- a/imednet/endpoints/studies.py
+++ b/imednet/endpoints/studies.py
@@ -49,3 +49,6 @@ class StudiesEndpoint(BaseEndpoint):
         if not raw:
             raise ValueError(f"Study {study_key} not found")
         return Study.model_validate(raw[0])
+
+
+__all__ = ["StudiesEndpoint"]

--- a/imednet/endpoints/subjects.py
+++ b/imednet/endpoints/subjects.py
@@ -56,3 +56,6 @@ class SubjectsEndpoint(BaseEndpoint):
         if not raw:
             raise ValueError(f"Subject {subject_key} not found in study {study_key}")
         return Subject.from_json(raw[0])
+
+
+__all__ = ["SubjectsEndpoint"]

--- a/imednet/endpoints/users.py
+++ b/imednet/endpoints/users.py
@@ -53,3 +53,6 @@ class UsersEndpoint(BaseEndpoint):
         if not raw:
             raise ValueError(f"User {user_id} not found in study {study_key}")
         return User.from_json(raw[0])
+
+
+__all__ = ["UsersEndpoint"]

--- a/imednet/endpoints/variables.py
+++ b/imednet/endpoints/variables.py
@@ -60,3 +60,6 @@ class VariablesEndpoint(BaseEndpoint):
         if not raw:
             raise ValueError(f"Variable {variable_id} not found in study {study_key}")
         return Variable.from_json(raw[0])
+
+
+__all__ = ["VariablesEndpoint"]

--- a/imednet/endpoints/visits.py
+++ b/imednet/endpoints/visits.py
@@ -56,3 +56,6 @@ class VisitsEndpoint(BaseEndpoint):
         if not raw:
             raise ValueError(f"Visit {visit_id} not found in study {study_key}")
         return Visit.from_json(raw[0])
+
+
+__all__ = ["VisitsEndpoint"]

--- a/imednet/models/base.py
+++ b/imednet/models/base.py
@@ -24,7 +24,7 @@ class SortField(BaseModel):
     model_config = ConfigDict(populate_by_name=True)
 
     @field_validator("property", "direction", mode="before")
-    def _fill_strs(cls, v):
+    def _fill_strs(cls, v: Any) -> str:
         return parse_str_or_default(v)
 
 
@@ -40,11 +40,11 @@ class Pagination(BaseModel):
     model_config = ConfigDict(populate_by_name=True)
 
     @field_validator("current_page", "size", "total_pages", "total_elements", mode="before")
-    def _fill_ints(cls, v):
+    def _fill_ints(cls, v: Any) -> int:
         return parse_int_or_default(v)
 
     @field_validator("sort", mode="before")
-    def _fill_list(cls, v):
+    def _fill_list(cls, v: Any) -> List[SortField]:
         return parse_list_or_default(v)
 
 
@@ -58,11 +58,11 @@ class Error(BaseModel):
     model_config = ConfigDict(populate_by_name=True)
 
     @field_validator("code", "message", mode="before")
-    def _fill_strs(cls, v):
+    def _fill_strs(cls, v: Any) -> str:
         return parse_str_or_default(v)
 
     @field_validator("details", mode="before")
-    def _fill_details(cls, v):
+    def _fill_details(cls, v: Any) -> Dict[str, Any]:
         return v if isinstance(v, dict) else {}
 
 
@@ -78,11 +78,11 @@ class Metadata(BaseModel):
     model_config = ConfigDict(populate_by_name=True)
 
     @field_validator("status", "method", "path", mode="before")
-    def _fill_strs(cls, v):
+    def _fill_strs(cls, v: Any) -> str:
         return parse_str_or_default(v)
 
     @field_validator("timestamp", mode="before")
-    def _parse_datetime(cls, v):
+    def _parse_datetime(cls, v: Any) -> datetime:
         return parse_datetime(v)
 
 

--- a/imednet/models/codings.py
+++ b/imednet/models/codings.py
@@ -47,13 +47,13 @@ class Coding(BaseModel):
         "dictionary_version",
         mode="before",
     )
-    def _fill_strs(cls, v):
+    def _fill_strs(cls, v: Any) -> str:
         return parse_str_or_default(v)
 
     @field_validator(
         "site_id", "subject_id", "form_id", "revision", "record_id", "coding_id", mode="before"
     )
-    def _fill_ints(cls, v):
+    def _fill_ints(cls, v: Any) -> int:
         return parse_int_or_default(v)
 
     @field_validator("date_coded", mode="before")

--- a/imednet/models/forms.py
+++ b/imednet/models/forms.py
@@ -30,11 +30,11 @@ class Form(BaseModel):
     model_config = ConfigDict(populate_by_name=True)
 
     @field_validator("study_key", "form_key", "form_name", "form_type", mode="before")
-    def _fill_strs(cls, v):
+    def _fill_strs(cls, v: Any) -> str:
         return parse_str_or_default(v)
 
     @field_validator("form_id", "revision", mode="before")
-    def _fill_ints(cls, v):
+    def _fill_ints(cls, v: Any) -> int:
         return parse_int_or_default(v)
 
     @field_validator(

--- a/imednet/models/intervals.py
+++ b/imednet/models/intervals.py
@@ -30,11 +30,11 @@ class FormSummary(BaseModel):
         return cls.model_validate(data)
 
     @field_validator("form_key", "form_name", mode="before")
-    def _fill_strs(cls, v):
+    def _fill_strs(cls, v: Any) -> str:
         return parse_str_or_default(v)
 
     @field_validator("form_id", mode="before")
-    def _fill_ints(cls, v):
+    def _fill_ints(cls, v: Any) -> int:
         return parse_int_or_default(v)
 
 
@@ -76,7 +76,7 @@ class Interval(BaseModel):
         "actual_date",
         mode="before",
     )
-    def _fill_strs(cls, v):
+    def _fill_strs(cls, v: Any) -> str:
         return parse_str_or_default(v)
 
     @field_validator(
@@ -89,11 +89,11 @@ class Interval(BaseModel):
         "epro_grace_period",
         mode="before",
     )
-    def _fill_ints(cls, v):
+    def _fill_ints(cls, v: Any) -> int:
         return parse_int_or_default(v)
 
     @field_validator("forms", mode="before")
-    def _fill_list(cls, v):
+    def _fill_list(cls, v: Any) -> List[FormSummary]:
         return parse_list_or_default(v)
 
     @field_validator("date_created", "date_modified", mode="before")

--- a/imednet/models/jobs.py
+++ b/imednet/models/jobs.py
@@ -20,11 +20,11 @@ class Job(BaseModel):
     model_config = ConfigDict(populate_by_name=True)
 
     @field_validator("job_id", "batch_id", "state", mode="before")
-    def _fill_strs(cls, v):
+    def _fill_strs(cls, v: Any) -> str:
         return parse_str_or_default(v)
 
     @field_validator("date_created", "date_started", "date_finished", mode="before")
-    def _parse_datetimes(cls, v):
+    def _parse_datetimes(cls, v: Any) -> datetime:
         return parse_datetime(v)
 
     @classmethod

--- a/imednet/models/queries.py
+++ b/imednet/models/queries.py
@@ -26,19 +26,19 @@ class QueryComment(BaseModel):
     model_config = ConfigDict(populate_by_name=True)
 
     @field_validator("annotation_status", "user", "comment", mode="before")
-    def _fill_strs(cls, v):
+    def _fill_strs(cls, v: Any) -> str:
         return parse_str_or_default(v)
 
     @field_validator("sequence", mode="before")
-    def _fill_ints(cls, v):
+    def _fill_ints(cls, v: Any) -> int:
         return parse_int_or_default(v)
 
     @field_validator("date", mode="before")
-    def _parse_date(cls, v):
+    def _parse_date(cls, v: Any) -> datetime:
         return parse_datetime(v)
 
     @field_validator("closed", mode="before")
-    def parse_bool_field(cls, v):
+    def parse_bool_field(cls, v: Any) -> bool:
         return parse_bool(v)
 
     @classmethod
@@ -75,19 +75,19 @@ class Query(BaseModel):
         "subject_key",
         mode="before",
     )
-    def _fill_strs(cls, v):
+    def _fill_strs(cls, v: Any) -> str:
         return parse_str_or_default(v)
 
     @field_validator("subject_id", "annotation_id", "record_id", mode="before")
-    def _fill_ints(cls, v):
+    def _fill_ints(cls, v: Any) -> int:
         return parse_int_or_default(v)
 
     @field_validator("query_comments", mode="before")
-    def _fill_list(cls, v):
+    def _fill_list(cls, v: Any) -> List[QueryComment]:
         return parse_list_or_default(v)
 
     @field_validator("date_created", "date_modified", mode="before")
-    def _parse_datetimes(cls, v):
+    def _parse_datetimes(cls, v: Any) -> datetime:
         return parse_datetime(v)
 
     @classmethod

--- a/imednet/models/record_revisions.py
+++ b/imednet/models/record_revisions.py
@@ -40,7 +40,7 @@ class RecordRevision(BaseModel):
         "interval_id",
         mode="before",
     )
-    def _fill_ints(cls, v):
+    def _fill_ints(cls, v: Any) -> int:
         return parse_int_or_default(v)
 
     @field_validator(
@@ -55,15 +55,15 @@ class RecordRevision(BaseModel):
         "reason_for_change",
         mode="before",
     )
-    def _fill_strs(cls, v):
+    def _fill_strs(cls, v: Any) -> str:
         return parse_str_or_default(v)
 
     @field_validator("deleted", mode="before")
-    def _parse_deleted(cls, v):
+    def _parse_deleted(cls, v: Any) -> bool:
         return parse_bool(v)
 
     @field_validator("date_created", mode="before")
-    def _parse_date_created(cls, v):
+    def _parse_date_created(cls, v: Any) -> datetime:
         return parse_datetime(v)
 
     @classmethod

--- a/imednet/models/records.py
+++ b/imednet/models/records.py
@@ -23,15 +23,15 @@ class Keyword(BaseModel):
     model_config = ConfigDict(populate_by_name=True)
 
     @field_validator("keyword_name", "keyword_key", mode="before")
-    def _fill_strs(cls, v):
+    def _fill_strs(cls, v: Any) -> str:
         return parse_str_or_default(v)
 
     @field_validator("keyword_id", mode="before")
-    def _fill_ints(cls, v):
+    def _fill_ints(cls, v: Any) -> int:
         return parse_int_or_default(v)
 
     @field_validator("date_added", mode="before")
-    def _parse_date_added(cls, v):
+    def _parse_date_added(cls, v: Any) -> datetime:
         return parse_datetime(v)
 
     @classmethod
@@ -72,7 +72,7 @@ class Record(BaseModel):
         "parent_record_id",
         mode="before",
     )
-    def _fill_ints(cls, v):
+    def _fill_ints(cls, v: Any) -> int:
         return parse_int_or_default(v)
 
     @field_validator(
@@ -85,19 +85,19 @@ class Record(BaseModel):
         "subject_key",
         mode="before",
     )
-    def _fill_strs(cls, v):
+    def _fill_strs(cls, v: Any) -> str:
         return parse_str_or_default(v)
 
     @field_validator("keywords", mode="before")
-    def _fill_list(cls, v):
+    def _fill_list(cls, v: Any) -> List[Keyword]:
         return parse_list_or_default(v)
 
     @field_validator("deleted", mode="before")
-    def parse_bool_field(cls, v):
+    def parse_bool_field(cls, v: Any) -> bool:
         return parse_bool(v)
 
     @field_validator("date_created", "date_modified", mode="before")
-    def _parse_datetimes(cls, v):
+    def _parse_datetimes(cls, v: Any) -> datetime:
         return parse_datetime(v)
 
     @classmethod
@@ -113,7 +113,7 @@ class RecordJobResponse(BaseModel):
     model_config = ConfigDict(populate_by_name=True)
 
     @field_validator("job_id", "batch_id", "state", mode="before")
-    def _fill_strs(cls, v):
+    def _fill_strs(cls, v: Any) -> str:
         return parse_str_or_default(v)
 
     @classmethod
@@ -132,7 +132,7 @@ class BaseRecordRequest(BaseModel):
     model_config = ConfigDict(populate_by_name=True)
 
     @field_validator("form_key", mode="before")
-    def _fill_strs(cls, v):
+    def _fill_strs(cls, v: Any) -> str:
         return parse_str_or_default(v)
 
 
@@ -140,7 +140,7 @@ class RegisterSubjectRequest(BaseRecordRequest):
     site_name: str = Field("", alias="siteName")
 
     @field_validator("site_name", mode="before")
-    def _fill_strs(cls, v):
+    def _fill_strs(cls, v: Any) -> str:
         return parse_str_or_default(v)
 
 
@@ -149,7 +149,7 @@ class UpdateScheduledRecordRequest(BaseRecordRequest):
     interval_name: str = Field("", alias="intervalName")
 
     @field_validator("subject_key", "interval_name", mode="before")
-    def _fill_strs(cls, v):
+    def _fill_strs(cls, v: Any) -> str:
         return parse_str_or_default(v)
 
 

--- a/imednet/models/sites.py
+++ b/imednet/models/sites.py
@@ -20,15 +20,15 @@ class Site(BaseModel):
     model_config = ConfigDict(populate_by_name=True)
 
     @field_validator("study_key", "site_name", "site_enrollment_status", mode="before")
-    def _fill_strs(cls, v):
+    def _fill_strs(cls, v: Any) -> str:
         return parse_str_or_default(v)
 
     @field_validator("site_id", mode="before")
-    def _fill_ints(cls, v):
+    def _fill_ints(cls, v: Any) -> int:
         return parse_int_or_default(v)
 
     @field_validator("date_created", "date_modified", mode="before")
-    def _parse_datetimes(cls, v):
+    def _parse_datetimes(cls, v: Any) -> datetime:
         return parse_datetime(v)
 
     @classmethod

--- a/imednet/models/studies.py
+++ b/imednet/models/studies.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from datetime import datetime
+from typing import Any
 
 from pydantic import BaseModel, ConfigDict, Field, field_validator
 
@@ -22,13 +23,13 @@ class Study(BaseModel):
     @field_validator(
         "sponsor_key", "study_key", "study_name", "study_description", "study_type", mode="before"
     )
-    def _fill_strs(cls, v):
+    def _fill_strs(cls, v: Any) -> str:
         return parse_str_or_default(v)
 
     @field_validator("study_id", mode="before")
-    def _fill_ints(cls, v):
+    def _fill_ints(cls, v: Any) -> int:
         return parse_int_or_default(v)
 
     @field_validator("date_created", "date_modified", mode="before")
-    def _parse_dates(cls, v):
+    def _parse_dates(cls, v: Any) -> datetime:
         return parse_datetime(v)

--- a/imednet/models/subjects.py
+++ b/imednet/models/subjects.py
@@ -23,15 +23,15 @@ class SubjectKeyword(BaseModel):
     model_config = ConfigDict(populate_by_name=True)
 
     @field_validator("keyword_name", "keyword_key", mode="before")
-    def _fill_strs(cls, v):
+    def _fill_strs(cls, v: Any) -> str:
         return parse_str_or_default(v)
 
     @field_validator("keyword_id", mode="before")
-    def _fill_ints(cls, v):
+    def _fill_ints(cls, v: Any) -> int:
         return parse_int_or_default(v)
 
     @field_validator("date_added", mode="before")
-    def _parse_date_added(cls, v):
+    def _parse_date_added(cls, v: Any) -> datetime:
         return parse_datetime(v)
 
     @classmethod
@@ -58,25 +58,25 @@ class Subject(BaseModel):
     model_config = ConfigDict(populate_by_name=True)
 
     @field_validator("subject_id", "site_id", mode="before")
-    def _fill_ints(cls, v):
+    def _fill_ints(cls, v: Any) -> int:
         return parse_int_or_default(v)
 
     @field_validator(
         "study_key", "subject_oid", "subject_key", "subject_status", "site_name", mode="before"
     )
-    def _fill_strs(cls, v):
+    def _fill_strs(cls, v: Any) -> str:
         return parse_str_or_default(v)
 
     @field_validator("keywords", mode="before")
-    def _fill_list(cls, v):
+    def _fill_list(cls, v: Any) -> List[SubjectKeyword]:
         return parse_list_or_default(v)
 
     @field_validator("deleted", mode="before")
-    def parse_bool_field(cls, v):
+    def parse_bool_field(cls, v: Any) -> bool:
         return parse_bool(v)
 
     @field_validator("enrollment_start_date", "date_created", "date_modified", mode="before")
-    def _parse_datetimes(cls, v):
+    def _parse_datetimes(cls, v: Any) -> datetime:
         return parse_datetime(v)
 
     @classmethod

--- a/imednet/models/users.py
+++ b/imednet/models/users.py
@@ -29,19 +29,19 @@ class Role(BaseModel):
 
     # —— Parse or default datetimes
     @field_validator("date_created", "date_modified", mode="before")
-    def _parse_datetimes(cls, v):
+    def _parse_datetimes(cls, v: Any) -> datetime:
         return parse_datetime(v)
 
     @field_validator("community_id", "level", mode="before")
-    def _fill_ints(cls, v):
+    def _fill_ints(cls, v: Any) -> int:
         return parse_int_or_default(v)
 
     @field_validator("role_id", "name", "description", "type", mode="before")
-    def _fill_strs(cls, v):
+    def _fill_strs(cls, v: Any) -> str:
         return parse_str_or_default(v)
 
     @field_validator("inactive", mode="before")
-    def parse_bool_field(cls, v):
+    def parse_bool_field(cls, v: Any) -> bool:
         return parse_bool(v)
 
     @classmethod
@@ -63,17 +63,17 @@ class User(BaseModel):
 
     # —— Coerce None → default strings
     @field_validator("user_id", "login", "first_name", "last_name", "email", mode="before")
-    def _fill_strs(cls, v):
+    def _fill_strs(cls, v: Any) -> str:
         return parse_str_or_default(v)
 
     # —— Coerce None → default bool
     @field_validator("user_active_in_study", mode="before")
-    def _parse_active_flag(cls, v):
+    def _parse_active_flag(cls, v: Any) -> bool:
         return parse_bool(v)
 
     # —— Coerce None → empty list for roles
     @field_validator("roles", mode="before")
-    def _fill_roles(cls, v):
+    def _fill_roles(cls, v: Any) -> List[Role]:
         return parse_list_or_default(v)
 
     @classmethod

--- a/imednet/models/variables.py
+++ b/imednet/models/variables.py
@@ -38,19 +38,19 @@ class Variable(BaseModel):
         "label",
         mode="before",
     )
-    def _fill_strs(cls, v):
+    def _fill_strs(cls, v: Any) -> str:
         return parse_str_or_default(v)
 
     @field_validator("variable_id", "sequence", "revision", "form_id", mode="before")
-    def _fill_ints(cls, v):
+    def _fill_ints(cls, v: Any) -> int:
         return parse_int_or_default(v)
 
     @field_validator("date_created", "date_modified", mode="before")
-    def _parse_datetimes(cls, v):
+    def _parse_datetimes(cls, v: Any) -> datetime:
         return parse_datetime(v)
 
     @field_validator("disabled", "deleted", "blinded", mode="before")
-    def parse_bool_field(cls, v):
+    def parse_bool_field(cls, v: Any) -> bool:
         return parse_bool(v)
 
     @classmethod

--- a/imednet/models/visits.py
+++ b/imednet/models/visits.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from datetime import datetime
-from typing import Any, Dict, Optional
+from typing import Any, Dict, Optional, cast
 
 from pydantic import BaseModel, ConfigDict, Field, field_validator
 
@@ -35,25 +35,25 @@ class Visit(BaseModel):
         "visit_date_question",
         mode="before",
     )
-    def _fill_strs(cls, v):
+    def _fill_strs(cls, v: Any) -> str:
         return parse_str_or_default(v)
 
     @field_validator("visit_id", "interval_id", "subject_id", mode="before")
-    def _fill_ints(cls, v):
+    def _fill_ints(cls, v: Any) -> int:
         return parse_int_or_default(v)
 
     @field_validator("start_date", "end_date", "due_date", "visit_date", mode="before")
-    def _clean_empty_dates(cls, v):
+    def _clean_empty_dates(cls, v: Any) -> Optional[datetime]:
         if not v:
             return None
-        return v
+        return cast(datetime, v)
 
     @field_validator("deleted", mode="before")
-    def parse_bool_field(cls, v):
+    def parse_bool_field(cls, v: Any) -> bool:
         return parse_bool(v)
 
     @field_validator("date_created", "date_modified", mode="before")
-    def _parse_datetimes(cls, v):
+    def _parse_datetimes(cls, v: Any) -> datetime:
         return parse_datetime(v)
 
     @classmethod

--- a/imednet/workflows/record_mapper.py
+++ b/imednet/workflows/record_mapper.py
@@ -1,5 +1,5 @@
 import logging
-from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, Type, Union  # Add TYPE_CHECKING
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, Type, Union
 
 import pandas as pd
 from pydantic import BaseModel, Field, ValidationError, create_model

--- a/imednet/workflows/study_structure.py
+++ b/imednet/workflows/study_structure.py
@@ -65,7 +65,7 @@ def get_study_structure(sdk: "ImednetSDK", study_key: str) -> StudyStructure:
             )
             interval_structures.append(interval_struct)
 
-        return StudyStructure(study_key=study_key, intervals=interval_structures)  # type: ignore[call-arg]
+        return StudyStructure(study_key=study_key, intervals=interval_structures)
 
     except Exception as e:
         # Catch potential API errors or processing errors

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -81,3 +81,15 @@ strict = true
 
 [tool.mypy-imednet.core]
 strict = true
+
+[tool.mypy-imednet.models]
+strict = true
+
+[tool.mypy-imednet.endpoints]
+strict = true
+
+[tool.mypy-imednet.workflows]
+strict = true
+
+[tool.mypy-imednet.cli]
+strict = true


### PR DESCRIPTION
## Summary
- add annotations across Pydantic models
- export endpoint classes with `__all__`
- type CLI functions and parsing helpers
- enable strict mypy in more packages

## Testing
- `pre-commit run --files $(cat /tmp/changed_files.txt)`
- `pytest -q --cov=imednet`

------
https://chatgpt.com/codex/tasks/task_e_6847a10be5c8832c9b5e2aaeb7ec778f