### PR TITLE
Fix async tests setup

### DIFF
--- a/tests/e2e/test_live.py
+++ b/tests/e2e/test_live.py
@@ -1,4 +1,3 @@
-import asyncio
 import os
 from typing import AsyncIterator, Iterator
 
@@ -17,13 +16,6 @@ API_KEY = os.getenv("IMEDNET_API_KEY")
 SECURITY_KEY = os.getenv("IMEDNET_SECURITY_KEY")
 BASE_URL = os.getenv("IMEDNET_BASE_URL")
 RUN_E2E = os.getenv("IMEDNET_RUN_E2E") == "1"
-
-
-@pytest.fixture(scope="module")
-def event_loop() -> Iterator[asyncio.AbstractEventLoop]:
-    loop = asyncio.new_event_loop()
-    yield loop
-    loop.close()
 
 
 pytestmark = pytest.mark.skipif(
@@ -105,7 +97,7 @@ def test_list_records(sdk: ImednetSDK, study_key: str) -> None:
         assert isinstance(records[0], Record)
 
 
-@pytest.mark.asyncio
+@pytest.mark.asyncio(scope="module")
 async def test_async_studies(async_sdk: AsyncImednetSDK) -> None:
     studies = await async_sdk.studies.async_list()
     assert isinstance(studies, list)


### PR DESCRIPTION
## Summary
- remove custom event_loop fixture from e2e tests
- mark async study test to use module-scoped loop

## Testing
- `poetry run ruff check --fix .`
- `poetry run black --check .`
- `poetry run mypy imednet`
- `poetry run pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684b492c0410832cbe16c6bfe299e4ce