### PR TITLE
Add VaultClient for Vault metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Desktop UI now supports saving and loading command parameter templates.
 - Added credential profile management with encryption for switching between
   multiple saved profiles.
+- Added `VaultClient` for retrieving Vault object and field metadata.
 
 ### Fixed
 

--- a/imednet/vault_client.py
+++ b/imednet/vault_client.py
@@ -1,0 +1,101 @@
+"""Lightweight client for Veeva Vault metadata."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List
+
+import requests
+from pydantic import BaseModel, ConfigDict, Field, field_validator
+
+from .models.validators import parse_bool, parse_list_or_default, parse_str_or_default
+
+
+class VaultAuthError(Exception):
+    """Raised when the Vault API returns 401."""
+
+
+API_VER = "v24.3"
+
+
+class VaultObject(BaseModel):
+    """Minimal Vault object description."""
+
+    name: str = Field("", alias="name__v")
+    label: str = Field("", alias="label__v")
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    @field_validator("name", "label", mode="before")
+    def _fill_strs(cls, v: Any) -> str:
+        return parse_str_or_default(v)
+
+
+class VaultField(BaseModel):
+    """Metadata about a single Vault field."""
+
+    name: str = Field("", alias="name__v")
+    label: str = Field("", alias="label__v")
+    data_type: str = Field("", alias="data_type__v")
+    required: bool = Field(False, alias="required__v")
+    default_value: str | None = Field(None, alias="default_value__v")
+    picklist_values: List[str] = Field(default_factory=list, alias="picklist_values__v")
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    @field_validator("name", "label", "data_type", "default_value", mode="before")
+    def _fill_strs(cls, v: Any) -> str | None:
+        return parse_str_or_default(v) if v is not None else None
+
+    @field_validator("required", mode="before")
+    def _parse_bool(cls, v: Any) -> bool:
+        return parse_bool(v)
+
+    @field_validator("picklist_values", mode="before")
+    def _parse_list(cls, v: Any) -> List[str]:
+        return parse_list_or_default(v)
+
+    @property
+    def is_reference(self) -> bool:
+        """Return True if this field is a lookup/reference."""
+
+        return self.data_type == "Lookup"
+
+
+class VaultClient:
+    """Simple HTTP client for Vault metadata APIs."""
+
+    def __init__(self, session_id: str, domain: str) -> None:
+        self.session_id = session_id
+        self.domain = domain.rstrip("/")
+
+    def _headers(self) -> Dict[str, str]:
+        return {"Authorization": self.session_id}
+
+    def _url(self, path: str) -> str:
+        return f"{self.domain}/api/{API_VER}{path}"
+
+    def list_objects(self) -> List[VaultObject]:
+        url = self._url("/metadata/vobjects")
+        resp = requests.get(url, headers=self._headers())
+        if resp.status_code == 401:
+            raise VaultAuthError("Unauthorized")
+        resp.raise_for_status()
+        data = resp.json().get("data", [])
+        return [VaultObject.model_validate(obj) for obj in data]
+
+    def get_object_fields(self, object_api: str) -> List[VaultField]:
+        url = self._url(f"/metadata/vobjects/{object_api}")
+        resp = requests.get(url, headers=self._headers())
+        if resp.status_code == 401:
+            raise VaultAuthError("Unauthorized")
+        resp.raise_for_status()
+        data = resp.json().get("data", [])
+        return [VaultField.model_validate(f) for f in data]
+
+
+__all__ = [
+    "VaultClient",
+    "VaultObject",
+    "VaultField",
+    "VaultAuthError",
+]

--- a/tests/fixtures/vault_subject_fields.json
+++ b/tests/fixtures/vault_subject_fields.json
@@ -1,0 +1,28 @@
+{
+  "data": [
+    {
+      "name__v": "subject_id__v",
+      "label__v": "Subject ID",
+      "data_type__v": "Text",
+      "required__v": true,
+      "default_value__v": null,
+      "picklist_values__v": []
+    },
+    {
+      "name__v": "site__v",
+      "label__v": "Site",
+      "data_type__v": "Lookup",
+      "required__v": true,
+      "default_value__v": null,
+      "picklist_values__v": []
+    },
+    {
+      "name__v": "status__v",
+      "label__v": "Status",
+      "data_type__v": "Picklist",
+      "required__v": false,
+      "default_value__v": "Enrolled",
+      "picklist_values__v": ["Screening", "Enrolled", "Completed"]
+    }
+  ]
+}

--- a/tests/unit/test_vault_client.py
+++ b/tests/unit/test_vault_client.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+import responses
+from imednet.vault_client import (
+    API_VER,
+    VaultAuthError,
+    VaultClient,
+    VaultField,
+)
+
+
+def load_fixture(name: str) -> dict:
+    path = Path(__file__).resolve().parent.parent / "fixtures" / name
+    return json.loads(path.read_text())
+
+
+def test_list_objects_success() -> None:
+    client = VaultClient("tok", "https://vault.example.com")
+    url = f"https://vault.example.com/api/{API_VER}/metadata/vobjects"
+    with responses.RequestsMock() as rsps:
+        rsps.add(
+            responses.GET,
+            url,
+            json={"data": [{"name__v": "subject__c", "label__v": "Subject"}]},
+            status=200,
+        )
+        objs = client.list_objects()
+
+    assert [o.name for o in objs] == ["subject__c"]
+    assert [o.label for o in objs] == ["Subject"]
+
+
+def test_get_object_fields_success() -> None:
+    fixture = load_fixture("vault_subject_fields.json")
+    client = VaultClient("tok", "https://vault.example.com")
+    url = f"https://vault.example.com/api/{API_VER}/metadata/vobjects/subject__c"
+    with responses.RequestsMock() as rsps:
+        rsps.add(responses.GET, url, json=fixture, status=200)
+        fields = client.get_object_fields("subject__c")
+
+    assert isinstance(fields[0], VaultField)
+    assert fields[0].required is True
+    assert fields[-1].picklist_values == ["Screening", "Enrolled", "Completed"]
+
+
+def test_auth_error() -> None:
+    client = VaultClient("tok", "https://vault.example.com")
+    url = f"https://vault.example.com/api/{API_VER}/metadata/vobjects"
+    with responses.RequestsMock() as rsps:
+        rsps.add(responses.GET, url, status=401)
+        with pytest.raises(VaultAuthError):
+            client.list_objects()


### PR DESCRIPTION
## Summary
- implement `VaultClient` for Veeva Vault metadata APIs
- add example fixture for subject fields
- cover `VaultClient` with unit tests
- document VaultClient in changelog

## Testing
- `poetry run pre-commit run --files imednet/vault_client.py tests/unit/test_vault_client.py tests/fixtures/vault_subject_fields.json CHANGELOG.md`
- `poetry run pytest -q --cov=imednet`

------
https://chatgpt.com/codex/tasks/task_e_6848381acb28832cbc39420c32a310ce