### PR TITLE
Add async study structure workflow

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,5 +15,8 @@ repos:
     rev: v1.10.0
     hooks:
       - id: mypy
-        additional_dependencies: ["pandas-stubs", "types-requests"]
+        additional_dependencies:
+          - pandas-stubs
+          - types-requests
+          - pydantic
         args: ["--ignore-missing-imports", "--no-strict-optional"]

--- a/tests/unit/async/test_workflows_study_structure.py
+++ b/tests/unit/async/test_workflows_study_structure.py
@@ -1,0 +1,43 @@
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from imednet.models.forms import Form
+from imednet.models.intervals import FormSummary, Interval
+from imednet.models.variables import Variable
+from imednet.workflows.study_structure import async_get_study_structure
+
+
+@pytest.mark.asyncio
+async def test_async_get_study_structure_aggregates_related_data(monkeypatch) -> None:
+    sdk = MagicMock()
+    sdk._async_client = object()
+    interval = Interval(
+        interval_id=1,
+        interval_name="INT1",
+        interval_sequence=1,
+        interval_description="desc",
+        interval_group_name="grp",
+        forms=[FormSummary(form_id=1, form_key="F1", form_name="Form1")],
+    )
+    form = Form(form_id=1, form_key="F1", form_name="Form1")
+    variable = Variable(variable_id=1, variable_name="V1", label="Var 1", form_id=1)
+
+    sdk.intervals.async_list = AsyncMock(return_value=[interval])
+    sdk.forms.async_list = AsyncMock(return_value=[form])
+    sdk.variables.async_list = AsyncMock(return_value=[variable])
+
+    orig_dump = Interval.model_dump
+    monkeypatch.setattr(
+        Interval,
+        "model_dump",
+        lambda self: {k: v for k, v in orig_dump(self).items() if k != "forms"},
+    )
+
+    structure = await async_get_study_structure(sdk, "STUDY")
+
+    sdk.intervals.async_list.assert_called_once_with("STUDY")
+    sdk.forms.async_list.assert_called_once_with("STUDY")
+    sdk.variables.async_list.assert_called_once_with("STUDY")
+
+    assert structure.study_key == "STUDY"
+    assert structure.intervals[0].forms[0].variables[0].variable_name == "V1"


### PR DESCRIPTION
## Summary
- support asynchronous retrieval of study structure
- add asyncio-based test coverage
- ensure mypy pre-commit hook has required dependencies

## Testing
- `poetry run ruff check --fix .`
- `poetry run black --check .`
- `poetry run mypy imednet`
- `poetry run pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684b48fbbe7c832c8e5154f560d5a82c