### PR TITLE
Add pandas utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ See the [Changelog](CHANGELOG.md) for release history.
 - Automatic pagination
 - Data models for requests and responses
 - Workflow utilities for data extraction and mapping
+- Pandas helpers for DataFrame conversion and CSV export
 
 ## Installation
 
@@ -76,6 +77,22 @@ try:
     print(json.dumps(structure.model_dump(by_alias=True), indent=2, ensure_ascii=False, default=str))
 except Exception as e:
     print(f"Error retrieving study structure: {e}")
+```
+
+### Exporting records to CSV
+
+Install the optional pandas dependency and call
+``export_records_csv`` to save all records for a study:
+
+```bash
+pip install imednet-python-sdk[pandas]
+```
+
+```python
+from imednet.utils.pandas import export_records_csv
+
+sdk = ImednetSDK()
+export_records_csv(sdk, study_key, "records.csv")
 ```
 
 ### Using the Command Line Interface (CLI)

--- a/docs/imednet.utils.rst
+++ b/docs/imednet.utils.rst
@@ -20,6 +20,14 @@ imednet.utils.filters module
    :undoc-members:
    :show-inheritance:
 
+imednet.utils.pandas module
+--------------------------
+
+.. automodule:: imednet.utils.pandas
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
 imednet.utils.typing module
 ---------------------------
 

--- a/imednet/utils/__init__.py
+++ b/imednet/utils/__init__.py
@@ -6,10 +6,27 @@ from .dates import format_iso_datetime, parse_iso_datetime
 from .filters import build_filter_string
 from .typing import DataFrame, JsonDict
 
+
+def __getattr__(name: str):
+    if name in {"records_to_dataframe", "export_records_csv"}:
+        from .pandas import export_records_csv, records_to_dataframe
+
+        globals().update(
+            {
+                "records_to_dataframe": records_to_dataframe,
+                "export_records_csv": export_records_csv,
+            }
+        )
+        return globals()[name]
+    raise AttributeError(name)
+
+
 __all__ = [
     "parse_iso_datetime",
     "format_iso_datetime",
     "build_filter_string",
+    "records_to_dataframe",
+    "export_records_csv",
     "JsonDict",
     "DataFrame",
 ]

--- a/imednet/utils/pandas.py
+++ b/imednet/utils/pandas.py
@@ -1,0 +1,44 @@
+"""Pandas helpers for working with iMednet models."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, List
+
+import pandas as pd
+
+from ..models.records import Record
+
+if TYPE_CHECKING:  # pragma: no cover - only for type checking
+    from ..sdk import ImednetSDK
+
+
+def records_to_dataframe(records: List[Record], *, flatten: bool = False) -> pd.DataFrame:
+    """Convert a list of :class:`~imednet.models.records.Record` to a DataFrame.
+
+    Each record is converted using :meth:`pydantic.BaseModel.model_dump` with
+    ``by_alias=False``. If ``flatten`` is ``True`` the ``record_data`` column is
+    expanded using :func:`pandas.json_normalize` so that each variable becomes a
+    column in the resulting DataFrame.
+    """
+
+    rows = [r.model_dump(by_alias=False) for r in records]
+    df = pd.DataFrame(rows)
+    if flatten and not df.empty:
+        record_df = pd.json_normalize(df["record_data"], sep="_")
+        df = pd.concat([df.drop(columns=["record_data"]), record_df], axis=1)
+    return df
+
+
+def export_records_csv(
+    sdk: "ImednetSDK", study_key: str, file_path: str, *, flatten: bool = True
+) -> None:
+    """Fetch all records for ``study_key`` and write them to ``file_path``.
+
+    Parameters are passed to :func:`records_to_dataframe` and the resulting
+    DataFrame is written with :meth:`pandas.DataFrame.to_csv` using
+    ``index=False``.
+    """
+
+    records = sdk.records.list(study_key=study_key)
+    df = records_to_dataframe(records, flatten=flatten)
+    df.to_csv(file_path, index=False)

--- a/tests/unit/test_utils_pandas.py
+++ b/tests/unit/test_utils_pandas.py
@@ -1,0 +1,36 @@
+from unittest.mock import MagicMock
+
+import pandas as pd
+from imednet.models.records import Record
+from imednet.utils.pandas import export_records_csv, records_to_dataframe
+
+
+def _sample_record() -> Record:
+    return Record(
+        record_id=1,
+        subject_key="S1",
+        visit_id=1,
+        form_id=10,
+        record_status="Complete",
+        record_data={"AGE": 30},
+    )
+
+
+def test_records_to_dataframe_flatten() -> None:
+    rec = _sample_record()
+    df = records_to_dataframe([rec], flatten=True)
+    assert "record_data" not in df.columns
+    assert df.loc[0, "AGE"] == 30
+
+
+def test_export_records_csv(tmp_path) -> None:
+    sdk = MagicMock()
+    sdk.records.list.return_value = [_sample_record()]
+    out_path = tmp_path / "records.csv"
+
+    export_records_csv(sdk, "STUDY", str(out_path))
+
+    assert out_path.exists()
+    df = pd.read_csv(out_path)
+    assert df.loc[0, "AGE"] == 30
+    sdk.records.list.assert_called_once_with(study_key="STUDY")


### PR DESCRIPTION
## Summary
- add pandas helper functions for record export
- document usage of pandas utilities
- expose pandas utils lazily in utils
- add unit tests for CSV export and dataframe conversion

## Testing
- `poetry run ruff check --fix .`
- `poetry run black --check .`
- `poetry run mypy imednet`
- `poetry run pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684b1b10509c832cb17174a9279d2240