### PR TITLE
Add parsing helpers for studies, sites and records

### DIFF
--- a/docs/imednet.utils.rst
+++ b/docs/imednet.utils.rst
@@ -20,6 +20,14 @@ imednet.utils.filters module
    :undoc-members:
    :show-inheritance:
 
+imednet.utils.parsing module
+----------------------------
+
+.. automodule:: imednet.utils.parsing
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
 imednet.utils.typing module
 ---------------------------
 

--- a/imednet/models/base.py
+++ b/imednet/models/base.py
@@ -97,3 +97,7 @@ class ApiResponse(BaseModel, Generic[T]):
     data: T
 
     model_config = ConfigDict(populate_by_name=True)
+
+
+class Envelope(ApiResponse[List[T]], Generic[T]):
+    """Standard list envelope returned by many iMedNet endpoints."""

--- a/imednet/models/records.py
+++ b/imednet/models/records.py
@@ -38,6 +38,11 @@ class Keyword(BaseModel):
     def from_json(cls, data: Dict[str, Any]) -> Keyword:
         return cls.model_validate(data)
 
+    @classmethod
+    def from_api(cls, item: Dict[str, Any]) -> "Keyword":
+        """Alias of ``from_json`` for API payloads."""
+        return cls.model_validate(item)
+
 
 class Record(BaseModel):
     study_key: str = Field("", alias="studyKey")
@@ -104,6 +109,11 @@ class Record(BaseModel):
     def from_json(cls, data: Dict[str, Any]) -> Record:
         return cls.model_validate(data)
 
+    @classmethod
+    def from_api(cls, item: Dict[str, Any]) -> "Record":
+        """Alias of ``from_json`` for API payloads."""
+        return cls.model_validate(item)
+
 
 class RecordJobResponse(BaseModel):
     job_id: str = Field("", alias="jobId")
@@ -119,6 +129,11 @@ class RecordJobResponse(BaseModel):
     @classmethod
     def from_json(cls, data: Dict[str, Any]) -> RecordJobResponse:
         return cls.model_validate(data)
+
+    @classmethod
+    def from_api(cls, item: Dict[str, Any]) -> "RecordJobResponse":
+        """Alias of ``from_json`` for API payloads."""
+        return cls.model_validate(item)
 
 
 class RecordData(RootModel[Dict[str, Any]]):

