### PR TITLE
Add Airflow export utilities

### DIFF
--- a/imednet/examples/airflow/imednet_export_dag.py
+++ b/imednet/examples/airflow/imednet_export_dag.py
@@ -1,0 +1,32 @@
+from datetime import datetime
+
+from imednet.integrations.airflow import ImednetExportOperator
+
+from airflow import DAG
+
+"""Example DAG using :class:`ImednetExportOperator` to write records to a CSV file.
+
+Configuration notes:
+- Create an Airflow connection ``imednet_default`` (or pass a custom
+  ``imednet_conn_id``) containing your ``api_key`` and ``security_key``.
+  ``base_url`` can be supplied in the connection ``extra`` JSON for non-default
+  environments. Environment variables ``IMEDNET_API_KEY`` and
+  ``IMEDNET_SECURITY_KEY`` are used as fallbacks.
+
+Replace ``STUDY_KEY`` and ``/tmp/records.csv`` with real values before running.
+"""
+
+default_args = {"start_date": datetime(2024, 1, 1)}
+
+with DAG(
+    dag_id="imednet_export_example",
+    schedule_interval=None,
+    default_args=default_args,
+    catchup=False,
+) as dag:
+    export_records = ImednetExportOperator(
+        task_id="export_records",
+        study_key="STUDY_KEY",
+        file_path="/tmp/records.csv",
+        flatten=True,
+    )

--- a/imednet/integrations/__init__.py
+++ b/imednet/integrations/__init__.py
@@ -1,0 +1,3 @@
+from .airflow import ImednetExportOperator, ImednetHook
+
+__all__ = ["ImednetHook", "ImednetExportOperator"]

