### PR TITLE
Add async client support

### DIFF
--- a/imednet/core/__init__.py
+++ b/imednet/core/__init__.py
@@ -2,7 +2,7 @@
 Re-exports core components for easier access.
 """
 
-from .client import Client
+from .client import AsyncClient, Client
 from .context import Context
 from .exceptions import (
     ApiError,
@@ -15,10 +15,11 @@ from .exceptions import (
     ServerError,
     ValidationError,
 )
-from .paginator import Paginator
+from .paginator import AsyncPaginator, Paginator
 
 __all__ = [
     "Client",
+    "AsyncClient",
     "Context",
     "ImednetError",
     "RequestError",
@@ -30,4 +31,5 @@ __all__ = [
     "ServerError",
     "ValidationError",
     "Paginator",
+    "AsyncPaginator",
 ]

--- a/imednet/core/client.py
+++ b/imednet/core/client.py
@@ -24,7 +24,14 @@ except Exception:  # pragma: no cover - optional dependency
     trace = None
     Tracer = None
 import httpx
-from tenacity import RetryCallState, RetryError, Retrying, stop_after_attempt, wait_exponential
+from tenacity import (
+    AsyncRetrying,
+    RetryCallState,
+    RetryError,
+    Retrying,
+    stop_after_attempt,
+    wait_exponential,
+)
 
 from imednet.core.exceptions import (
     ApiError,
@@ -232,3 +239,152 @@ class Client:
             json: JSON body for the request.
         """
         return self._request("POST", path, json=json, **kwargs)
+
+
+class AsyncClient:
+    """Asynchronous variant of :class:`Client` using ``httpx.AsyncClient``."""
+
+    DEFAULT_BASE_URL = Client.DEFAULT_BASE_URL
+
+    def __init__(
+        self,
+        api_key: Optional[str] = None,
+        security_key: Optional[str] = None,
+        base_url: Optional[str] = None,
+        timeout: Union[float, httpx.Timeout] = 30.0,
+        retries: int = 3,
+        backoff_factor: float = 1.0,
+        log_level: Union[int, str] = logging.INFO,
+        tracer: Optional[Tracer] = None,
+    ) -> None:
+        api_key = api_key or os.getenv("IMEDNET_API_KEY")
+        security_key = security_key or os.getenv("IMEDNET_SECURITY_KEY")
+        if not api_key or not security_key:
+            raise ValueError("API key and security key are required")
+
+        self.base_url = base_url or os.getenv("IMEDNET_BASE_URL") or self.DEFAULT_BASE_URL
+        self.timeout = timeout if isinstance(timeout, httpx.Timeout) else httpx.Timeout(timeout)
+        self.retries = retries
+        self.backoff_factor = backoff_factor
+
+        level = logging.getLevelName(log_level.upper()) if isinstance(log_level, str) else log_level
+        configure_json_logging(level)
+        logger.setLevel(level)
+
+        self._client = httpx.AsyncClient(
+            base_url=self.base_url,
+            headers={
+                "Accept": "application/json",
+                "Content-Type": "application/json",
+                "x-api-key": api_key,
+                "x-imn-security-key": security_key,
+            },
+            timeout=self.timeout,
+        )
+
+        if tracer is not None:
+            self._tracer = tracer
+        elif trace is not None:
+            self._tracer = trace.get_tracer(__name__)
+        else:
+            self._tracer = None
+
+    async def __aenter__(self) -> "AsyncClient":
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb) -> None:
+        await self.aclose()
+
+    async def aclose(self) -> None:
+        """Close the underlying async HTTP client."""
+        await self._client.aclose()
+
+    def _should_retry(self, retry_state: RetryCallState) -> bool:
+        if retry_state.outcome is None:
+            return False
+        exc = retry_state.outcome.exception()
+        if isinstance(exc, (httpx.RequestError,)):
+            return True
+        return False
+
+    async def _request(
+        self,
+        method: str,
+        url: str,
+        **kwargs: Any,
+    ) -> httpx.Response:
+        retryer = AsyncRetrying(
+            stop=stop_after_attempt(self.retries),
+            wait=wait_exponential(multiplier=self.backoff_factor),
+            retry=self._should_retry,
+            reraise=True,
+        )
+
+        span_cm = (
+            self._tracer.start_as_current_span(
+                "http_request", attributes={"endpoint": url, "method": method}
+            )
+            if self._tracer
+            else nullcontext()
+        )
+
+        async with span_cm as span:
+            try:
+                start = time.monotonic()
+                async for attempt in retryer:
+                    with attempt:
+                        response = await self._client.request(method, url, **kwargs)
+                latency = time.monotonic() - start
+                logger.info(
+                    "http_request",
+                    extra={
+                        "method": method,
+                        "url": url,
+                        "status_code": response.status_code,
+                        "latency": latency,
+                    },
+                )
+            except RetryError as e:
+                logger.error("Request failed after retries: %s", e)
+                raise RequestError("Network request failed after retries")
+
+            if span is not None:
+                span.set_attribute("status_code", response.status_code)
+
+        if response.is_error:
+            status = response.status_code
+            try:
+                body = response.json()
+            except Exception:
+                body = response.text
+            if status == 400:
+                raise ValidationError(body)
+            if status == 401:
+                raise AuthenticationError(body)
+            if status == 403:
+                raise AuthorizationError(body)
+            if status == 404:
+                raise NotFoundError(body)
+            if status == 429:
+                raise RateLimitError(body)
+            if 500 <= status < 600:
+                raise ServerError(body)
+            raise ApiError(body)
+
+        return response
+
+    async def get(
+        self,
+        path: str,
+        params: Optional[Dict[str, Any]] = None,
+        **kwargs: Any,
+    ) -> httpx.Response:
+        return await self._request("GET", path, params=params, **kwargs)
+
+    async def post(
+        self,
+        path: str,
+        json: Optional[Any] = None,
+        **kwargs: Any,
+    ) -> httpx.Response:
+        return await self._request("POST", path, json=json, **kwargs)