--- a/imednet/models/sites.py
+++ b/imednet/models/sites.py
@@ -37,3 +37,8 @@ class Site(BaseModel):
         Create a Site instance from JSON-like dict.
         """
         return cls.model_validate(data)
+
+    @classmethod
+    def from_api(cls, item: Dict[str, Any]) -> "Site":
+        """Alias of ``from_json`` for API payloads."""
+        return cls.model_validate(item)

--- a/imednet/models/studies.py
+++ b/imednet/models/studies.py
@@ -33,3 +33,8 @@ class Study(BaseModel):
     @field_validator("date_created", "date_modified", mode="before")
     def _parse_dates(cls, v: Any) -> datetime:
         return parse_datetime(v)
+
+    @classmethod
+    def from_api(cls, item: dict[str, Any]) -> "Study":
+        """Create a Study from a raw API item."""
+        return cls.model_validate(item)

--- a/imednet/utils/parsing.py
+++ b/imednet/utils/parsing.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+from typing import Any, List
+
+from ..models.base import Envelope
+from ..models.records import Record
+from ..models.sites import Site
+from ..models.studies import Study
+
+
+def parse_studies(json_obj: dict[str, Any]) -> List[Study]:
+    """Parse a studies API response."""
+    return Envelope[Study].model_validate(json_obj).data
+
+
+def parse_sites(json_obj: dict[str, Any]) -> List[Site]:
+    """Parse a sites API response."""
+    return Envelope[Site].model_validate(json_obj).data
+
+
+def parse_records(json_obj: dict[str, Any]) -> List[Record]:
+    """Parse a records API response."""
+    return Envelope[Record].model_validate(json_obj).data

--- a/tests/fixtures/sample_records.json
+++ b/tests/fixtures/sample_records.json
@@ -1,0 +1,27 @@
+{
+  "metadata": {
+    "status": "OK",
+    "method": "GET",
+    "path": "/api/v1/edc/studies/S1/records",
+    "timestamp": "2025-05-01T00:00:00Z"
+  },
+  "data": [
+    {
+      "studyKey": "S1",
+      "recordId": 100,
+      "formId": 5,
+      "formKey": "F5",
+      "intervalId": 1,
+      "recordOid": "OID1",
+      "recordType": "Scheduled",
+      "recordStatus": "Complete",
+      "deleted": false,
+      "dateCreated": "2025-01-01T00:00:00Z",
+      "dateModified": "2025-01-01T00:00:00Z",
+      "subjectId": 11,
+      "subjectKey": "SUB1",
+      "visitId": 101,
+      "recordData": {"v1": "a"}
+    }
+  ]
+}

--- a/tests/fixtures/sample_sites.json
+++ b/tests/fixtures/sample_sites.json
@@ -1,0 +1,18 @@
+{
+  "metadata": {
+    "status": "OK",
+    "method": "GET",
+    "path": "/api/v1/edc/studies/S1/sites",
+    "timestamp": "2025-05-01T00:00:00Z"
+  },
+  "data": [
+    {
+      "studyKey": "S1",
+      "siteId": 1,
+      "siteName": "Site One",
+      "siteEnrollmentStatus": "Active",
+      "dateCreated": "2025-01-01T00:00:00Z",
+      "dateModified": "2025-01-01T00:00:00Z"
+    }
+  ]
+}

--- a/tests/fixtures/sample_studies.json
+++ b/tests/fixtures/sample_studies.json
@@ -1,0 +1,20 @@
+{
+  "metadata": {
+    "status": "OK",
+    "method": "GET",
+    "path": "/api/v1/edc/studies",
+    "timestamp": "2025-05-01T00:00:00Z"
+  },
+  "data": [
+    {
+      "studyKey": "S1",
+      "studyId": 1,
+      "studyName": "Study One",
+      "studyDescription": "Desc",
+      "studyType": "EDC",
+      "dateCreated": "2025-01-01T00:00:00Z",
+      "dateModified": "2025-01-01T00:00:00Z",
+      "sponsorKey": "SP1"
+    }
+  ]
+}

--- a/tests/unit/test_parsing_helpers.py
+++ b/tests/unit/test_parsing_helpers.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from imednet.models.records import Record
+from imednet.models.sites import Site
+from imednet.models.studies import Study
+from imednet.utils.parsing import parse_records, parse_sites, parse_studies
+
+FIXTURES = Path(__file__).resolve().parents[1] / "fixtures"
+
+
+def load(name: str) -> dict:
+    with open(FIXTURES / name, "r", encoding="utf-8") as fh:
+        return json.load(fh)
+
+
+def test_parse_studies() -> None:
+    data = load("sample_studies.json")
+    studies = parse_studies(data)
+    assert isinstance(studies, list)
+    assert isinstance(studies[0], Study)
+    assert studies[0].study_key == "S1"
+
+
+def test_parse_sites() -> None:
+    data = load("sample_sites.json")
+    sites = parse_sites(data)
+    assert isinstance(sites, list)
+    assert isinstance(sites[0], Site)
+    assert sites[0].site_id == 1
+
+
+def test_parse_records() -> None:
+    data = load("sample_records.json")
+    records = parse_records(data)
+    assert isinstance(records, list)
+    assert isinstance(records[0], Record)
+    assert records[0].record_id == 100
+    assert records[0].record_data == {"v1": "a"}


### PR DESCRIPTION
## Summary
- add `Envelope` generic model
- implement `from_api` class methods for Study, Site and Record models
- add parsing helpers for studies, sites, records
- document new parsing utilities
- test parsing helpers using sample API responses

## Testing
- `poetry run pre-commit run --files imednet/models/base.py imednet/models/studies.py imednet/models/sites.py imednet/models/records.py imednet/utils/parsing.py docs/imednet.utils.rst tests/unit/test_parsing_helpers.py tests/fixtures/sample_records.json tests/fixtures/sample_sites.json tests/fixtures/sample_studies.json`
- `poetry run pytest -q --cov=imednet`
- `poetry run sphinx-build -b html docs docs/_build/html`

------
https://chatgpt.com/codex/tasks/task_e_68490359a72c832c8b3f488cd25a57e4