### PR TITLE
Add schema validator tests

### DIFF
--- a/tests/e2e/test_schema_validator_live.py
+++ b/tests/e2e/test_schema_validator_live.py
@@ -1,0 +1,71 @@
+import os
+
+import pytest
+from imednet.core.exceptions import ValidationError
+from imednet.sdk import ImednetSDK
+from imednet.utils.schema import SchemaValidator
+
+API_KEY = os.getenv("IMEDNET_API_KEY")
+SECURITY_KEY = os.getenv("IMEDNET_SECURITY_KEY")
+BASE_URL = os.getenv("IMEDNET_BASE_URL")
+RUN_E2E = os.getenv("IMEDNET_RUN_E2E") == "1"
+
+pytestmark = pytest.mark.skipif(
+    not RUN_E2E or not (API_KEY and SECURITY_KEY),
+    reason=(
+        "Set IMEDNET_RUN_E2E=1 and provide IMEDNET_API_KEY/IMEDNET_SECURITY_KEY to run e2e tests"
+    ),
+)
+
+
+@pytest.fixture(scope="module")
+def sdk() -> ImednetSDK:
+    with ImednetSDK(api_key=API_KEY, security_key=SECURITY_KEY, base_url=BASE_URL) as client:
+        yield client
+
+
+@pytest.fixture(scope="module")
+def study_key(sdk: ImednetSDK) -> str:
+    studies = sdk.studies.list()
+    if not studies:
+        pytest.skip("No studies available for e2e tests")
+    return studies[0].study_key
+
+
+def _get_first_variable(sdk: ImednetSDK, study_key: str):
+    variables = sdk.variables.list(study_key=study_key)
+    if not variables:
+        pytest.skip("No variables available for e2e tests")
+    return variables[0]
+
+
+def _wrong_value(var_type: str):
+    t = var_type.lower()
+    if t in {"text", "string"}:
+        return 1
+    return "bad"
+
+
+def test_validator_unknown_variable(sdk: ImednetSDK, study_key: str) -> None:
+    var = _get_first_variable(sdk, study_key)
+    validator = SchemaValidator(sdk)
+
+    with pytest.raises(ValidationError):
+        validator.validate_record(
+            study_key, {"formKey": var.form_key, "data": {var.variable_name + "_x": 1}}
+        )
+
+    assert validator.schema.variables_for_form(var.form_key)
+
+
+def test_validator_wrong_type(sdk: ImednetSDK, study_key: str) -> None:
+    var = _get_first_variable(sdk, study_key)
+    validator = SchemaValidator(sdk)
+
+    with pytest.raises(ValidationError):
+        validator.validate_record(
+            study_key,
+            {"formKey": var.form_key, "data": {var.variable_name: _wrong_value(var.variable_type)}},
+        )
+
+    assert validator.schema.variables_for_form(var.form_key)

--- a/tests/unit/test_schema_validator.py
+++ b/tests/unit/test_schema_validator.py
@@ -1,0 +1,46 @@
+from unittest.mock import MagicMock
+
+import pytest
+from imednet.core.exceptions import ValidationError
+from imednet.models.variables import Variable
+from imednet.utils.schema import SchemaValidator
+
+
+def _build_sdk(variable: Variable) -> MagicMock:
+    sdk = MagicMock()
+    sdk.variables.list.return_value = [variable]
+    return sdk
+
+
+def test_validate_record_unknown_variable() -> None:
+    var = Variable(variable_name="age", variable_type="integer", form_id=1, form_key="F1")
+    sdk = _build_sdk(var)
+    validator = SchemaValidator(sdk)
+
+    with pytest.raises(ValidationError):
+        validator.validate_record("STUDY", {"formKey": "F1", "data": {"bad": 1}})
+
+    sdk.variables.list.assert_called_once_with(study_key="STUDY", refresh=True)
+
+
+def test_validate_record_wrong_type() -> None:
+    var = Variable(variable_name="age", variable_type="integer", form_id=1, form_key="F1")
+    sdk = _build_sdk(var)
+    validator = SchemaValidator(sdk)
+
+    with pytest.raises(ValidationError):
+        validator.validate_record("STUDY", {"formKey": "F1", "data": {"age": "x"}})
+
+    sdk.variables.list.assert_called_once_with(study_key="STUDY", refresh=True)
+
+
+def test_refresh_called_when_form_not_cached() -> None:
+    var = Variable(variable_name="age", variable_type="integer", form_id=1, form_key="F1")
+    sdk = _build_sdk(var)
+    validator = SchemaValidator(sdk)
+    validator.refresh = MagicMock(wraps=validator.refresh)
+
+    validator.validate_record("STUDY", {"formKey": "F1", "data": {"age": 1}})
+
+    validator.refresh.assert_called_once_with("STUDY")
+    sdk.variables.list.assert_called_once_with(study_key="STUDY", refresh=True)


### PR DESCRIPTION
## Summary
- add unit tests for SchemaValidator
- add e2e tests for SchemaValidator

## Testing
- `poetry run ruff check --fix .`
- `poetry run black --check .`
- `poetry run mypy imednet`
- `poetry run pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684b4fb404d0832caad1e8d64d2f03b1