### PR TITLE
Enable pydantic mypy plugin

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -91,8 +91,9 @@ ignore = ["D", "ANN", "S101"]
 
 [tool.mypy]
 python_version = "3.10"
-strict = false 
+strict = false
 ignore_missing_imports = true
+plugins = ["pydantic.mypy"]
 # ────────────────────────────────────────────────────────────────
 # Ignore all files under imednet/examples/
 exclude                = '^imednet/examples/.*$'


### PR DESCRIPTION
## Summary
- configure mypy to use the `pydantic.mypy` plugin

## Testing
- `poetry run ruff check --fix .`
- `poetry run black --check .`
- `poetry run mypy imednet`
- `poetry run pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684b45ca9be0832cb4f134bb03b7a078