### PR TITLE
Update register_subjects workflow return type

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,5 +15,5 @@ repos:
     rev: v1.10.0
     hooks:
       - id: mypy
-        additional_dependencies: ["pandas-stubs", "types-requests"]
+        additional_dependencies: ["pandas-stubs", "types-requests", "pydantic"]
         args: ["--ignore-missing-imports", "--no-strict-optional"]

--- a/imednet/workflows/register_subjects.py
+++ b/imednet/workflows/register_subjects.py
@@ -4,8 +4,9 @@ This workflow is self-contained and does not borrow from record_update.py.
 It provides a simple, robust interface for registering one or more subjects.
 """
 
-from typing import TYPE_CHECKING, Any, List, Optional
+from typing import TYPE_CHECKING, List, Optional
 
+from imednet.models.jobs import Job
 from imednet.models.records import RegisterSubjectRequest
 
 # Use TYPE_CHECKING to avoid circular import at runtime
@@ -29,7 +30,7 @@ class RegisterSubjectsWorkflow:
         study_key: str,
         subjects: List[RegisterSubjectRequest],
         email_notify: Optional[str] = None,
-    ) -> Any:  # Consider defining a more specific return type if possible
+    ) -> Job:
         """
         Registers multiple subjects in the specified study.
 
@@ -40,7 +41,8 @@ class RegisterSubjectsWorkflow:
             email_notify: Optional email address to notify upon completion.
 
         Returns:
-            The response from the API call (e.g., a Job object or similar).
+            A :class:`Job` object representing the background job
+            created for the registration request.
 
         Raises:
             ApiError: If the API call fails.

--- a/tests/unit/test_workflows_register_subjects.py
+++ b/tests/unit/test_workflows_register_subjects.py
@@ -1,18 +1,22 @@
 from unittest.mock import MagicMock
 
+from imednet.models.jobs import Job
 from imednet.models.records import RegisterSubjectRequest
 from imednet.workflows.register_subjects import RegisterSubjectsWorkflow
 
 
 def test_register_subjects_passes_records_correctly() -> None:
     sdk = MagicMock()
+    job = Job(batch_id="1", state="PROCESSING")
+    sdk.records.create.return_value = job
     wf = RegisterSubjectsWorkflow(sdk)
     req = RegisterSubjectRequest(form_key="F", site_name="SITE")
 
-    wf.register_subjects("STUDY", [req], email_notify="test@example.com")
+    result = wf.register_subjects("STUDY", [req], email_notify="test@example.com")
 
     sdk.records.create.assert_called_once_with(
         study_key="STUDY",
         records_data=[req.model_dump(by_alias=True)],
         email_notify="test@example.com",
     )
+    assert result == job


### PR DESCRIPTION
## Summary
- return `Job` from `RegisterSubjectsWorkflow.register_subjects`
- test workflow returns `Job`
- ensure mypy pre-commit hook installs pydantic

## Testing
- `poetry run ruff check --fix .`
- `poetry run black --check .`
- `poetry run mypy imednet`
- `poetry run pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684b48f8e9b4832cbe237865ede7df08