### PR TITLE
Add SchemaValidator for record validation

### DIFF
--- a/imednet/utils/__init__.py
+++ b/imednet/utils/__init__.py
@@ -19,13 +19,14 @@ def __getattr__(name: str):
             }
         )
         return globals()[name]
-    if name in {"SchemaCache", "validate_record_data"}:
-        from .schema import SchemaCache, validate_record_data
+    if name in {"SchemaCache", "validate_record_data", "SchemaValidator"}:
+        from .schema import SchemaCache, SchemaValidator, validate_record_data
 
         globals().update(
             {
                 "SchemaCache": SchemaCache,
                 "validate_record_data": validate_record_data,
+                "SchemaValidator": SchemaValidator,
             }
         )
         return globals()[name]
@@ -43,4 +44,5 @@ __all__ = [
     "DataFrame",
     "SchemaCache",
     "validate_record_data",
+    "SchemaValidator",
 ]


### PR DESCRIPTION
## Summary
- add `SchemaValidator` helper that loads variables and validates records
- wire `RecordUpdateWorkflow` to use `SchemaValidator`
- test early validation when batch data violates schema

## Testing
- `poetry run ruff check --fix .`
- `poetry run black --check .`
- `poetry run mypy imednet`
- `poetry run pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684b2de2c38c832cbd418ed41abfe137