### PR TITLE
Implement Site model alias tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Added PyPI, code style (Black), linter (Ruff), and typing (Mypy) badges to `README.md`.
 - Added `pandas` to development dependencies for workflow features.
+- Implemented `Site` model with alias support for API responses.
 - Created `TEST_PLAN.md` outlining steps to achieve 90% test coverage.
 - Exposed all workflow helpers through new CLI subcommands.
 - Added a Tkinter-based desktop UI (`imednet-ui`) for running workflows with

--- a/tests/unit/test_site_model.py
+++ b/tests/unit/test_site_model.py
@@ -1,0 +1,39 @@
+import datetime
+
+from imednet.models.sites import Site
+
+
+def test_site_model_validate_aliases() -> None:
+    data = {
+        "studyKey": "S1",
+        "siteId": 1,
+        "siteName": "Site A",
+        "siteEnrollmentStatus": "ACTIVE",
+        "dateCreated": "2024-01-01T12:00:00Z",
+        "dateModified": "2024-01-02T12:00:00Z",
+    }
+    site = Site.model_validate(data)
+    assert site.study_key == "S1"
+    assert site.site_id == 1
+    assert site.site_name == "Site A"
+    assert site.site_enrollment_status == "ACTIVE"
+    assert site.date_created == datetime.datetime(
+        2024, 1, 1, 12, 0, 0, tzinfo=datetime.timezone.utc
+    )
+    assert site.date_modified == datetime.datetime(
+        2024, 1, 2, 12, 0, 0, tzinfo=datetime.timezone.utc
+    )
+
+
+def test_site_model_validate_field_names() -> None:
+    data = {
+        "study_key": "S1",
+        "site_id": 2,
+        "site_name": "Site B",
+        "site_enrollment_status": "OPEN",
+    }
+    site = Site.model_validate(data)
+    assert site.site_id == 2
+    assert site.study_key == "S1"
+    assert site.site_name == "Site B"
+    assert site.site_enrollment_status == "OPEN"


### PR DESCRIPTION
## Summary
- test Site model aliases match Study model behavior
- document Site model in changelog

## Testing
- `poetry run pre-commit run --files CHANGELOG.md tests/unit/test_site_model.py`
- `poetry run pytest -q --cov=imednet`

------
https://chatgpt.com/codex/tasks/task_e_6849033d9d68832c887006bdc8235486