### PR TITLE
Add core module tests

### DIFF
--- a/tests/unit/test_core_client.py
+++ b/tests/unit/test_core_client.py
@@ -1,0 +1,65 @@
+import httpx
+import pytest
+from imednet.core import exceptions
+from imednet.core.client import Client
+
+
+class DummyResponse:
+    def __init__(self, data, status=200):
+        self._data = data
+        self.status_code = status
+        self.request = httpx.Request("GET", "https://example.com")
+
+    def json(self):
+        return self._data
+
+    @property
+    def text(self):
+        return str(self._data)
+
+    @property
+    def is_error(self):
+        return self.status_code >= 400
+
+
+def test_initialization_sets_defaults() -> None:
+    client = Client(api_key="A", security_key="B")
+    assert client.base_url == Client.DEFAULT_BASE_URL
+    assert client._client.headers["x-api-key"] == "A"
+    assert client._client.headers["x-imn-security-key"] == "B"
+
+
+def test_retry_logic_retries_request_errors(monkeypatch) -> None:
+    client = Client(api_key="A", security_key="B", retries=2)
+    call_count = {"count": 0}
+
+    def side_effect(method: str, url: str, **kwargs):
+        call_count["count"] += 1
+        if call_count["count"] == 1:
+            raise httpx.RequestError("boom", request=httpx.Request(method, url))
+        return DummyResponse({"ok": True})
+
+    monkeypatch.setattr(client._client, "request", side_effect)
+    response = client.get("/path")
+    assert call_count["count"] == 2
+    assert response.json() == {"ok": True}
+
+
+@pytest.mark.parametrize(
+    "status,exc",
+    [
+        (400, exceptions.ValidationError),
+        (401, exceptions.AuthenticationError),
+        (403, exceptions.AuthorizationError),
+        (404, exceptions.NotFoundError),
+        (429, exceptions.RateLimitError),
+        (500, exceptions.ServerError),
+        (418, exceptions.ApiError),
+    ],
+)
+def test_request_error_mapping(monkeypatch, status, exc) -> None:
+    client = Client(api_key="A", security_key="B")
+    resp = DummyResponse({"error": status}, status)
+    monkeypatch.setattr(client._client, "request", lambda *a, **kw: resp)
+    with pytest.raises(exc):
+        client.get("/some")

--- a/tests/unit/test_core_context.py
+++ b/tests/unit/test_core_context.py
@@ -1,0 +1,9 @@
+from imednet.core.context import Context
+
+
+def test_set_and_clear_default_study_key() -> None:
+    ctx = Context()
+    ctx.set_default_study_key("S1")
+    assert ctx.default_study_key == "S1"
+    ctx.clear_default_study_key()
+    assert ctx.default_study_key is None

--- a/tests/unit/test_core_exceptions.py
+++ b/tests/unit/test_core_exceptions.py
@@ -1,0 +1,17 @@
+from imednet.core import exceptions
+
+
+def test_api_error_str_includes_details() -> None:
+    err = exceptions.ApiError({"msg": "bad"}, status_code=400)
+    text = str(err)
+    assert "Status Code: 400" in text
+    assert "msg" in text
+
+
+def test_exception_hierarchy() -> None:
+    assert issubclass(exceptions.AuthenticationError, exceptions.ApiError)
+    assert issubclass(exceptions.AuthorizationError, exceptions.ApiError)
+    assert issubclass(exceptions.NotFoundError, exceptions.ApiError)
+    assert issubclass(exceptions.RateLimitError, exceptions.ApiError)
+    assert issubclass(exceptions.ServerError, exceptions.ApiError)
+    assert issubclass(exceptions.ValidationError, exceptions.ApiError)

--- a/tests/unit/test_core_paginator.py
+++ b/tests/unit/test_core_paginator.py
@@ -1,0 +1,35 @@
+from typing import Any, Dict, List
+
+from imednet.core.paginator import Paginator
+
+
+class DummyClient:
+    def __init__(self, responses: List[Dict[str, Any]]):
+        self.responses = responses
+        self.calls: List[Dict[str, Any]] = []
+
+    def get(self, path: str, params: Dict[str, Any] | None = None):
+        self.calls.append({"path": path, "params": params})
+        data = self.responses.pop(0)
+        return type("Resp", (), {"json": lambda self: data})()
+
+
+def test_single_page_iteration() -> None:
+    client = DummyClient([{"data": [1, 2]}])
+    paginator = Paginator(client, "/p")
+    assert list(paginator) == [1, 2]
+    assert client.calls[0]["params"]["page"] == 0
+
+
+def test_multiple_page_iteration() -> None:
+    client = DummyClient(
+        [
+            {"data": [1], "pagination": {"totalPages": 2}},
+            {"data": [2], "pagination": {"totalPages": 2}},
+        ]
+    )
+    paginator = Paginator(client, "/p", params={"a": 1}, page_size=10)
+    items = list(paginator)
+    assert items == [1, 2]
+    assert client.calls[0]["params"] == {"a": 1, "page": 0, "size": 10}
+    assert client.calls[1]["params"] == {"a": 1, "page": 1, "size": 10}


### PR DESCRIPTION
## Summary
- add client unit tests for retry logic and error mapping
- add tests for Context, Paginator and custom exceptions

## Testing
- `poetry run ruff check --fix .`
- `poetry run black --check .`
- `poetry run mypy imednet`
- `poetry run pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684b155e0b44832c91b99372c840cb91