### PR TITLE
Add async study structure workflow

### DIFF
--- a/imednet/workflows/__init__.py
+++ b/imednet/workflows/__init__.py
@@ -12,7 +12,7 @@ from .query_management import QueryManagementWorkflow
 from .record_mapper import RecordMapper
 from .record_update import RecordUpdateWorkflow
 from .register_subjects import RegisterSubjectsWorkflow
-from .study_structure import get_study_structure
+from .study_structure import async_get_study_structure, get_study_structure
 from .subject_data import SubjectDataWorkflow
 
 __all__ = [
@@ -32,4 +32,5 @@ __all__ = [
     "RegisterSubjectsWorkflow",
     "SubjectDataWorkflow",
     "get_study_structure",
+    "async_get_study_structure",
 ]

--- a/tests/unit/async/test_workflows_study_structure.py
+++ b/tests/unit/async/test_workflows_study_structure.py
@@ -1,0 +1,42 @@
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from imednet.models.forms import Form
+from imednet.models.intervals import FormSummary, Interval
+from imednet.models.variables import Variable
+from imednet.workflows.study_structure import async_get_study_structure
+
+
+@pytest.mark.asyncio
+async def test_async_get_study_structure_aggregates_related_data(monkeypatch) -> None:
+    sdk = MagicMock()
+    interval = Interval(
+        interval_id=1,
+        interval_name="INT1",
+        interval_sequence=1,
+        interval_description="desc",
+        interval_group_name="grp",
+        forms=[FormSummary(form_id=1, form_key="F1", form_name="Form1")],
+    )
+    form = Form(form_id=1, form_key="F1", form_name="Form1")
+    variable = Variable(variable_id=1, variable_name="V1", label="Var 1", form_id=1)
+
+    sdk.intervals.async_list = AsyncMock(return_value=[interval])
+    sdk.forms.async_list = AsyncMock(return_value=[form])
+    sdk.variables.async_list = AsyncMock(return_value=[variable])
+
+    orig_dump = Interval.model_dump
+    monkeypatch.setattr(
+        Interval,
+        "model_dump",
+        lambda self: {k: v for k, v in orig_dump(self).items() if k != "forms"},
+    )
+
+    structure = await async_get_study_structure(sdk, "STUDY")
+
+    sdk.intervals.async_list.assert_awaited_once_with("STUDY")
+    sdk.forms.async_list.assert_awaited_once_with("STUDY")
+    sdk.variables.async_list.assert_awaited_once_with("STUDY")
+
+    assert structure.study_key == "STUDY"
+    assert structure.intervals[0].forms[0].variables[0].variable_name == "V1"


### PR DESCRIPTION
## Summary
- implement `async_get_study_structure` workflow
- expose async workflow in `__all__`
- test async study structure retrieval

## Testing
- `poetry run ruff check --fix .`
- `poetry run black --check .`
- `poetry run mypy imednet`
- `poetry run pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684b4af46584832c8a245d0210bbd8b2