### PR TITLE
Implement Record model and envelope parsing

### DIFF
--- a/imednet/models/__init__.py
+++ b/imednet/models/__init__.py
@@ -3,6 +3,7 @@
 This package contains all data models used by the SDK to represent iMedNet resources.
 """
 
+from imednet.models.base import Envelope
 from imednet.models.codings import Coding
 from imednet.models.forms import Form
 from imednet.models.intervals import FormSummary, Interval
@@ -69,4 +70,5 @@ __all__: list[str] = [
     "parse_str_or_default",
     "parse_list_or_default",
     "parse_dict_or_default",
+    "Envelope",
 ]

--- a/imednet/models/base.py
+++ b/imednet/models/base.py
@@ -89,11 +89,24 @@ class Metadata(BaseModel):
 T = TypeVar("T")
 
 
-class ApiResponse(BaseModel, Generic[T]):
-    """Generic API response model."""
+class Envelope(BaseModel, Generic[T]):
+    """Generic API response wrapper used by the iMedNet API."""
 
     metadata: Metadata
     pagination: Optional[Pagination] = None
     data: T
 
     model_config = ConfigDict(populate_by_name=True)
+
+
+# Backwards compatibility alias
+ApiResponse = Envelope
+
+__all__ = [
+    "SortField",
+    "Pagination",
+    "Error",
+    "Metadata",
+    "Envelope",
+    "ApiResponse",
+]

--- a/imednet/models/records.py
+++ b/imednet/models/records.py
@@ -1,3 +1,5 @@
+"""Data models for record-related API endpoints."""
+
 from __future__ import annotations
 
 from datetime import datetime
@@ -122,7 +124,12 @@ class RecordJobResponse(BaseModel):
 
 
 class RecordData(RootModel[Dict[str, Any]]):
-    pass
+    """Flexible record data placeholder.
+
+    The schema of ``recordData`` varies by form. Study-specific
+    validation will be added in a future milestone using a
+    schema inspector.
+    """
 
 
 class BaseRecordRequest(BaseModel):

--- a/tests/unit/test_record_model.py
+++ b/tests/unit/test_record_model.py
@@ -1,0 +1,55 @@
+from imednet.models.base import Envelope
+from imednet.models.records import Record
+
+
+def test_record_envelope_roundtrip() -> None:
+    record_payload = {
+        "studyKey": "STU",
+        "intervalId": 1,
+        "formId": 2,
+        "formKey": "DEMO",
+        "siteId": 10,
+        "recordId": 100,
+        "recordOid": "OID123",
+        "recordType": "scheduled",
+        "recordStatus": "completed",
+        "deleted": False,
+        "dateCreated": "2025-06-01T10:00:00Z",
+        "dateModified": "2025-06-01T12:00:00Z",
+        "subjectId": 200,
+        "subjectOid": "SUBJ123",
+        "subjectKey": "SUBJKEY",
+        "visitId": 1,
+        "parentRecordId": 0,
+        "keywords": [
+            {
+                "keywordName": "Test",
+                "keywordKey": "TEST",
+                "keywordId": 1,
+                "dateAdded": "2025-06-01T09:00:00Z",
+            }
+        ],
+        "recordData": {"AGE": 25, "SEX": "M"},
+    }
+
+    payload = {
+        "metadata": {
+            "status": "ok",
+            "method": "GET",
+            "path": "/records",
+            "timestamp": "2025-06-01T12:00:00Z",
+            "error": {"code": "", "message": "", "details": {}},
+        },
+        "pagination": {
+            "currentPage": 0,
+            "size": 1,
+            "totalPages": 1,
+            "totalElements": 1,
+            "sort": [],
+        },
+        "data": [record_payload],
+    }
+
+    env = Envelope[list[Record]].model_validate(payload)
+    rec = env.data[0]
+    assert rec.model_dump(by_alias=True, exclude_none=True, mode="json") == record_payload


### PR DESCRIPTION
## Summary
- define `Envelope` generic response wrapper
- expose `Envelope` via `models.__init__`
- document flexible `recordData` field
- add tests for parsing `Envelope[Record]`

## Testing
- `poetry run pre-commit run --files imednet/models/base.py imednet/models/__init__.py imednet/models/records.py tests/unit/test_record_model.py`
- `poetry run pytest -q --cov=imednet`

------
https://chatgpt.com/codex/tasks/task_e_6849034fc7b4832cb557f8a12cfd4c4d