### PR TITLE
Add job status & wait CLI tests

### DIFF
--- a/tests/unit/cli/test_cli.py
+++ b/tests/unit/cli/test_cli.py
@@ -230,3 +230,15 @@ def test_export_sql_calls_helper(
     )
     assert result.exit_code == 0
     func.assert_called_once_with(sdk, "STUDY", "table", "sqlite://")
+
+
+def test_jobs_status_success(runner: CliRunner, sdk: MagicMock) -> None:
+    result = runner.invoke(cli.app, ["jobs", "status", "STUDY", "BATCH"])
+    assert result.exit_code == 0
+    sdk.get_job.assert_called_once_with("STUDY", "BATCH")
+
+
+def test_jobs_wait_success(runner: CliRunner, sdk: MagicMock) -> None:
+    result = runner.invoke(cli.app, ["jobs", "wait", "STUDY", "BATCH"])
+    assert result.exit_code == 0
+    sdk.poll_job.assert_called_once_with("STUDY", "BATCH", interval=5, timeout=300)


### PR DESCRIPTION
## Summary
- cover `jobs status` & `jobs wait` commands in CLI tests

## Testing
- `poetry run ruff check --fix .`
- `poetry run black --check .`
- `poetry run mypy imednet`
- `poetry run pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684b4fb0e754832cbf8730f310d79a2e