### PR TITLE
Add export CLI commands

### DIFF
--- a/imednet/cli.py
+++ b/imednet/cli.py
@@ -11,6 +11,7 @@ from rich import print
 from typing_extensions import Any, Dict, List, Optional
 
 from .core.exceptions import ApiError
+from .integrations import export
 from .sdk import ImednetSDK
 
 # Import the public filter utility
@@ -266,6 +267,102 @@ def list_records(
                 print(df.head().to_string(index=False))
                 if len(df) > 5:
                     print(f"... ({len(df)} total records)")
+    except ApiError as e:
+        print(f"[bold red]API Error:[/bold red] {e}")
+        raise typer.Exit(code=1)
+    except Exception as e:
+        print(f"[bold red]An unexpected error occurred:[/bold red] {e}")
+        raise typer.Exit(code=1)
+
+
+# --- Export Commands ---
+export_app = typer.Typer(name="export", help="Export study data.")
+app.add_typer(export_app)
+
+
+@export_app.command("csv")
+def export_csv(
+    study_key: str = typer.Argument(..., help="The key identifying the study."),
+    path: Path = typer.Argument(..., help="Destination file path."),
+):
+    """Export records for a study to CSV."""
+    sdk = get_sdk()
+    try:
+        export.export_csv(sdk, study_key, str(path))
+        print(f"Saved records to {path}")
+    except ApiError as e:
+        print(f"[bold red]API Error:[/bold red] {e}")
+        raise typer.Exit(code=1)
+    except Exception as e:
+        print(f"[bold red]An unexpected error occurred:[/bold red] {e}")
+        raise typer.Exit(code=1)
+
+
+@export_app.command("excel")
+def export_excel(
+    study_key: str = typer.Argument(..., help="The key identifying the study."),
+    path: Path = typer.Argument(..., help="Destination file path."),
+):
+    """Export records for a study to Excel."""
+    sdk = get_sdk()
+    try:
+        export.export_excel(sdk, study_key, str(path))
+        print(f"Saved records to {path}")
+    except ApiError as e:
+        print(f"[bold red]API Error:[/bold red] {e}")
+        raise typer.Exit(code=1)
+    except Exception as e:
+        print(f"[bold red]An unexpected error occurred:[/bold red] {e}")
+        raise typer.Exit(code=1)
+
+
+@export_app.command("json")
+def export_json(
+    study_key: str = typer.Argument(..., help="The key identifying the study."),
+    path: Path = typer.Argument(..., help="Destination file path."),
+):
+    """Export records for a study to JSON."""
+    sdk = get_sdk()
+    try:
+        export.export_json(sdk, study_key, str(path))
+        print(f"Saved records to {path}")
+    except ApiError as e:
+        print(f"[bold red]API Error:[/bold red] {e}")
+        raise typer.Exit(code=1)
+    except Exception as e:
+        print(f"[bold red]An unexpected error occurred:[/bold red] {e}")
+        raise typer.Exit(code=1)
+
+
+@export_app.command("parquet")
+def export_parquet(
+    study_key: str = typer.Argument(..., help="The key identifying the study."),
+    path: Path = typer.Argument(..., help="Destination file path."),
+):
+    """Export records for a study to Parquet."""
+    sdk = get_sdk()
+    try:
+        export.export_parquet(sdk, study_key, str(path))
+        print(f"Saved records to {path}")
+    except ApiError as e:
+        print(f"[bold red]API Error:[/bold red] {e}")
+        raise typer.Exit(code=1)
+    except Exception as e:
+        print(f"[bold red]An unexpected error occurred:[/bold red] {e}")
+        raise typer.Exit(code=1)
+
+
+@export_app.command("sql")
+def export_sql(
+    study_key: str = typer.Argument(..., help="The key identifying the study."),
+    table: str = typer.Argument(..., help="Target table name."),
+    connection_string: str = typer.Argument(..., help="SQLAlchemy connection string."),
+):
+    """Export records for a study to a SQL table."""
+    sdk = get_sdk()
+    try:
+        export.export_sql(sdk, study_key, table, connection_string)
+        print(f"Exported records to table {table}")
     except ApiError as e:
         print(f"[bold red]API Error:[/bold red] {e}")
         raise typer.Exit(code=1)

--- a/imednet/integrations/__init__.py
+++ b/imednet/integrations/__init__.py
@@ -1,0 +1,11 @@
+"""Integration helpers for working with external systems."""
+
+from .export import export_csv, export_excel, export_json, export_parquet, export_sql
+
+__all__ = [
+    "export_csv",
+    "export_excel",
+    "export_json",
+    "export_parquet",
+    "export_sql",
+]

--- a/imednet/integrations/export.py
+++ b/imednet/integrations/export.py
@@ -1,0 +1,57 @@
+"""Helpers for exporting study data to various formats."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from ..utils import records_to_dataframe
+
+if TYPE_CHECKING:  # pragma: no cover - used for type hints only
+    from ..sdk import ImednetSDK
+
+
+def export_csv(sdk: "ImednetSDK", study_key: str, path: str, *, flatten: bool = True) -> None:
+    """Export study records to a CSV file."""
+    records = sdk.records.list(study_key=study_key)
+    df = records_to_dataframe(records, flatten=flatten)
+    df.to_csv(path, index=False)
+
+
+def export_excel(sdk: "ImednetSDK", study_key: str, path: str, *, flatten: bool = True) -> None:
+    """Export study records to an Excel file."""
+    records = sdk.records.list(study_key=study_key)
+    df = records_to_dataframe(records, flatten=flatten)
+    df.to_excel(path, index=False)
+
+
+def export_json(sdk: "ImednetSDK", study_key: str, path: str, *, flatten: bool = True) -> None:
+    """Export study records to a JSON file."""
+    records = sdk.records.list(study_key=study_key)
+    df = records_to_dataframe(records, flatten=flatten)
+    df.to_json(path, orient="records", indent=2)
+
+
+def export_parquet(sdk: "ImednetSDK", study_key: str, path: str, *, flatten: bool = True) -> None:
+    """Export study records to a Parquet file."""
+    records = sdk.records.list(study_key=study_key)
+    df = records_to_dataframe(records, flatten=flatten)
+    df.to_parquet(path, index=False)
+
+
+def export_sql(
+    sdk: "ImednetSDK",
+    study_key: str,
+    table: str,
+    connection_string: str,
+    *,
+    flatten: bool = True,
+    if_exists: str = "replace",
+) -> None:
+    """Export study records to a SQL table using ``pandas.to_sql``."""
+    records = sdk.records.list(study_key=study_key)
+    df = records_to_dataframe(records, flatten=flatten)
+    from sqlalchemy import create_engine
+
+    engine = create_engine(connection_string)
+    with engine.begin() as conn:
+        df.to_sql(table, conn, if_exists=if_exists, index=False)

--- a/tests/unit/cli/test_cli.py
+++ b/tests/unit/cli/test_cli.py
@@ -177,3 +177,36 @@ def test_records_list_api_error(runner: CliRunner, sdk: MagicMock) -> None:
     result = runner.invoke(cli.app, ["records", "list", "STUDY"])
     assert result.exit_code == 1
     assert "API Error" in result.stdout
+
+
+def test_export_csv_calls_helper(
+    runner: CliRunner, sdk: MagicMock, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    helper = MagicMock()
+    monkeypatch.setattr(cli.export, "export_csv", helper)
+    result = runner.invoke(cli.app, ["export", "csv", "STUDY", "out.csv"])
+    assert result.exit_code == 0
+    helper.assert_called_once_with(sdk, "STUDY", "out.csv")
+
+
+def test_export_parquet_calls_helper(
+    runner: CliRunner, sdk: MagicMock, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    helper = MagicMock()
+    monkeypatch.setattr(cli.export, "export_parquet", helper)
+    result = runner.invoke(cli.app, ["export", "parquet", "STUDY", "out.parquet"])
+    assert result.exit_code == 0
+    helper.assert_called_once_with(sdk, "STUDY", "out.parquet")
+
+
+def test_export_sql_calls_helper(
+    runner: CliRunner, sdk: MagicMock, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    helper = MagicMock()
+    monkeypatch.setattr(cli.export, "export_sql", helper)
+    result = runner.invoke(
+        cli.app,
+        ["export", "sql", "STUDY", "records", "sqlite:///:memory:"],
+    )
+    assert result.exit_code == 0
+    helper.assert_called_once_with(sdk, "STUDY", "records", "sqlite:///:memory:")


### PR DESCRIPTION
## Summary
- add integration helpers for exporting to CSV, Excel, JSON, Parquet, and SQL
- add an `export` command group to `imednet.cli`
- test new export CLI commands

## Testing
- `poetry run ruff check --fix .`
- `poetry run black --check .`
- `poetry run mypy imednet`
- `poetry run pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684b3677274c832cbc7fe9190c3f5df0