### PR TITLE
Fix mis-indented tracer argument

### DIFF
--- a/imednet/core/client.py
+++ b/imednet/core/client.py
@@ -23,33 +23,6 @@ try:  # opentelemetry is optional
 except Exception:  # pragma: no cover - optional dependency
     trace = None
     Tracer = None
-
-        tracer: Optional[Tracer] = None,
-            tracer: Optional OpenTelemetry tracer.
-        self.tracer = tracer
-        if self.tracer is None and trace is not None:
-            self.tracer = trace.get_tracer(__name__)
-
-            span_cm = (
-                self.tracer.start_as_current_span("http_request") if self.tracer else nullcontext()
-            with span_cm as span:
-                if span is not None:
-                    span.set_attribute("http.method", method)
-                    span.set_attribute("http.url", url)
-                    span.set_attribute("http.target", httpx.URL(url).path)
-                response = retryer(lambda: self._client.request(method, url, **kwargs))
-                latency = time.monotonic() - start
-                logger.info(
-                    "http_request",
-                    extra={
-                        "method": method,
-                        "url": url,
-                        "status_code": response.status_code,
-                        "latency": latency,
-                    },
-                )
-                if span is not None:
-                    span.set_attribute("http.status_code", response.status_code)
 import httpx
 from tenacity import RetryCallState, RetryError, Retrying, stop_after_attempt, wait_exponential
 


### PR DESCRIPTION
## Summary
- fix an indentation issue in `client.py`

## Testing
- `poetry run ruff check --fix .`
- `poetry run black --check .`
- `poetry run mypy imednet`
- `poetry run pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684b26ed44d8832cad12917b907eaf52