### PR TITLE
Add API overview docs

### DIFF
--- a/docs/api_overview.rst
+++ b/docs/api_overview.rst
@@ -1,0 +1,44 @@
+API Overview
+===========
+
+This page summarizes the core concepts of the Mednet EDC REST API and how the
+SDK interacts with it.
+
+Base URL
+--------
+
+The SDK communicates with the production API at
+``https://edc.prod.imednetapi.com`` by default. Override this with the
+``IMEDNET_BASE_URL`` environment variable if using a private deployment.
+
+Authentication
+--------------
+
+All requests must include ``x-api-key`` and ``x-imn-security-key`` headers. The
+:class:`~imednet.core.client.Client` and :class:`~imednet.core.async_client.AsyncClient`
+read ``IMEDNET_API_KEY`` and ``IMEDNET_SECURITY_KEY`` from the environment and
+populate these headers automatically.
+
+HTTP methods and errors
+-----------------------
+
+The API primarily supports ``GET`` and ``POST`` requests. Non‐successful status
+codes raise typed exceptions:
+
+* ``400`` – :class:`~imednet.core.exceptions.ValidationError`
+* ``401`` – :class:`~imednet.core.exceptions.AuthenticationError`
+* ``403`` – :class:`~imednet.core.exceptions.AuthorizationError`
+* ``404`` – :class:`~imednet.core.exceptions.NotFoundError`
+* ``429`` – :class:`~imednet.core.exceptions.RateLimitError`
+* ``5xx`` – :class:`~imednet.core.exceptions.ServerError`
+
+Filtering
+---------
+
+Endpoints accept a ``filter`` parameter that matches the syntax documented in the
+Mednet API guide. For clinical data queries, ``recordDataFilter`` can be supplied
+alongside ``filter``. See :mod:`imednet.endpoints.records` for usage examples.
+
+Dates must use UTC timestamps except where noted. When filtering visits by
+``startDate``, ``dueDate``, ``endDate`` or ``visitDate``, use ``YYYY-MM-DD``.
+

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -6,6 +6,7 @@ Welcome to imednet-sdk's documentation!
    :caption: Contents:
 
    logging_and_tracing
+   api_overview
    cli
    airflow
    modules


### PR DESCRIPTION
## Summary
- document API base URL, auth headers, and filtering
- include the new API overview page in the Sphinx index

## Testing
- `poetry run ruff check --fix .`
- `poetry run black --check .`
- `poetry run mypy imednet`
- `poetry run pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684b7b18916c832caf5f144eb0f346dc