### PR TITLE
Add MednetClient for v2 API

### DIFF
--- a/imednet/mednet_client.py
+++ b/imednet/mednet_client.py
@@ -1,0 +1,88 @@
+"""Lightweight client for the iMednet v2 API."""
+
+from __future__ import annotations
+
+import json
+import time
+from pathlib import Path
+from typing import Any, Dict, List, Optional, cast
+
+import requests
+from pydantic import BaseModel
+
+
+class MednetApiError(Exception):
+    """Raised when the iMednet API returns an error."""
+
+
+class Form(BaseModel):
+    """Simplified form representation."""
+
+    id: int
+    name: str
+
+
+class Variable(BaseModel):
+    """Simplified variable representation."""
+
+    id: int
+    name: str
+
+
+class MednetClient:
+    """Simple wrapper around the iMednet REST API."""
+
+    BASE_URL = "https://api.imednet.com/v2"
+
+    def __init__(self, study_key: str, headers: Dict[str, str]) -> None:
+        self.study_key = study_key
+        self.headers = headers
+
+    def _request(self, path: str, params: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
+        """Internal GET request with basic retry and back-off."""
+        url = f"{self.BASE_URL}{path}"
+        backoff = 1
+        for attempt in range(3):
+            try:
+                resp = requests.get(url, headers=self.headers, params=params, timeout=10)
+            except requests.RequestException as exc:
+                if attempt == 2:
+                    raise MednetApiError(str(exc)) from exc
+            else:
+                if resp.status_code == 200:
+                    return cast(Dict[str, Any], resp.json())
+                if 500 <= resp.status_code < 600 and attempt < 2:
+                    pass
+                else:
+                    raise MednetApiError(f"HTTP {resp.status_code}: {resp.text}")
+            time.sleep(backoff)
+            backoff *= 2
+        raise MednetApiError("Max retries exceeded")
+
+    def get_forms(self, test_mode: bool = False) -> List[Form]:
+        """Return list of forms for the configured study."""
+        if test_mode:
+            fixture = (
+                Path(__file__).resolve().parents[1] / "tests" / "fixtures" / "mednet_sample.json"
+            )
+            with fixture.open("r", encoding="utf-8") as fh:
+                data = json.load(fh)
+        else:
+            data = self._request(f"/studies/{self.study_key}/forms")
+        forms = data.get("forms", data.get("data", []))
+        return [Form.model_validate(f) for f in forms]
+
+    def get_variables(self, form_id: int) -> List[Variable]:
+        """Return variables for a form, handling pagination."""
+        path = f"/forms/{form_id}/variables"
+        params: Optional[Dict[str, Any]] = None
+        results: List[Variable] = []
+        while True:
+            data = self._request(path, params=params)
+            vars_data = data.get("variables", data.get("data", []))
+            results.extend(Variable.model_validate(v) for v in vars_data)
+            token = data.get("nextPageToken")
+            if not token:
+                break
+            params = {"pageToken": token}
+        return results

--- a/tests/fixtures/mednet_sample.json
+++ b/tests/fixtures/mednet_sample.json
@@ -1,0 +1,20 @@
+{
+  "forms": [
+    {
+      "id": 1,
+      "name": "Demographics",
+      "variables": [
+        {"id": 101, "name": "Age"},
+        {"id": 102, "name": "Sex"}
+      ]
+    },
+    {
+      "id": 2,
+      "name": "Vitals",
+      "variables": [
+        {"id": 201, "name": "Height"},
+        {"id": 202, "name": "Weight"}
+      ]
+    }
+  ]
+}

--- a/tests/unit/test_mednet_client.py
+++ b/tests/unit/test_mednet_client.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+import pytest
+import responses
+from imednet.mednet_client import Form, MednetApiError, MednetClient, Variable
+
+
+@responses.activate
+def test_get_forms_success() -> None:
+    client = MednetClient("S1", headers={"Authorization": "t"})
+    responses.add(
+        responses.GET,
+        "https://api.imednet.com/v2/studies/S1/forms",
+        json={"forms": [{"id": 1, "name": "F1"}]},
+        status=200,
+    )
+    forms = client.get_forms()
+    assert forms == [Form(id=1, name="F1")]
+
+
+@responses.activate
+def test_get_forms_401_error() -> None:
+    client = MednetClient("S1", headers={})
+    responses.add(
+        responses.GET,
+        "https://api.imednet.com/v2/studies/S1/forms",
+        json={"detail": "bad"},
+        status=401,
+    )
+    with pytest.raises(MednetApiError):
+        client.get_forms()
+
+
+def test_get_forms_stub() -> None:
+    client = MednetClient("S1", headers={})
+    forms = client.get_forms(test_mode=True)
+    assert len(forms) == 2
+    assert forms[0].id == 1
+
+
+@responses.activate
+def test_request_retries(monkeypatch: pytest.MonkeyPatch) -> None:
+    sleep_times: list[float] = []
+    monkeypatch.setattr("time.sleep", lambda s: sleep_times.append(s))
+    client = MednetClient("S1", headers={})
+    responses.add(
+        responses.GET,
+        "https://api.imednet.com/v2/studies/S1/forms",
+        status=500,
+    )
+    responses.add(
+        responses.GET,
+        "https://api.imednet.com/v2/studies/S1/forms",
+        json={"forms": []},
+        status=200,
+    )
+    forms = client.get_forms()
+    assert forms == []
+    assert sleep_times  # ensured backoff triggered
+
+
+@responses.activate
+def test_get_variables_pagination() -> None:
+    client = MednetClient("S1", headers={})
+    responses.add(
+        responses.GET,
+        "https://api.imednet.com/v2/forms/1/variables",
+        json={"variables": [{"id": 1, "name": "v1"}], "nextPageToken": "abc"},
+        status=200,
+    )
+    responses.add(
+        responses.GET,
+        "https://api.imednet.com/v2/forms/1/variables",
+        match=[responses.matchers.query_param_matcher({"pageToken": "abc"})],
+        json={"variables": [{"id": 2, "name": "v2"}]},
+        status=200,
+    )
+    variables = client.get_variables(1)
+    assert variables == [Variable(id=1, name="v1"), Variable(id=2, name="v2")]


### PR DESCRIPTION
## Summary
- implement `MednetClient` with simple request helper
- support fetching forms and variables
- provide offline fixture for demo usage
- test behaviour including retries and pagination

## Testing
- `pre-commit run --files imednet/mednet_client.py tests/unit/test_mednet_client.py tests/fixtures/mednet_sample.json`
- `mypy --strict imednet/mednet_client.py`
- `pytest -q --cov=imednet`

------
https://chatgpt.com/codex/tasks/task_e_684837698b0c832cb510cbeb3392aa12