### PR TITLE
Add OpenTelemetry tracing support

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,11 +93,17 @@ imednet sites list STUDY_KEY
 imednet subjects list STUDY_KEY --filter "subject_status=Screened"
 
 # Get help for a specific command
-imednet subjects list --help 
+imednet subjects list --help
 ```
 
 - See the full API reference in the [HTML docs](docs/_build/html/index.html).
 - More examples can be found in the `imednet/examples/` directory.
+
+### Tracing with OpenTelemetry
+
+The SDK can emit OpenTelemetry spans for each HTTP request. Install
+`opentelemetry-instrumentation-requests` to enable automatic tracing or provide your own
+tracer to :class:`imednet.core.client.Client`.
 
 ## Documentation
 


### PR DESCRIPTION
## Summary
- allow passing a tracer into `Client`
- create spans around HTTP requests
- explain optional tracing in README
- test tracer integration

## Testing
- `poetry run ruff check --fix .`
- `poetry run black --check .`
- `poetry run mypy imednet`
- `poetry run pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684b1d64ae68832cadaf5aefb9a06da0