--- a/imednet/integrations/airflow.py
+++ b/imednet/integrations/airflow.py
@@ -1,0 +1,65 @@
+"""Airflow hook and operator utilities."""
+
+from __future__ import annotations
+
+import os
+from typing import Any, Iterable
+
+from airflow.hooks.base import BaseHook
+from airflow.models import BaseOperator
+
+from ..sdk import ImednetSDK
+from ..utils import export_records_csv
+
+
+class ImednetHook(BaseHook):
+    """Retrieve an :class:`~imednet.sdk.ImednetSDK` from an Airflow connection."""
+
+    conn_name_attr = "imednet_conn_id"
+    default_conn_name = "imednet_default"
+    conn_type = "imednet"
+    hook_name = "iMednet"
+
+    def __init__(self, imednet_conn_id: str | None = None) -> None:
+        super().__init__()
+        self.imednet_conn_id = imednet_conn_id or self.default_conn_name
+
+    def get_conn(self) -> ImednetSDK:  # type: ignore[override]
+        conn = self.get_connection(self.imednet_conn_id)
+        extras = conn.extra_dejson
+        api_key = extras.get("api_key") or conn.login or os.getenv("IMEDNET_API_KEY")
+        security_key = (
+            extras.get("security_key") or conn.password or os.getenv("IMEDNET_SECURITY_KEY")
+        )
+        base_url = extras.get("base_url") or os.getenv("IMEDNET_BASE_URL")
+        return ImednetSDK(api_key=api_key, security_key=security_key, base_url=base_url)
+
+
+class ImednetExportOperator(BaseOperator):
+    """Export records to a CSV file using :func:`~imednet.utils.export_records_csv`."""
+
+    template_fields: Iterable[str] = ("study_key", "file_path")
+
+    def __init__(
+        self,
+        *,
+        study_key: str,
+        file_path: str,
+        flatten: bool = True,
+        imednet_conn_id: str = ImednetHook.default_conn_name,
+        **kwargs: Any,
+    ) -> None:
+        super().__init__(**kwargs)
+        self.study_key = study_key
+        self.file_path = file_path
+        self.flatten = flatten
+        self.imednet_conn_id = imednet_conn_id
+
+    def execute(self, context: dict[str, Any]) -> str:  # type: ignore[override]
+        hook = ImednetHook(self.imednet_conn_id)
+        sdk = hook.get_conn()
+        export_records_csv(sdk, self.study_key, self.file_path, flatten=self.flatten)
+        return self.file_path
+
+
+__all__ = ["ImednetHook", "ImednetExportOperator"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,9 +44,11 @@ tenacity = "^9.1.2"
 python-dotenv = "^1.1.0"
 typer = {extras = ["all"], version = "^0.15.2"}
 python-json-logger = "^2.0.7"
+apache-airflow = { version = "^2.9.0", optional = true }
 
 [tool.poetry.extras]
 pandas = ["pandas"]
+airflow = ["apache-airflow"]
 
 [tool.poetry.group.dev.dependencies]
 pandas = ">=2.2.3,<3.0.0"

--- a/tests/unit/test_airflow_integration.py
+++ b/tests/unit/test_airflow_integration.py
@@ -1,0 +1,89 @@
+from __future__ import annotations
+
+import sys
+from types import ModuleType
+from unittest.mock import MagicMock
+
+import pytest
+
+
+def _fake_airflow(monkeypatch):
+    airflow_mod = ModuleType("airflow")
+    hooks_mod = ModuleType("airflow.hooks")
+    base_mod = ModuleType("airflow.hooks.base")
+
+    connection = MagicMock()
+    connection.login = "login"
+    connection.password = "secret"
+    connection.extra_dejson = {"base_url": "https://example.com"}
+
+    class DummyBaseHook:
+        @classmethod
+        def get_connection(cls, _):
+            return connection
+
+    base_mod.BaseHook = DummyBaseHook
+    hooks_mod.base = base_mod
+    airflow_mod.hooks = hooks_mod
+
+    models_mod = ModuleType("airflow.models")
+
+    class DummyBaseOperator:
+        template_fields: tuple[str, ...] = ()
+
+        def __init__(self, **_):
+            pass
+
+    models_mod.BaseOperator = DummyBaseOperator
+
+    monkeypatch.setitem(sys.modules, "airflow", airflow_mod)
+    monkeypatch.setitem(sys.modules, "airflow.hooks", hooks_mod)
+    monkeypatch.setitem(sys.modules, "airflow.hooks.base", base_mod)
+    monkeypatch.setitem(sys.modules, "airflow.models", models_mod)
+
+    return connection
+
+
+@pytest.fixture(autouse=True)
+def airflow_stubs(monkeypatch):
+    return _fake_airflow(monkeypatch)
+
+
+def test_imednet_hook_returns_sdk(monkeypatch):
+    import imednet.integrations.airflow as ia
+
+    sdk_instance = MagicMock()
+    monkeypatch.setattr(ia, "ImednetSDK", MagicMock(return_value=sdk_instance))
+
+    hook = ia.ImednetHook()
+    sdk = hook.get_conn()
+
+    assert sdk is sdk_instance
+    ia.ImednetSDK.assert_called_once_with(
+        api_key="login", security_key="secret", base_url="https://example.com"
+    )
+
+
+def test_export_operator_uses_hook(monkeypatch):
+    import imednet.integrations.airflow as ia
+
+    sdk_instance = MagicMock()
+    hook = MagicMock()
+    hook.get_conn.return_value = sdk_instance
+    monkeypatch.setattr(ia, "ImednetHook", MagicMock(return_value=hook))
+
+    export = MagicMock()
+    monkeypatch.setattr(ia, "export_records_csv", export)
+
+    op = ia.ImednetExportOperator(
+        task_id="t",
+        study_key="STUDY",
+        file_path="/tmp/out.csv",
+        flatten=False,
+    )
+
+    result = op.execute({})
+
+    assert result == "/tmp/out.csv"
+    export.assert_called_once_with(sdk_instance, "STUDY", "/tmp/out.csv", flatten=False)
+    hook.get_conn.assert_called_once()


### PR DESCRIPTION
## Summary
- add Airflow hook and export operator
- show usage in a new example DAG
- support optional `airflow` extras
- test hook and operator logic

## Testing
- `poetry run ruff check --fix .`
- `poetry run black --check .`
- `poetry run mypy imednet`
- `poetry run pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684b36838c80832cb1747b0343ea1f28