### PR TITLE
Update docs for setup script

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -57,3 +57,6 @@ Run tests locally:
 ```bash
 poetry run pytest
 ```
+
+Run `./scripts/setup.sh` before running tests to ensure all development
+dependencies are installed and pre-commit hooks are set up.

--- a/README.md
+++ b/README.md
@@ -281,6 +281,9 @@ Build and test:
 poetry run pytest --cov=imednet
 ```
 
+Run `./scripts/setup.sh` once before running tests to install the development
+dependencies and set up the pre-commit hooks.
+
 ## Contributing
 
 Please read [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines on how to contribute.


### PR DESCRIPTION
## Summary
- remind contributors to run `./scripts/setup.sh` before running tests

## Testing
- `poetry run ruff check --fix .`
- `poetry run black --check .`
- `poetry run mypy imednet`
- `poetry run pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684b4620f9ac832cb630c9d04d7777b1