### PR TITLE
Add Airflow export utilities

### DIFF
--- a/imednet/examples/airflow/imednet_export_operator_dag.py
+++ b/imednet/examples/airflow/imednet_export_operator_dag.py
@@ -1,0 +1,26 @@
+from datetime import datetime
+
+from imednet.integrations.airflow import ImednetExportOperator
+
+from airflow import DAG
+
+"""Example DAG showing :class:`ImednetExportOperator` to write records to a file.
+
+Update ``STUDY_KEY`` and ``output_path`` before running. Credentials are read from
+an Airflow connection ``imednet_default`` (or override ``imednet_conn_id``).
+"""
+
+default_args = {"start_date": datetime(2024, 1, 1)}
+
+with DAG(
+    dag_id="imednet_export_example",
+    schedule_interval=None,
+    default_args=default_args,
+    catchup=False,
+) as dag:
+    export_records = ImednetExportOperator(
+        task_id="export_records",
+        study_key="STUDY_KEY",
+        output_path="/tmp/records.csv",
+        export_func="export_to_csv",
+    )

--- a/imednet/integrations/airflow.py
+++ b/imednet/integrations/airflow.py
@@ -1,0 +1,63 @@
+"""Airflow integration helpers for exporting study data."""
+
+from __future__ import annotations
+
+import os
+from typing import Any, Dict, Iterable, Optional
+
+from airflow.hooks.base import BaseHook
+from airflow.models import BaseOperator
+
+from ..sdk import ImednetSDK
+from . import export
+
+
+class ImednetHook(BaseHook):
+    """Retrieve an :class:`ImednetSDK` instance from an Airflow connection."""
+
+    def __init__(self, imednet_conn_id: str = "imednet_default") -> None:
+        super().__init__()
+        self.imednet_conn_id = imednet_conn_id
+
+    def get_conn(self) -> ImednetSDK:  # type: ignore[override]
+        conn = self.get_connection(self.imednet_conn_id)
+        extras = conn.extra_dejson
+        api_key = extras.get("api_key") or conn.login or os.getenv("IMEDNET_API_KEY")
+        security_key = (
+            extras.get("security_key") or conn.password or os.getenv("IMEDNET_SECURITY_KEY")
+        )
+        base_url = extras.get("base_url") or os.getenv("IMEDNET_BASE_URL")
+        return ImednetSDK(api_key=api_key, security_key=security_key, base_url=base_url)
+
+
+class ImednetExportOperator(BaseOperator):
+    """Export study records using helpers from :mod:`imednet.integrations.export`."""
+
+    template_fields: Iterable[str] = ("study_key", "output_path")
+
+    def __init__(
+        self,
+        *,
+        study_key: str,
+        output_path: str,
+        export_func: str = "export_to_csv",
+        export_kwargs: Optional[Dict[str, Any]] = None,
+        imednet_conn_id: str = "imednet_default",
+        **kwargs: Any,
+    ) -> None:
+        super().__init__(**kwargs)
+        self.study_key = study_key
+        self.output_path = output_path
+        self.export_func = export_func
+        self.export_kwargs = export_kwargs or {}
+        self.imednet_conn_id = imednet_conn_id
+
+    def execute(self, context: Dict[str, Any]) -> str:
+        hook = ImednetHook(self.imednet_conn_id)
+        sdk = hook.get_conn()
+        export_callable = getattr(export, self.export_func)
+        export_callable(sdk, self.study_key, self.output_path, **self.export_kwargs)
+        return self.output_path
+
+
+__all__ = ["ImednetHook", "ImednetExportOperator"]

