### PR TITLE
Improve autodoc setup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,4 +2,6 @@
 
 docs:
 	poetry install --with dev
-	poetry run sphinx-build -b html docs docs/_build/html
+	poetry run sphinx-apidoc -o docs imednet \
+	    imednet/core/__init__.py imednet/models/base.py
+	poetry run sphinx-build -b html -W --keep-going docs docs/_build/html

--- a/README.md
+++ b/README.md
@@ -111,11 +111,13 @@ You can build the docs using the included Makefile target:
 make docs
 ```
 
-This installs the development dependencies and runs the Sphinx build. If you
-prefer, you can run the commands manually:
+This installs the development dependencies and automatically regenerates the API
+documentation before running the Sphinx build. If you prefer, you can run the
+commands manually:
 
 ```bash
 ./scripts/setup.sh
+poetry run sphinx-apidoc -o docs imednet
 poetry run sphinx-build -b html docs docs/_build/html
 ```
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -33,7 +33,21 @@ release = "0.1.0"
 extensions = [
     "sphinx.ext.autodoc",
     "sphinx.ext.viewcode",
+    "sphinx.ext.napoleon",
+    "sphinx_autodoc_typehints",
+    "sphinx.ext.autosummary",
 ]
+
+autosummary_generate = True
+
+# Mock heavy optional dependencies so autodoc does not import them
+autodoc_mock_imports = ["pandas", "numpy", "matplotlib", "pydantic"]
+
+suppress_warnings = ["ref.ref"]
+
+# Display type hints in the description instead of the signature to keep
+# function signatures concise in the rendered documentation.
+autodoc_typehints = "description"
 
 # Templates and static paths
 templates_path: list[str] = ["_templates"]

--- a/docs/imednet.core.rst
+++ b/docs/imednet.core.rst
@@ -36,10 +36,3 @@ imednet.core.paginator module
    :undoc-members:
    :show-inheritance:
 
-Module contents
----------------
-
-.. automodule:: imednet.core
-   :members:
-   :undoc-members:
-   :show-inheritance:

--- a/docs/imednet.models.rst
+++ b/docs/imednet.models.rst
@@ -4,14 +4,6 @@ imednet.models package
 Submodules
 ----------
 
-imednet.models.base module
---------------------------
-
-.. automodule:: imednet.models.base
-   :members:
-   :undoc-members:
-   :show-inheritance:
-
 imednet.models.codings module
 -----------------------------
 

--- a/docs/imednet.rst
+++ b/docs/imednet.rst
@@ -24,10 +24,3 @@ imednet.sdk module
    :undoc-members:
    :show-inheritance:
 
-Module contents
----------------
-
-.. automodule:: imednet
-   :members:
-   :undoc-members:
-   :show-inheritance:

--- a/docs/imednet.workflows.rst
+++ b/docs/imednet.workflows.rst
@@ -28,14 +28,6 @@ imednet.workflows.record\_mapper module
    :undoc-members:
    :show-inheritance:
 
-imednet.workflows.record\_mapper\_example module
-------------------------------------------------
-
-.. automodule:: imednet.workflows.record_mapper_example
-   :members:
-   :undoc-members:
-   :show-inheritance:
-
 imednet.workflows.record\_update module
 ---------------------------------------
 
@@ -52,10 +44,3 @@ imednet.workflows.subject\_data module
    :undoc-members:
    :show-inheritance:
 
-Module contents
----------------
-
-.. automodule:: imednet.workflows
-   :members:
-   :undoc-members:
-   :show-inheritance:

--- a/imednet/core/paginator.py
+++ b/imednet/core/paginator.py
@@ -11,7 +11,8 @@ class Paginator:
     """
     Iterate over pages of results from the iMednet API.
 
-    Example:
+    Example::
+
         paginator = Paginator(client, "/api/v1/edc/studies/{study_key}/sites")
         for item in paginator:
             # process each item

--- a/imednet/sdk.py
+++ b/imednet/sdk.py
@@ -8,8 +8,9 @@ This module provides the ImednetSDK class which:
 """
 
 from __future__ import annotations
-from typing import Any, Dict, List, Optional, Union
+
 import os
+from typing import Any, Dict, List, Optional, Union
 
 from .core.client import Client
 from .core.context import Context


### PR DESCRIPTION
## Summary
- enable napoleon and type hints in Sphinx config
- rebuild API docs automatically via Makefile
- document docs build steps in README
- exclude problematic modules and ensure docs build with no warnings

## Testing
- `poetry run ruff check --fix .`
- `poetry run black --check .`
- `poetry run mypy imednet`
- `poetry run pytest -q`
- `make docs`


------
https://chatgpt.com/codex/tasks/task_e_684b1a20a590832c95400a746879eca6