### PR TITLE
Add job polling helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ See the [Changelog](CHANGELOG.md) for release history.
 - Data models for requests and responses
 - Workflow utilities for data extraction and mapping
 - Pandas helpers for DataFrame conversion and CSV export
+- Helper to wait for background job completion
 
 ## Installation
 
@@ -93,6 +94,18 @@ from imednet.utils.pandas import export_records_csv
 
 sdk = ImednetSDK()
 export_records_csv(sdk, study_key, "records.csv")
+```
+
+### Waiting for job completion
+
+Use :func:`imednet.utils.jobs.wait_for_job` to poll a batch job until it
+reaches a terminal state:
+
+```python
+from imednet.utils.jobs import wait_for_job
+
+job = sdk.records.create(study_key, records_data)
+final_status = wait_for_job(sdk, study_key, job.batch_id)
 ```
 
 ### Using the Command Line Interface (CLI)

--- a/docs/imednet.utils.rst
+++ b/docs/imednet.utils.rst
@@ -28,6 +28,14 @@ imednet.utils.pandas module
    :undoc-members:
    :show-inheritance:
 
+imednet.utils.jobs module
+------------------------
+
+.. automodule:: imednet.utils.jobs
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
 imednet.utils.typing module
 ---------------------------
 

--- a/imednet/sdk.py
+++ b/imednet/sdk.py
@@ -8,8 +8,9 @@ This module provides the ImednetSDK class which:
 """
 
 from __future__ import annotations
-from typing import Any, Dict, List, Optional, Union
+
 import os
+from typing import Any, Dict, List, Optional, Union
 
 from .core.client import Client
 from .core.context import Context

--- a/imednet/utils/__init__.py
+++ b/imednet/utils/__init__.py
@@ -4,6 +4,7 @@ Re-exports utility functions for easier access.
 
 from .dates import format_iso_datetime, parse_iso_datetime
 from .filters import build_filter_string
+from .jobs import TERMINAL_JOB_STATES, wait_for_job
 from .typing import DataFrame, JsonDict
 
 
@@ -25,6 +26,8 @@ __all__ = [
     "parse_iso_datetime",
     "format_iso_datetime",
     "build_filter_string",
+    "TERMINAL_JOB_STATES",
+    "wait_for_job",
     "records_to_dataframe",
     "export_records_csv",
     "JsonDict",

--- a/imednet/utils/jobs.py
+++ b/imednet/utils/jobs.py
@@ -1,0 +1,49 @@
+"""Utilities for working with asynchronous jobs."""
+
+from __future__ import annotations
+
+import time
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:  # pragma: no cover - import for type checking only
+    from ..models.jobs import Job
+    from ..sdk import ImednetSDK
+
+
+TERMINAL_JOB_STATES = {"COMPLETED", "FAILED", "CANCELLED"}
+
+
+def wait_for_job(
+    sdk: "ImednetSDK",
+    study_key: str,
+    batch_id: str,
+    *,
+    timeout: int = 300,
+    poll_interval: int = 5,
+) -> Job:
+    """Poll ``sdk.jobs.get`` until the job reaches a terminal state.
+
+    Args:
+        sdk: SDK instance used to fetch job status.
+        study_key: Study identifier.
+        batch_id: Job batch ID.
+        timeout: Maximum time in seconds to wait.
+        poll_interval: Delay between polls in seconds.
+
+    Returns:
+        The final :class:`~imednet.models.jobs.Job` object.
+
+    Raises:
+        TimeoutError: If the job does not reach a terminal state within ``timeout``.
+    """
+
+    start = time.monotonic()
+    while True:
+        job = sdk.jobs.get(study_key, batch_id)
+        if job.state.upper() in TERMINAL_JOB_STATES:
+            return job
+        if time.monotonic() - start >= timeout:
+            raise TimeoutError(
+                f"Timeout ({timeout}s) waiting for job batch '{batch_id}' to complete."
+            )
+        time.sleep(poll_interval)

--- a/imednet/utils/pandas.py
+++ b/imednet/utils/pandas.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, List
+from typing import TYPE_CHECKING, Any, List, cast
 
 import pandas as pd
 
@@ -24,7 +24,7 @@ def records_to_dataframe(records: List[Record], *, flatten: bool = False) -> pd.
     rows = [r.model_dump(by_alias=False) for r in records]
     df = pd.DataFrame(rows)
     if flatten and not df.empty:
-        record_df = pd.json_normalize(df["record_data"], sep="_")
+        record_df = pd.json_normalize(cast(List[dict[str, Any]], df["record_data"]), sep="_")
         df = pd.concat([df.drop(columns=["record_data"]), record_df], axis=1)
     return df
 

--- a/imednet/workflows/record_update.py
+++ b/imednet/workflows/record_update.py
@@ -1,15 +1,12 @@
 """Placeholder for Record Creation/Update workflows."""
 
-import time
 from typing import TYPE_CHECKING, Any, Dict, List, Literal, Union
 
 from ..models import Job
+from ..utils.jobs import wait_for_job
 
 if TYPE_CHECKING:
     from ..sdk import ImednetSDK
-
-# Define terminal states for job polling
-TERMINAL_JOB_STATES = {"COMPLETED", "FAILED", "CANCELLED"}  # Adjust if needed based on API
 
 
 class RecordUpdateWorkflow:
@@ -69,30 +66,13 @@ class RecordUpdateWorkflow:
             # Should not happen if API call was successful, but good practice to check
             raise ValueError("Submission successful but no batch_id received.")
 
-        start_time = time.monotonic()
-        batch_id = initial_job_status.batch_id
-        current_job_status = initial_job_status
-
-        while True:
-            if current_job_status.state.upper() in TERMINAL_JOB_STATES:
-                return current_job_status
-
-            elapsed_time = time.monotonic() - start_time
-            if elapsed_time >= timeout:
-                raise TimeoutError(
-                    f"Timeout ({timeout}s) waiting for job batch '{batch_id}' "
-                    f"to complete. Last state: {current_job_status.state}"
-                )
-
-            # Wait before polling again
-            time.sleep(poll_interval)
-
-            # Poll the job status using the batch_id
-            # Assuming sdk.jobs.get expects study_key and batch_id
-            current_job_status = self._sdk.jobs.get(study_key, batch_id)  # Added study_key
-
-        # This line is technically unreachable due to the loop structure but ensures return type
-        return current_job_status
+        return wait_for_job(
+            self._sdk,
+            study_key,
+            initial_job_status.batch_id,
+            timeout=timeout,
+            poll_interval=poll_interval,
+        )
 
     def register_subject(
         self,

--- a/tests/unit/test_utils_jobs.py
+++ b/tests/unit/test_utils_jobs.py
@@ -1,0 +1,33 @@
+from unittest.mock import MagicMock
+
+import pytest
+from imednet.models.jobs import Job
+from imednet.utils.jobs import wait_for_job
+
+
+def test_wait_for_job_polls_until_terminal(monkeypatch) -> None:
+    sdk = MagicMock()
+    processing = Job(batch_id="1", state="PROCESSING")
+    completed = Job(batch_id="1", state="COMPLETED")
+    sdk.jobs.get.side_effect = [processing, completed]
+
+    monkeypatch.setattr("imednet.utils.jobs.time.sleep", lambda *args: None)
+
+    job = wait_for_job(sdk, "STUDY", "1", timeout=5, poll_interval=0)
+
+    assert job is completed
+    assert sdk.jobs.get.call_count == 2
+    for call in sdk.jobs.get.call_args_list:
+        assert call.args == ("STUDY", "1")
+
+
+def test_wait_for_job_timeout(monkeypatch) -> None:
+    sdk = MagicMock()
+    sdk.jobs.get.return_value = Job(batch_id="1", state="PROCESSING")
+
+    times = iter([0, 1, 2, 3, 4, 5])
+    monkeypatch.setattr("imednet.utils.jobs.time.monotonic", lambda: next(times))
+    monkeypatch.setattr("imednet.utils.jobs.time.sleep", lambda *args: None)
+
+    with pytest.raises(TimeoutError):
+        wait_for_job(sdk, "STUDY", "1", timeout=5, poll_interval=0)

--- a/tests/unit/test_workflows_record_update.py
+++ b/tests/unit/test_workflows_record_update.py
@@ -6,7 +6,7 @@ from imednet.workflows.record_update import RecordUpdateWorkflow
 
 def test_submit_record_batch_no_wait() -> None:
     sdk = MagicMock()
-    job = Job(batch_id="1", state="PROCESSING")
+    job = Job(batch_id="1", state="PROCESSING")  # type: ignore[call-arg]
     sdk.records.create.return_value = job
 
     wf = RecordUpdateWorkflow(sdk)
@@ -18,14 +18,14 @@ def test_submit_record_batch_no_wait() -> None:
 
 def test_submit_record_batch_wait_for_completion(monkeypatch) -> None:
     sdk = MagicMock()
-    initial_job = Job(batch_id="1", state="PROCESSING")
-    completed_job = Job(batch_id="1", state="COMPLETED")
+    initial_job = Job(batch_id="1", state="PROCESSING")  # type: ignore[call-arg]
+    completed_job = Job(batch_id="1", state="COMPLETED")  # type: ignore[call-arg]
     sdk.records.create.return_value = initial_job
     sdk.jobs.get.side_effect = [initial_job, completed_job]
 
     wf = RecordUpdateWorkflow(sdk)
     # patch sleep to avoid delay
-    monkeypatch.setattr("time.sleep", lambda *args: None)
+    monkeypatch.setattr("imednet.utils.jobs.time.sleep", lambda *args: None)
     result = wf.submit_record_batch(
         "STUDY",
         [{"a": 1}],
@@ -36,13 +36,14 @@ def test_submit_record_batch_wait_for_completion(monkeypatch) -> None:
 
     sdk.records.create.assert_called_once_with("STUDY", [{"a": 1}])
     sdk.jobs.get.assert_called_with("STUDY", "1")
+    assert sdk.jobs.get.call_count == 2
     assert result.state == "COMPLETED"
 
 
 def test_update_scheduled_record_builds_payload() -> None:
     sdk = MagicMock()
     wf = RecordUpdateWorkflow(sdk)
-    wf.submit_record_batch = MagicMock(return_value="job")
+    wf.submit_record_batch = MagicMock(return_value="job")  # type: ignore[assignment]
 
     result = wf.update_scheduled_record(
         "STUDY",


### PR DESCRIPTION
## Summary
- add `wait_for_job` utility for polling job status
- re-export helper via `imednet.utils`
- refactor `RecordUpdateWorkflow` to use helper
- document helper in README and Sphinx docs
- test job polling behaviour and update workflow tests

## Testing
- `poetry run ruff check --fix .`
- `poetry run black --check .`
- `poetry run mypy imednet tests/unit/test_workflows_record_update.py`
- `poetry run pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684b1d1ff3f4832c856421cc8b71ed2f