--- a/imednet/integrations/export.py
+++ b/imednet/integrations/export.py
@@ -47,4 +47,4 @@ def export_to_sql(
 
     df: pd.DataFrame = RecordMapper(sdk).dataframe(study_key)
     engine = create_engine(conn_str)
-    df.to_sql(table, engine, if_exists=if_exists, index=False, **kwargs)
+    df.to_sql(table, engine, if_exists=if_exists, index=False, **kwargs)  # type: ignore[arg-type]

--- a/imednet/utils/pandas.py
+++ b/imednet/utils/pandas.py
@@ -24,7 +24,7 @@ def records_to_dataframe(records: List[Record], *, flatten: bool = False) -> pd.
     rows = [r.model_dump(by_alias=False) for r in records]
     df = pd.DataFrame(rows)
     if flatten and not df.empty:
-        record_df = pd.json_normalize(df["record_data"], sep="_")
+        record_df = pd.json_normalize(df["record_data"], sep="_")  # type: ignore[arg-type]
         df = pd.concat([df.drop(columns=["record_data"]), record_df], axis=1)
     return df
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -2017,6 +2017,7 @@ docs = ["furo (>=2023.7.26)", "proselint (>=0.13)", "sphinx (>=7.1.2,!=7.3)", "s
 test = ["covdefaults (>=2.3)", "coverage (>=7.2.7)", "coverage-enable-subprocess (>=1)", "flaky (>=3.7)", "packaging (>=23.1)", "pytest (>=7.4)", "pytest-env (>=0.8.2)", "pytest-freezer (>=0.4.8) ; platform_python_implementation == \"PyPy\" or platform_python_implementation == \"GraalVM\" or platform_python_implementation == \"CPython\" and sys_platform == \"win32\" and python_version >= \"3.13\"", "pytest-mock (>=3.11.1)", "pytest-randomly (>=3.12)", "pytest-timeout (>=2.1)", "setuptools (>=68)", "time-machine (>=2.10) ; platform_python_implementation == \"CPython\""]
 
 [extras]
+airflow = []
 pandas = ["pandas"]
 pyarrow = ["pyarrow"]
 sqlalchemy = ["SQLAlchemy"]
@@ -2024,4 +2025,4 @@ sqlalchemy = ["SQLAlchemy"]
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.10"
-content-hash = "77013d18651628f80c0d4a64081944d20b0f89d9a577e971c16367b403631543"
+content-hash = "d58eb4add7cb4b30a59b39cd503afae50ef463a896af6fef2c92f9f4b5c0151f"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,6 +51,7 @@ python-json-logger = "^2.0.7"
 pandas = ["pandas"]
 pyarrow = ["pyarrow"]
 sqlalchemy = ["SQLAlchemy"]
+airflow = ["apache-airflow", "apache-airflow-providers-amazon"]
 
 [tool.poetry.group.dev.dependencies]
 pandas = ">=2.2.3,<3.0.0"

--- a/tests/unit/test_airflow_integration.py
+++ b/tests/unit/test_airflow_integration.py
@@ -1,0 +1,87 @@
+import sys
+from types import ModuleType
+from unittest.mock import MagicMock
+
+import imednet.sdk as sdk_mod
+
+
+def _setup_airflow(monkeypatch):
+    airflow_mod = ModuleType("airflow")
+    hooks_pkg = ModuleType("airflow.hooks")
+    hooks_mod = ModuleType("airflow.hooks.base")
+    models_mod = ModuleType("airflow.models")
+
+    class DummyBaseHook:
+        @classmethod
+        def get_connection(cls, conn_id):
+            raise NotImplementedError
+
+    class DummyBaseOperator:
+        template_fields = ()
+
+        def __init__(self, **kwargs):
+            pass
+
+    hooks_mod.BaseHook = DummyBaseHook
+    models_mod.BaseOperator = DummyBaseOperator
+
+    hooks_pkg.base = hooks_mod
+    airflow_mod.hooks = hooks_pkg
+    airflow_mod.models = models_mod
+
+    monkeypatch.setitem(sys.modules, "airflow", airflow_mod)
+    monkeypatch.setitem(sys.modules, "airflow.hooks", hooks_pkg)
+    monkeypatch.setitem(sys.modules, "airflow.hooks.base", hooks_mod)
+    monkeypatch.setitem(sys.modules, "airflow.models", models_mod)
+
+
+def test_imednet_hook_returns_sdk(monkeypatch):
+    _setup_airflow(monkeypatch)
+
+    conn = MagicMock()
+    conn.login = "KEY"
+    conn.password = "SEC"
+    conn.extra_dejson = {"base_url": "https://example.com"}
+
+    import airflow.hooks.base as hooks_base
+
+    monkeypatch.setattr(
+        hooks_base.BaseHook,
+        "get_connection",
+        classmethod(lambda cls, cid: conn),
+    )
+
+    import imednet.integrations.airflow as airflow_mod
+
+    hook = airflow_mod.ImednetHook()
+    sdk = hook.get_conn()
+
+    assert isinstance(sdk, sdk_mod.ImednetSDK)
+    assert sdk._client._client.headers["x-api-key"] == "KEY"
+    assert sdk._client._client.headers["x-imn-security-key"] == "SEC"
+    assert sdk._client.base_url == "https://example.com"
+
+
+def test_export_operator_calls_helper(monkeypatch):
+    _setup_airflow(monkeypatch)
+
+    sdk = MagicMock()
+    hook_inst = MagicMock(get_conn=MagicMock(return_value=sdk))
+
+    import imednet.integrations.airflow as airflow_mod
+
+    monkeypatch.setattr(airflow_mod, "ImednetHook", MagicMock(return_value=hook_inst))
+    export_mock = MagicMock()
+    monkeypatch.setattr(airflow_mod.export, "export_to_csv", export_mock)
+
+    op = airflow_mod.ImednetExportOperator(
+        task_id="t",
+        study_key="S",
+        output_path="/tmp/out.csv",
+        export_func="export_to_csv",
+    )
+
+    result = op.execute({})
+
+    export_mock.assert_called_once_with(sdk, "S", "/tmp/out.csv")
+    assert result == "/tmp/out.csv"


### PR DESCRIPTION
## Summary
- provide `ImednetHook` and `ImednetExportOperator`
- show new operator usage in an example DAG
- add Airflow optional dependencies
- cover hook and operator with tests

## Testing
- `poetry run ruff check --fix .`
- `poetry run black --check .`
- `poetry run mypy imednet`
- `poetry run pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684b3a19b944832c9bda1bfd044bf8c5