--- a/imednet/endpoints/base.py
+++ b/imednet/endpoints/base.py
@@ -4,7 +4,7 @@ Base endpoint mix-in for all API resource endpoints.
 
 from typing import Any, Dict
 
-from imednet.core.client import Client
+from imednet.core.client import AsyncClient, Client
 from imednet.core.context import Context
 
 
@@ -17,8 +17,14 @@ class BaseEndpoint:
 
     path: str  # to be set in subclasses
 
-    def __init__(self, client: Client, ctx: Context) -> None:
+    def __init__(
+        self,
+        client: Client,
+        ctx: Context,
+        async_client: AsyncClient | None = None,
+    ) -> None:
         self._client = client
+        self._async_client = async_client
         self._ctx = ctx
 
     def _auto_filter(self, filters: Dict[str, Any]) -> Dict[str, Any]:

--- a/imednet/endpoints/variables.py
+++ b/imednet/endpoints/variables.py
@@ -2,7 +2,7 @@
 
 from typing import Any, Dict, List, Optional
 
-from imednet.core.client import Client
+from imednet.core.client import AsyncClient, Client
 from imednet.core.context import Context
 from imednet.core.paginator import Paginator
 from imednet.endpoints.base import BaseEndpoint
@@ -19,8 +19,13 @@ class VariablesEndpoint(BaseEndpoint):
 
     path = "/api/v1/edc/studies"
 
-    def __init__(self, client: Client, ctx: Context) -> None:
-        super().__init__(client, ctx)
+    def __init__(
+        self,
+        client: Client,
+        ctx: Context,
+        async_client: AsyncClient | None = None,
+    ) -> None:
+        super().__init__(client, ctx, async_client)
         self._variables_cache: Dict[str, List[Variable]] = {}
 
     def list(

--- a/tests/unit/endpoints/test_studies_endpoint_async.py
+++ b/tests/unit/endpoints/test_studies_endpoint_async.py
@@ -1,0 +1,23 @@
+import imednet.endpoints.studies as studies
+import pytest
+from imednet.models.studies import Study
+
+
+@pytest.mark.asyncio
+async def test_async_list_builds_path_and_filters(
+    monkeypatch,
+    dummy_client,
+    context,
+    async_paginator_factory,
+    patch_build_filter,
+):
+    ep = studies.StudiesEndpoint(dummy_client, context, async_client=dummy_client)
+    captured = async_paginator_factory(studies, [{"studyKey": "S1"}])
+    filter_capture = patch_build_filter(studies)
+
+    result = await ep.async_list(status="active")
+
+    assert captured["path"] == "/api/v1/edc/studies"
+    assert captured["params"] == {"filter": "FILTERED"}
+    assert filter_capture["filters"] == {"status": "active"}
+    assert isinstance(result[0], Study)

--- a/tests/unit/test_core_async_client.py
+++ b/tests/unit/test_core_async_client.py
@@ -1,0 +1,12 @@
+import httpx
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_async_get_success(async_http_client, respx_mock_async_client, sample_data):
+    respx_mock_async_client.get("/items").mock(return_value=httpx.Response(200, json=sample_data))
+
+    response = await async_http_client.get("/items")
+
+    assert response.status_code == 200
+    assert response.json() == sample_data

--- a/tests/unit/test_sdk_async.py
+++ b/tests/unit/test_sdk_async.py
@@ -1,0 +1,32 @@
+import pytest
+from imednet import sdk as sdk_mod
+from imednet.core.client import AsyncClient
+
+
+def _create_async_sdk() -> sdk_mod.ImednetSDK:
+    return sdk_mod.ImednetSDK(
+        api_key="key",
+        security_key="secret",
+        base_url="https://example.com",
+        enable_async=True,
+    )
+
+
+def test_async_sdk_initializes_async_client() -> None:
+    sdk = _create_async_sdk()
+    assert isinstance(sdk._async_client, AsyncClient)
+
+
+@pytest.mark.asyncio
+async def test_async_context_management(monkeypatch) -> None:
+    called = {"close": False}
+
+    async def fake_aclose(self) -> None:
+        called["close"] = True
+
+    monkeypatch.setattr(AsyncClient, "aclose", fake_aclose)
+
+    async with _create_async_sdk() as sdk:
+        assert isinstance(sdk, sdk_mod.ImednetSDK)
+
+    assert called["close"]


### PR DESCRIPTION
## Summary
- add `AsyncClient` and `AsyncPaginator`
- extend endpoints to support optional async operations
- update SDK to create async client when enabled
- provide async tests for client, endpoint and SDK

## Testing
- `poetry run ruff check --fix .`
- `poetry run black --check .`
- `poetry run mypy imednet`
- `poetry run pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684b2c69f768832c9dc4edb3da70de81