### PR TITLE
Add coverage details to live test plan

### DIFF
--- a/tests/LIVE_TEST_PLAN.md
+++ b/tests/LIVE_TEST_PLAN.md
@@ -1,0 +1,102 @@
+# Live (End-to-End) Test Plan
+
+These tests execute against a real iMedNet environment. They are skipped by default
+and require `IMEDNET_RUN_E2E=1` with valid credentials. Each item below should be
+covered by a dedicated test case so failures are easy to diagnose.
+
+## Endpoints
+
+For every endpoint the `list` and `get` operations should be verified:
+
+- `StudiesEndpoint`
+- `SitesEndpoint`
+- `SubjectsEndpoint`
+- `RecordsEndpoint`
+- `IntervalsEndpoint`
+- `VisitsEndpoint`
+- `VariablesEndpoint`
+- `FormsEndpoint`
+- `QueriesEndpoint`
+- `RecordRevisionsEndpoint`
+- `UsersEndpoint`
+- `JobsEndpoint`
+- `CodingsEndpoint`
+- `JobsEndpoint.get` should also be validated independently using a known
+  batch ID.
+- `RecordsEndpoint.create` should be exercised to confirm record submission and
+  that `JobsEndpoint.get` retrieves the resulting job status.
+
+Every synchronous test should have an asynchronous counterpart using
+`AsyncImednetSDK`. For example, `AsyncImednetSDK.studies.async_list()` mirrors
+`ImednetSDK.studies.list()` and should verify the same behaviors.
+
+## SDK Utilities
+
+Common convenience methods on :class:`ImednetSDK` also deserve coverage:
+
+- `get_studies`
+- `get_records`
+- `get_sites`
+- `get_subjects`
+- `get_forms`
+- `get_intervals`
+- `get_variables`
+- `get_visits`
+- `get_codings`
+- `get_queries`
+- `get_record_revisions`
+- `get_users`
+- `get_job`
+- `poll_job`
+
+## Workflow Helpers
+
+The workflow utilities in `imednet.workflows` should be tested using small,
+non‑destructive calls. Each bullet corresponds to a separate live test.
+
+- `get_study_structure` and `async_get_study_structure`
+- `RegisterSubjectsWorkflow.register_subjects`
+- `DataExtractionWorkflow.extract_records_by_criteria`
+- `DataExtractionWorkflow.extract_audit_trail`
+- `SubjectDataWorkflow.get_all_subject_data`
+- `QueryManagementWorkflow.get_open_queries`
+- `QueryManagementWorkflow.get_queries_for_subject`
+- `QueryManagementWorkflow.get_queries_by_site`
+- `QueryManagementWorkflow.get_query_state_counts`
+- `RecordMapper.dataframe`
+- `RecordUpdateWorkflow.submit_record_batch`
+- `RecordUpdateWorkflow.register_subject`
+- `RecordUpdateWorkflow.update_scheduled_record`
+- `RecordUpdateWorkflow.create_new_record`
+
+## CLI Commands
+
+Live tests should execute the CLI via `typer.testing.CliRunner`.
+Run each command with minimal arguments and verify a successful exit code:
+
+- `imednet studies list`
+- `imednet sites list <STUDY_KEY>`
+- `imednet subjects list <STUDY_KEY>`
+- `imednet records list <STUDY_KEY>`
+- `imednet jobs status <STUDY_KEY> <BATCH_ID>`
+- `imednet jobs wait <STUDY_KEY> <BATCH_ID>`
+- `imednet export parquet <STUDY_KEY> tmp.parquet`
+- `imednet export csv <STUDY_KEY> tmp.csv`
+- `imednet export excel <STUDY_KEY> tmp.xlsx`
+- `imednet export json <STUDY_KEY> tmp.json`
+- `imednet export sql <STUDY_KEY> TABLE sqlite:///test.db`
+- `imednet workflows extract-records <STUDY_KEY>`
+
+## Integrations
+
+The integration helpers require validation using temporary files or buckets:
+
+- `export_to_csv`
+- `export_to_excel`
+- `export_to_json`
+- `export_to_parquet`
+- `export_to_sql`
+- `ImednetToS3Operator` and `ImednetJobSensor` from the Airflow module
+- `ImednetExportOperator` from the Airflow module
+- `ImednetHook` for connection retrieval
+

--- a/tests/TEST_PLAN.md
+++ b/tests/TEST_PLAN.md
@@ -144,3 +144,11 @@ The current test suite only includes a basic smoke test (`tests/unit/test_smoke.
 9. **Use `typer.testing.CliRunner`:** For testing CLI commands.
 
 By systematically adding tests for these specific files and classes/functions, focusing on both successful paths and error conditions, the project should be able to achieve the 90% coverage target.
+
+## Live End-to-End Tests
+
+Real API integration tests are optional but recommended. See `LIVE_TEST_PLAN.md` in
+this directory for a complete list of features. Every endpoint, workflow method, CLI
+command (including export and job utilities), and integration helper should have a
+dedicated live test that runs only when `IMEDNET_RUN_E2E=1` and valid credentials are
+supplied.


### PR DESCRIPTION
## Summary
- expand end-to-end coverage guide with CLI commands and Airflow operator
- clarify that async variants and job status checks also need tests
- list SDK convenience methods for completeness

## Testing
- `poetry run ruff check --fix .`
- `poetry run black --check .`
- `poetry run mypy imednet`
- `poetry run pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684b543bd2e0832c833fe473675ae569