### PR TITLE
Add Airflow DAG examples

### DIFF
--- a/imednet/examples/airflow/imednet_job_sensor_dag.py
+++ b/imednet/examples/airflow/imednet_job_sensor_dag.py
@@ -1,0 +1,34 @@
+from datetime import datetime
+
+from imednet.airflow import ImednetJobSensor
+
+from airflow import DAG
+
+"""Example DAG demonstrating :class:`ImednetJobSensor` to monitor an iMednet job.
+
+This sensor periodically polls iMednet until the specified job reaches a
+terminal state. Configuration is similar to ``ImednetToS3Operator``:
+- Credentials are read from the Airflow connection ``imednet_default`` (or a
+  custom ``imednet_conn_id``) using the login/password or ``extra`` fields.
+  Environment variables ``IMEDNET_API_KEY`` and ``IMEDNET_SECURITY_KEY`` may be
+  used as fallbacks.
+- ``base_url`` can be provided in ``extra`` or via ``IMEDNET_BASE_URL`` when
+  targeting a non‑default environment.
+
+Update ``STUDY_KEY`` and ``BATCH_ID`` with real values before running.
+"""
+
+default_args = {"start_date": datetime(2024, 1, 1)}
+
+with DAG(
+    dag_id="imednet_job_sensor_example",
+    schedule_interval=None,
+    default_args=default_args,
+    catchup=False,
+) as dag:
+    wait_for_job = ImednetJobSensor(
+        task_id="wait_for_job",
+        study_key="STUDY_KEY",
+        batch_id="BATCH_ID",
+        poke_interval=60,
+    )

--- a/imednet/examples/airflow/imednet_to_s3_dag.py
+++ b/imednet/examples/airflow/imednet_to_s3_dag.py
@@ -1,0 +1,39 @@
+from datetime import datetime
+
+from imednet.airflow import ImednetToS3Operator
+
+from airflow import DAG
+
+"""Example DAG using :class:`ImednetToS3Operator` to export data to S3.
+
+Configuration notes:
+- Create an Airflow connection with ``conn_id`` ``imednet_default`` (or pass a
+  custom ``imednet_conn_id``). The connection should provide your iMednet
+  ``api_key`` and ``security_key`` either via the login/password fields or the
+  ``extra`` JSON. ``base_url`` may also be supplied in ``extra`` when using a
+  non‑default iMednet environment. If these values are not set on the
+  connection the operator falls back to ``IMEDNET_API_KEY``,
+  ``IMEDNET_SECURITY_KEY`` and ``IMEDNET_BASE_URL`` environment variables.
+- An AWS connection (``aws_default`` by default) is used by ``S3Hook`` to write
+  the JSON output. You can override it via ``aws_conn_id``.
+
+Replace ``STUDY_KEY`` and the S3 parameters with real values before running the
+DAG.
+"""
+
+default_args = {"start_date": datetime(2024, 1, 1)}
+
+with DAG(
+    dag_id="imednet_to_s3_example",
+    schedule_interval=None,
+    default_args=default_args,
+    catchup=False,
+) as dag:
+    export_records = ImednetToS3Operator(
+        task_id="export_records",
+        study_key="STUDY_KEY",
+        s3_bucket="your-bucket",
+        s3_key="imednet/records.json",
+        endpoint="records",
+        endpoint_kwargs={"page_size": 100},
+    )


### PR DESCRIPTION
## Summary
- add `imednet/examples/airflow/` with example DAGs
- demonstrate `ImednetToS3Operator` and `ImednetJobSensor`

## Testing
- `poetry run ruff check --fix .`
- `poetry run black --check .`
- `poetry run mypy imednet`
- `poetry run pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684b317dfd08832c86f37cbc6703a2b3