### PR TITLE
Add Sort model

### DIFF
--- a/src/imednet_py/models.py
+++ b/src/imednet_py/models.py
@@ -59,3 +59,13 @@ class SitesEnvelope(Envelope[List[Site]]):
 
 class RecordsEnvelope(Envelope[List[Record]]):
     pass
+
+
+class Sort(BaseModel):
+    """Sort order item used in pagination metadata."""
+
+    # ``property`` is a reserved keyword in Python, use ``property_`` internally
+    property_: str = Field(alias="property")
+    direction: str
+
+    model_config = ConfigDict(populate_by_name=True)

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,5 +1,5 @@
 from imednet_py.base import IMNModel
-from imednet_py.models import Meta
+from imednet_py.models import Meta, Sort
 from pydantic import Field
 
 
@@ -29,3 +29,12 @@ def test_meta_model() -> None:
     assert meta.path == "/studies"
     assert meta.timestamp == "2025-06-11T00:00:00Z"
     assert meta.error is None
+
+
+def test_sort_round_trip() -> None:
+    sort = Sort(property_="studyKey", direction="ASC")
+    dumped = sort.model_dump(by_alias=True)
+    assert dumped == {"property": "studyKey", "direction": "ASC"}
+    reloaded = Sort.model_validate(dumped)
+    assert reloaded.property_ == "studyKey"
+    assert reloaded.direction == "ASC"


### PR DESCRIPTION
## Summary
- add Sort model representing pagination sorting details
- test round-trip alias handling

## Testing
- `pip install -e .[tests]`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6849027ba6e0832c8b824c44a141f302