### PR TITLE
Clean up comments and remove unused state variable

### DIFF
--- a/imednet/cli.py
+++ b/imednet/cli.py
@@ -29,11 +29,6 @@ load_dotenv()
 
 app = typer.Typer(help="iMednet SDK Command Line Interface")
 
-# --- State Management ---
-# Store SDK instance globally for reuse within commands if needed,
-# initialized via callback.
-state = {"sdk": None}
-
 
 def get_sdk() -> ImednetSDK:
     """Initializes and returns the ImednetSDK instance using env vars."""
@@ -74,7 +69,6 @@ def main(ctx: typer.Context):
     pass
 
 
-# Change input type hint to Optional[List[str]]
 def parse_filter_args(filter_args: Optional[List[str]]) -> Optional[Dict[str, Any]]:
     """Parses a list of 'key=value' strings into a dictionary."""
     if not filter_args:  # Handle None input
@@ -94,10 +88,8 @@ def parse_filter_args(filter_args: Optional[List[str]]) -> Optional[Dict[str, An
         elif value.lower() == "false":
             filter_dict[key.strip()] = False
         elif value.isdigit():
-            # This assignment is now valid due to Union type hint
             filter_dict[key.strip()] = int(value)
         else:
-            # This assignment is now valid due to Union type hint
             filter_dict[key.strip()] = value
     return filter_dict
 
@@ -249,7 +241,6 @@ def list_subjects(
     """List subjects for a specific study, with optional filtering."""
     sdk = get_sdk()
     try:
-        # parse_filter_args now correctly accepts Optional[List[str]]
         parsed_filter = parse_filter_args(subject_filter)
         # Use the imported public build_filter_string utility
         filter_str = build_filter_string(parsed_filter) if parsed_filter else None
@@ -388,7 +379,6 @@ def extract_records(
     workflow = DataExtractionWorkflow(sdk)
 
     try:
-        # parse_filter_args now correctly accepts Optional[List[str]]
         parsed_record_filter = parse_filter_args(record_filter)
         parsed_subject_filter = parse_filter_args(subject_filter)
         parsed_visit_filter = parse_filter_args(visit_filter)

--- a/imednet/models/study_structure.py
+++ b/imednet/models/study_structure.py
@@ -1,9 +1,9 @@
 from __future__ import annotations
 
-from datetime import datetime  # Added for type hints
+from datetime import datetime
 from typing import List
 
-from pydantic import BaseModel, ConfigDict, Field  # Added ConfigDict
+from pydantic import BaseModel, ConfigDict, Field
 
 # Import existing models needed for type hints and potentially reuse
 from .forms import Form

--- a/imednet/workflows/record_mapper.py
+++ b/imednet/workflows/record_mapper.py
@@ -1,5 +1,5 @@
 import logging
-from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, Type, Union  # Add TYPE_CHECKING
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, Type, Union
 
 import pandas as pd
 from pydantic import BaseModel, Field, ValidationError, create_model
@@ -8,7 +8,6 @@ from imednet.endpoints.records import Record as RecordModel
 from imednet.endpoints.variables import Variable as VariableModel
 from imednet.utils.filters import build_filter_string
 
-# Add conditional import
 if TYPE_CHECKING:
     from ..sdk import ImednetSDK
 
@@ -39,20 +38,18 @@ class RecordMapper:
 
     def __init__(
         self,
-        sdk: "ImednetSDK",  # Change type hint to string literal
-        # page_size is not used in current implementation, removed
+        sdk: "ImednetSDK",
     ):
         """
         :param sdk: An initialized ImednetSDK instance (with API credentials)
         """
         self.sdk = sdk
-        # self.page_size = page_size # Removed
 
     def dataframe(
         self,
         study_key: str,
         visit_key: Optional[str] = None,
-        use_labels_as_columns: bool = True,  # Added parameter
+        use_labels_as_columns: bool = True,
     ) -> pd.DataFrame:
         """
         Fetches variables and records for a study and returns a DataFrame.
@@ -77,7 +74,7 @@ class RecordMapper:
         # 2. Build dynamic Pydantic model for recordData with type hints (simplified)
         fields: Dict[str, tuple] = {}
         for key in variable_keys:
-            # Use Any type since specific mapping is removed
+            # Use Any type for variable values
             python_type = Any
             fields[key] = (
                 Optional[python_type],
@@ -113,9 +110,6 @@ class RecordMapper:
         except Exception as e:
             logger.error(f"Failed to fetch records for study '{study_key}': {e}")
             return pd.DataFrame()  # Return empty on fetch failure
-
-        # Removed client-side filtering
-        # if visit_key is not None:``
 
         # 4. Parse each record with error handling
         rows: List[Dict[str, Any]] = []

--- a/imednet/workflows/record_update.py
+++ b/imednet/workflows/record_update.py
@@ -105,7 +105,7 @@ class RecordUpdateWorkflow:
 
             # Poll the job status using the batch_id
             # Assuming sdk.jobs.get expects study_key and batch_id
-            current_job_status = self._sdk.jobs.get(study_key, batch_id)  # Added study_key
+            current_job_status = self._sdk.jobs.get(study_key, batch_id)
 
         # This line is technically unreachable due to the loop structure but ensures return type
         return current_job_status


### PR DESCRIPTION
## Summary
- remove unused `state` var from CLI
- tidy comments in CLI and workflows
- clean up comments in study structure models

## Testing
- `poetry run ruff check --fix .`
- `poetry run black --check .`
- `poetry run mypy imednet`
- `poetry run pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684b46090c18832ca31c8489ad457f0f