### PR TITLE
Add caching for forms and intervals listing

### DIFF
--- a/imednet/endpoints/intervals.py
+++ b/imednet/endpoints/intervals.py
@@ -2,6 +2,9 @@
 
 from typing import Any, Dict, List, Optional
 
+from imednet.core.async_client import AsyncClient
+from imednet.core.client import Client
+from imednet.core.context import Context
 from imednet.core.paginator import Paginator
 from imednet.endpoints.base import BaseEndpoint
 from imednet.models.intervals import Interval
@@ -17,7 +20,18 @@ class IntervalsEndpoint(BaseEndpoint):
 
     path = "/api/v1/edc/studies"
 
-    def list(self, study_key: Optional[str] = None, **filters) -> List[Interval]:
+    def __init__(
+        self,
+        client: Client,
+        ctx: Context,
+        async_client: AsyncClient | None = None,
+    ) -> None:
+        super().__init__(client, ctx, async_client)
+        self._intervals_cache: Dict[str, List[Interval]] = {}
+
+    def list(
+        self, study_key: Optional[str] = None, refresh: bool = False, **filters
+    ) -> List[Interval]:
         """
         List intervals in a study with optional filtering.
 
@@ -32,13 +46,21 @@ class IntervalsEndpoint(BaseEndpoint):
         if study_key:
             filters["studyKey"] = study_key
 
+        study = filters.get("studyKey", "")
+        additional_filters = {k: v for k, v in filters.items() if k != "studyKey"}
+        if not additional_filters and not refresh and study in self._intervals_cache:
+            return self._intervals_cache[study]
+
         params: Dict[str, Any] = {}
         if filters:
             params["filter"] = build_filter_string(filters)
 
-        path = self._build_path(filters.get("studyKey", ""), "intervals")
+        path = self._build_path(study, "intervals")
         paginator = Paginator(self._client, path, params=params, page_size=500)
-        return [Interval.from_json(item) for item in paginator]
+        result = [Interval.from_json(item) for item in paginator]
+        if not additional_filters:
+            self._intervals_cache[study] = result
+        return result
 
     def get(self, study_key: str, interval_id: int) -> Interval:
         """

--- a/tests/unit/endpoints/test_forms_endpoint.py
+++ b/tests/unit/endpoints/test_forms_endpoint.py
@@ -38,3 +38,28 @@ def test_get_not_found(dummy_client, context, response_factory):
     dummy_client.get.return_value = response_factory({"data": []})
     with pytest.raises(ValueError):
         ep.get("S1", 1)
+
+
+def test_list_caches_by_study_key(dummy_client, context, paginator_factory):
+    ep = forms.FormsEndpoint(dummy_client, context)
+    capture = paginator_factory(forms, [{"formId": 1}])
+
+    first = ep.list(study_key="S1")
+    second = ep.list(study_key="S1")
+
+    assert capture["count"] == 1
+    assert first == second
+
+    ep.list(study_key="S2")
+
+    assert capture["count"] == 2
+
+
+def test_list_refresh_bypasses_cache(dummy_client, context, paginator_factory):
+    ep = forms.FormsEndpoint(dummy_client, context)
+    capture = paginator_factory(forms, [{"formId": 1}])
+
+    ep.list(study_key="S1")
+    ep.list(study_key="S1", refresh=True)
+
+    assert capture["count"] == 2

--- a/tests/unit/endpoints/test_intervals_endpoint.py
+++ b/tests/unit/endpoints/test_intervals_endpoint.py
@@ -25,3 +25,28 @@ def test_get_not_found(dummy_client, context, response_factory):
     dummy_client.get.return_value = response_factory({"data": []})
     with pytest.raises(ValueError):
         ep.get("S1", 1)
+
+
+def test_list_caches_by_study_key(dummy_client, context, paginator_factory):
+    ep = intervals.IntervalsEndpoint(dummy_client, context)
+    capture = paginator_factory(intervals, [{"intervalId": 1}])
+
+    first = ep.list(study_key="S1")
+    second = ep.list(study_key="S1")
+
+    assert capture["count"] == 1
+    assert first == second
+
+    ep.list(study_key="S2")
+
+    assert capture["count"] == 2
+
+
+def test_list_refresh_bypasses_cache(dummy_client, context, paginator_factory):
+    ep = intervals.IntervalsEndpoint(dummy_client, context)
+    capture = paginator_factory(intervals, [{"intervalId": 1}])
+
+    ep.list(study_key="S1")
+    ep.list(study_key="S1", refresh=True)
+
+    assert capture["count"] == 2


### PR DESCRIPTION
## Summary
- cache results for FormsEndpoint and IntervalsEndpoint
- support `refresh` arg to bypass cache
- test cache behaviour for both endpoints

## Testing
- `poetry run ruff check --fix .`
- `poetry run black --check .`
- `poetry run mypy imednet`
- `poetry run pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684b4900a5b4832ca6cb123277004a4c