### PR TITLE
Add integration tests for core client and endpoints

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -110,6 +110,46 @@ jupyter = ["ipython (>=7.8.0)", "tokenize-rt (>=3.2.0)"]
 uvloop = ["uvloop (>=0.15.2)"]
 
 [[package]]
+name = "boto3"
+version = "1.38.36"
+description = "The AWS SDK for Python"
+optional = false
+python-versions = ">=3.9"
+groups = ["dev"]
+files = [
+    {file = "boto3-1.38.36-py3-none-any.whl", hash = "sha256:34c27d7317cadb62c0e9856e5d5aa0271ef47202d340584831048bc7ac904136"},
+    {file = "boto3-1.38.36.tar.gz", hash = "sha256:efe0aaa060f8fedd76e5c942055f051aee0432fc722d79d8830a9fd9db83593e"},
+]
+
+[package.dependencies]
+botocore = ">=1.38.36,<1.39.0"
+jmespath = ">=0.7.1,<2.0.0"
+s3transfer = ">=0.13.0,<0.14.0"
+
+[package.extras]
+crt = ["botocore[crt] (>=1.21.0,<2.0a0)"]
+
+[[package]]
+name = "botocore"
+version = "1.38.36"
+description = "Low-level, data-driven core of boto 3."
+optional = false
+python-versions = ">=3.9"
+groups = ["dev"]
+files = [
+    {file = "botocore-1.38.36-py3-none-any.whl", hash = "sha256:b6a50b853f6d23af9edfed89a59800c6bc1687a947cdd3492879f7d64e002d30"},
+    {file = "botocore-1.38.36.tar.gz", hash = "sha256:4a1ced1a4218bdff0ed5b46abb54570d473154ddefafa5d121a8d96e4b76ebc1"},
+]
+
+[package.dependencies]
+jmespath = ">=0.7.1,<2.0.0"
+python-dateutil = ">=2.1,<3.0.0"
+urllib3 = {version = ">=1.25.4,<2.2.0 || >2.2.0,<3", markers = "python_version >= \"3.10\""}
+
+[package.extras]
+crt = ["awscrt (==0.23.8)"]
+
+[[package]]
 name = "certifi"
 version = "2025.1.31"
 description = "Python package for providing Mozilla's CA Bundle."
@@ -120,6 +160,87 @@ files = [
     {file = "certifi-2025.1.31-py3-none-any.whl", hash = "sha256:ca78db4565a652026a4db2bcdf68f2fb589ea80d0be70e03929ed730746b84fe"},
     {file = "certifi-2025.1.31.tar.gz", hash = "sha256:3d5da6925056f6f18f119200434a4780a94263f10d1c21d032a6f6b2baa20651"},
 ]
+
+[[package]]
+name = "cffi"
+version = "1.17.1"
+description = "Foreign Function Interface for Python calling C code."
+optional = false
+python-versions = ">=3.8"
+groups = ["dev"]
+markers = "platform_python_implementation != \"PyPy\""
+files = [
+    {file = "cffi-1.17.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:df8b1c11f177bc2313ec4b2d46baec87a5f3e71fc8b45dab2ee7cae86d9aba14"},
+    {file = "cffi-1.17.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:8f2cdc858323644ab277e9bb925ad72ae0e67f69e804f4898c070998d50b1a67"},
+    {file = "cffi-1.17.1-cp310-cp310-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:edae79245293e15384b51f88b00613ba9f7198016a5948b5dddf4917d4d26382"},
+    {file = "cffi-1.17.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:45398b671ac6d70e67da8e4224a065cec6a93541bb7aebe1b198a61b58c7b702"},
+    {file = "cffi-1.17.1-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:ad9413ccdeda48c5afdae7e4fa2192157e991ff761e7ab8fdd8926f40b160cc3"},
+    {file = "cffi-1.17.1-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:5da5719280082ac6bd9aa7becb3938dc9f9cbd57fac7d2871717b1feb0902ab6"},
+    {file = "cffi-1.17.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2bb1a08b8008b281856e5971307cc386a8e9c5b625ac297e853d36da6efe9c17"},
+    {file = "cffi-1.17.1-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:045d61c734659cc045141be4bae381a41d89b741f795af1dd018bfb532fd0df8"},
+    {file = "cffi-1.17.1-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:6883e737d7d9e4899a8a695e00ec36bd4e5e4f18fabe0aca0efe0a4b44cdb13e"},
+    {file = "cffi-1.17.1-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:6b8b4a92e1c65048ff98cfe1f735ef8f1ceb72e3d5f0c25fdb12087a23da22be"},
+    {file = "cffi-1.17.1-cp310-cp310-win32.whl", hash = "sha256:c9c3d058ebabb74db66e431095118094d06abf53284d9c81f27300d0e0d8bc7c"},
+    {file = "cffi-1.17.1-cp310-cp310-win_amd64.whl", hash = "sha256:0f048dcf80db46f0098ccac01132761580d28e28bc0f78ae0d58048063317e15"},
+    {file = "cffi-1.17.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:a45e3c6913c5b87b3ff120dcdc03f6131fa0065027d0ed7ee6190736a74cd401"},
+    {file = "cffi-1.17.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:30c5e0cb5ae493c04c8b42916e52ca38079f1b235c2f8ae5f4527b963c401caf"},
+    {file = "cffi-1.17.1-cp311-cp311-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:f75c7ab1f9e4aca5414ed4d8e5c0e303a34f4421f8a0d47a4d019ceff0ab6af4"},
+    {file = "cffi-1.17.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a1ed2dd2972641495a3ec98445e09766f077aee98a1c896dcb4ad0d303628e41"},
+    {file = "cffi-1.17.1-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:46bf43160c1a35f7ec506d254e5c890f3c03648a4dbac12d624e4490a7046cd1"},
+    {file = "cffi-1.17.1-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:a24ed04c8ffd54b0729c07cee15a81d964e6fee0e3d4d342a27b020d22959dc6"},
+    {file = "cffi-1.17.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:610faea79c43e44c71e1ec53a554553fa22321b65fae24889706c0a84d4ad86d"},
+    {file = "cffi-1.17.1-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:a9b15d491f3ad5d692e11f6b71f7857e7835eb677955c00cc0aefcd0669adaf6"},
+    {file = "cffi-1.17.1-cp311-cp311-musllinux_1_1_i686.whl", hash = "sha256:de2ea4b5833625383e464549fec1bc395c1bdeeb5f25c4a3a82b5a8c756ec22f"},
+    {file = "cffi-1.17.1-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:fc48c783f9c87e60831201f2cce7f3b2e4846bf4d8728eabe54d60700b318a0b"},
+    {file = "cffi-1.17.1-cp311-cp311-win32.whl", hash = "sha256:85a950a4ac9c359340d5963966e3e0a94a676bd6245a4b55bc43949eee26a655"},
+    {file = "cffi-1.17.1-cp311-cp311-win_amd64.whl", hash = "sha256:caaf0640ef5f5517f49bc275eca1406b0ffa6aa184892812030f04c2abf589a0"},
+    {file = "cffi-1.17.1-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:805b4371bf7197c329fcb3ead37e710d1bca9da5d583f5073b799d5c5bd1eee4"},
+    {file = "cffi-1.17.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:733e99bc2df47476e3848417c5a4540522f234dfd4ef3ab7fafdf555b082ec0c"},
+    {file = "cffi-1.17.1-cp312-cp312-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:1257bdabf294dceb59f5e70c64a3e2f462c30c7ad68092d01bbbfb1c16b1ba36"},
+    {file = "cffi-1.17.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:da95af8214998d77a98cc14e3a3bd00aa191526343078b530ceb0bd710fb48a5"},
+    {file = "cffi-1.17.1-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:d63afe322132c194cf832bfec0dc69a99fb9bb6bbd550f161a49e9e855cc78ff"},
+    {file = "cffi-1.17.1-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:f79fc4fc25f1c8698ff97788206bb3c2598949bfe0fef03d299eb1b5356ada99"},
+    {file = "cffi-1.17.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b62ce867176a75d03a665bad002af8e6d54644fad99a3c70905c543130e39d93"},
+    {file = "cffi-1.17.1-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:386c8bf53c502fff58903061338ce4f4950cbdcb23e2902d86c0f722b786bbe3"},
+    {file = "cffi-1.17.1-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:4ceb10419a9adf4460ea14cfd6bc43d08701f0835e979bf821052f1805850fe8"},
+    {file = "cffi-1.17.1-cp312-cp312-win32.whl", hash = "sha256:a08d7e755f8ed21095a310a693525137cfe756ce62d066e53f502a83dc550f65"},
+    {file = "cffi-1.17.1-cp312-cp312-win_amd64.whl", hash = "sha256:51392eae71afec0d0c8fb1a53b204dbb3bcabcb3c9b807eedf3e1e6ccf2de903"},
+    {file = "cffi-1.17.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:f3a2b4222ce6b60e2e8b337bb9596923045681d71e5a082783484d845390938e"},
+    {file = "cffi-1.17.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:0984a4925a435b1da406122d4d7968dd861c1385afe3b45ba82b750f229811e2"},
+    {file = "cffi-1.17.1-cp313-cp313-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:d01b12eeeb4427d3110de311e1774046ad344f5b1a7403101878976ecd7a10f3"},
+    {file = "cffi-1.17.1-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:706510fe141c86a69c8ddc029c7910003a17353970cff3b904ff0686a5927683"},
+    {file = "cffi-1.17.1-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:de55b766c7aa2e2a3092c51e0483d700341182f08e67c63630d5b6f200bb28e5"},
+    {file = "cffi-1.17.1-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:c59d6e989d07460165cc5ad3c61f9fd8f1b4796eacbd81cee78957842b834af4"},
+    {file = "cffi-1.17.1-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:dd398dbc6773384a17fe0d3e7eeb8d1a21c2200473ee6806bb5e6a8e62bb73dd"},
+    {file = "cffi-1.17.1-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:3edc8d958eb099c634dace3c7e16560ae474aa3803a5df240542b305d14e14ed"},
+    {file = "cffi-1.17.1-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:72e72408cad3d5419375fc87d289076ee319835bdfa2caad331e377589aebba9"},
+    {file = "cffi-1.17.1-cp313-cp313-win32.whl", hash = "sha256:e03eab0a8677fa80d646b5ddece1cbeaf556c313dcfac435ba11f107ba117b5d"},
+    {file = "cffi-1.17.1-cp313-cp313-win_amd64.whl", hash = "sha256:f6a16c31041f09ead72d69f583767292f750d24913dadacf5756b966aacb3f1a"},
+    {file = "cffi-1.17.1-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:636062ea65bd0195bc012fea9321aca499c0504409f413dc88af450b57ffd03b"},
+    {file = "cffi-1.17.1-cp38-cp38-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:c7eac2ef9b63c79431bc4b25f1cd649d7f061a28808cbc6c47b534bd789ef964"},
+    {file = "cffi-1.17.1-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e221cf152cff04059d011ee126477f0d9588303eb57e88923578ace7baad17f9"},
+    {file = "cffi-1.17.1-cp38-cp38-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:31000ec67d4221a71bd3f67df918b1f88f676f1c3b535a7eb473255fdc0b83fc"},
+    {file = "cffi-1.17.1-cp38-cp38-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:6f17be4345073b0a7b8ea599688f692ac3ef23ce28e5df79c04de519dbc4912c"},
+    {file = "cffi-1.17.1-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0e2b1fac190ae3ebfe37b979cc1ce69c81f4e4fe5746bb401dca63a9062cdaf1"},
+    {file = "cffi-1.17.1-cp38-cp38-win32.whl", hash = "sha256:7596d6620d3fa590f677e9ee430df2958d2d6d6de2feeae5b20e82c00b76fbf8"},
+    {file = "cffi-1.17.1-cp38-cp38-win_amd64.whl", hash = "sha256:78122be759c3f8a014ce010908ae03364d00a1f81ab5c7f4a7a5120607ea56e1"},
+    {file = "cffi-1.17.1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:b2ab587605f4ba0bf81dc0cb08a41bd1c0a5906bd59243d56bad7668a6fc6c16"},
+    {file = "cffi-1.17.1-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:28b16024becceed8c6dfbc75629e27788d8a3f9030691a1dbf9821a128b22c36"},
+    {file = "cffi-1.17.1-cp39-cp39-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:1d599671f396c4723d016dbddb72fe8e0397082b0a77a4fab8028923bec050e8"},
+    {file = "cffi-1.17.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ca74b8dbe6e8e8263c0ffd60277de77dcee6c837a3d0881d8c1ead7268c9e576"},
+    {file = "cffi-1.17.1-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:f7f5baafcc48261359e14bcd6d9bff6d4b28d9103847c9e136694cb0501aef87"},
+    {file = "cffi-1.17.1-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:98e3969bcff97cae1b2def8ba499ea3d6f31ddfdb7635374834cf89a1a08ecf0"},
+    {file = "cffi-1.17.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:cdf5ce3acdfd1661132f2a9c19cac174758dc2352bfe37d98aa7512c6b7178b3"},
+    {file = "cffi-1.17.1-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:9755e4345d1ec879e3849e62222a18c7174d65a6a92d5b346b1863912168b595"},
+    {file = "cffi-1.17.1-cp39-cp39-musllinux_1_1_i686.whl", hash = "sha256:f1e22e8c4419538cb197e4dd60acc919d7696e5ef98ee4da4e01d3f8cfa4cc5a"},
+    {file = "cffi-1.17.1-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:c03e868a0b3bc35839ba98e74211ed2b05d2119be4e8a0f224fba9384f1fe02e"},
+    {file = "cffi-1.17.1-cp39-cp39-win32.whl", hash = "sha256:e31ae45bc2e29f6b2abd0de1cc3b9d5205aa847cafaecb8af1476a609a2f6eb7"},
+    {file = "cffi-1.17.1-cp39-cp39-win_amd64.whl", hash = "sha256:d016c76bdd850f3c626af19b0542c9677ba156e4ee4fccfdd7848803533ef662"},
+    {file = "cffi-1.17.1.tar.gz", hash = "sha256:1c39c6016c32bc48dd54561950ebd6836e1670f2ae46128f67cf49e789c52824"},
+]
+
+[package.dependencies]
+pycparser = "*"
 
 [[package]]
 name = "cfgv"
@@ -343,6 +464,66 @@ tomli = {version = "*", optional = true, markers = "python_full_version <= \"3.1
 toml = ["tomli ; python_full_version <= \"3.11.0a6\""]
 
 [[package]]
+name = "cryptography"
+version = "45.0.4"
+description = "cryptography is a package which provides cryptographic recipes and primitives to Python developers."
+optional = false
+python-versions = "!=3.9.0,!=3.9.1,>=3.7"
+groups = ["dev"]
+files = [
+    {file = "cryptography-45.0.4-cp311-abi3-macosx_10_9_universal2.whl", hash = "sha256:425a9a6ac2823ee6e46a76a21a4e8342d8fa5c01e08b823c1f19a8b74f096069"},
+    {file = "cryptography-45.0.4-cp311-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:680806cf63baa0039b920f4976f5f31b10e772de42f16310a6839d9f21a26b0d"},
+    {file = "cryptography-45.0.4-cp311-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:4ca0f52170e821bc8da6fc0cc565b7bb8ff8d90d36b5e9fdd68e8a86bdf72036"},
+    {file = "cryptography-45.0.4-cp311-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:f3fe7a5ae34d5a414957cc7f457e2b92076e72938423ac64d215722f6cf49a9e"},
+    {file = "cryptography-45.0.4-cp311-abi3-manylinux_2_28_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:25eb4d4d3e54595dc8adebc6bbd5623588991d86591a78c2548ffb64797341e2"},
+    {file = "cryptography-45.0.4-cp311-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:ce1678a2ccbe696cf3af15a75bb72ee008d7ff183c9228592ede9db467e64f1b"},
+    {file = "cryptography-45.0.4-cp311-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:49fe9155ab32721b9122975e168a6760d8ce4cffe423bcd7ca269ba41b5dfac1"},
+    {file = "cryptography-45.0.4-cp311-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:2882338b2a6e0bd337052e8b9007ced85c637da19ef9ecaf437744495c8c2999"},
+    {file = "cryptography-45.0.4-cp311-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:23b9c3ea30c3ed4db59e7b9619272e94891f8a3a5591d0b656a7582631ccf750"},
+    {file = "cryptography-45.0.4-cp311-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:b0a97c927497e3bc36b33987abb99bf17a9a175a19af38a892dc4bbb844d7ee2"},
+    {file = "cryptography-45.0.4-cp311-abi3-win32.whl", hash = "sha256:e00a6c10a5c53979d6242f123c0a97cff9f3abed7f064fc412c36dc521b5f257"},
+    {file = "cryptography-45.0.4-cp311-abi3-win_amd64.whl", hash = "sha256:817ee05c6c9f7a69a16200f0c90ab26d23a87701e2a284bd15156783e46dbcc8"},
+    {file = "cryptography-45.0.4-cp37-abi3-macosx_10_9_universal2.whl", hash = "sha256:964bcc28d867e0f5491a564b7debb3ffdd8717928d315d12e0d7defa9e43b723"},
+    {file = "cryptography-45.0.4-cp37-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:6a5bf57554e80f75a7db3d4b1dacaa2764611ae166ab42ea9a72bcdb5d577637"},
+    {file = "cryptography-45.0.4-cp37-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:46cf7088bf91bdc9b26f9c55636492c1cce3e7aaf8041bbf0243f5e5325cfb2d"},
+    {file = "cryptography-45.0.4-cp37-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:7bedbe4cc930fa4b100fc845ea1ea5788fcd7ae9562e669989c11618ae8d76ee"},
+    {file = "cryptography-45.0.4-cp37-abi3-manylinux_2_28_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:eaa3e28ea2235b33220b949c5a0d6cf79baa80eab2eb5607ca8ab7525331b9ff"},
+    {file = "cryptography-45.0.4-cp37-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:7ef2dde4fa9408475038fc9aadfc1fb2676b174e68356359632e980c661ec8f6"},
+    {file = "cryptography-45.0.4-cp37-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:6a3511ae33f09094185d111160fd192c67aa0a2a8d19b54d36e4c78f651dc5ad"},
+    {file = "cryptography-45.0.4-cp37-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:06509dc70dd71fa56eaa138336244e2fbaf2ac164fc9b5e66828fccfd2b680d6"},
+    {file = "cryptography-45.0.4-cp37-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:5f31e6b0a5a253f6aa49be67279be4a7e5a4ef259a9f33c69f7d1b1191939872"},
+    {file = "cryptography-45.0.4-cp37-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:944e9ccf67a9594137f942d5b52c8d238b1b4e46c7a0c2891b7ae6e01e7c80a4"},
+    {file = "cryptography-45.0.4-cp37-abi3-win32.whl", hash = "sha256:c22fe01e53dc65edd1945a2e6f0015e887f84ced233acecb64b4daadb32f5c97"},
+    {file = "cryptography-45.0.4-cp37-abi3-win_amd64.whl", hash = "sha256:627ba1bc94f6adf0b0a2e35d87020285ead22d9f648c7e75bb64f367375f3b22"},
+    {file = "cryptography-45.0.4-pp310-pypy310_pp73-macosx_10_9_x86_64.whl", hash = "sha256:a77c6fb8d76e9c9f99f2f3437c1a4ac287b34eaf40997cfab1e9bd2be175ac39"},
+    {file = "cryptography-45.0.4-pp310-pypy310_pp73-manylinux_2_28_aarch64.whl", hash = "sha256:7aad98a25ed8ac917fdd8a9c1e706e5a0956e06c498be1f713b61734333a4507"},
+    {file = "cryptography-45.0.4-pp310-pypy310_pp73-manylinux_2_28_x86_64.whl", hash = "sha256:3530382a43a0e524bc931f187fc69ef4c42828cf7d7f592f7f249f602b5a4ab0"},
+    {file = "cryptography-45.0.4-pp310-pypy310_pp73-manylinux_2_34_aarch64.whl", hash = "sha256:6b613164cb8425e2f8db5849ffb84892e523bf6d26deb8f9bb76ae86181fa12b"},
+    {file = "cryptography-45.0.4-pp310-pypy310_pp73-manylinux_2_34_x86_64.whl", hash = "sha256:96d4819e25bf3b685199b304a0029ce4a3caf98947ce8a066c9137cc78ad2c58"},
+    {file = "cryptography-45.0.4-pp310-pypy310_pp73-win_amd64.whl", hash = "sha256:b97737a3ffbea79eebb062eb0d67d72307195035332501722a9ca86bab9e3ab2"},
+    {file = "cryptography-45.0.4-pp311-pypy311_pp73-macosx_10_9_x86_64.whl", hash = "sha256:4828190fb6c4bcb6ebc6331f01fe66ae838bb3bd58e753b59d4b22eb444b996c"},
+    {file = "cryptography-45.0.4-pp311-pypy311_pp73-manylinux_2_28_aarch64.whl", hash = "sha256:03dbff8411206713185b8cebe31bc5c0eb544799a50c09035733716b386e61a4"},
+    {file = "cryptography-45.0.4-pp311-pypy311_pp73-manylinux_2_28_x86_64.whl", hash = "sha256:51dfbd4d26172d31150d84c19bbe06c68ea4b7f11bbc7b3a5e146b367c311349"},
+    {file = "cryptography-45.0.4-pp311-pypy311_pp73-manylinux_2_34_aarch64.whl", hash = "sha256:0339a692de47084969500ee455e42c58e449461e0ec845a34a6a9b9bf7df7fb8"},
+    {file = "cryptography-45.0.4-pp311-pypy311_pp73-manylinux_2_34_x86_64.whl", hash = "sha256:0cf13c77d710131d33e63626bd55ae7c0efb701ebdc2b3a7952b9b23a0412862"},
+    {file = "cryptography-45.0.4-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:bbc505d1dc469ac12a0a064214879eac6294038d6b24ae9f71faae1448a9608d"},
+    {file = "cryptography-45.0.4.tar.gz", hash = "sha256:7405ade85c83c37682c8fe65554759800a4a8c54b2d96e0f8ad114d31b808d57"},
+]
+
+[package.dependencies]
+cffi = {version = ">=1.14", markers = "platform_python_implementation != \"PyPy\""}
+
+[package.extras]
+docs = ["sphinx (>=5.3.0)", "sphinx-inline-tabs ; python_full_version >= \"3.8.0\"", "sphinx-rtd-theme (>=3.0.0) ; python_full_version >= \"3.8.0\""]
+docstest = ["pyenchant (>=3)", "readme-renderer (>=30.0)", "sphinxcontrib-spelling (>=7.3.1)"]
+nox = ["nox (>=2024.4.15)", "nox[uv] (>=2024.3.2) ; python_full_version >= \"3.8.0\""]
+pep8test = ["check-sdist ; python_full_version >= \"3.8.0\"", "click (>=8.0.1)", "mypy (>=1.4)", "ruff (>=0.3.6)"]
+sdist = ["build (>=1.0.0)"]
+ssh = ["bcrypt (>=3.1.5)"]
+test = ["certifi (>=2024)", "cryptography-vectors (==45.0.4)", "pretend (>=0.7)", "pytest (>=7.4.0)", "pytest-benchmark (>=4.0)", "pytest-cov (>=2.10.1)", "pytest-xdist (>=3.5.0)"]
+test-randomorder = ["pytest-randomly"]
+
+[[package]]
 name = "distlib"
 version = "0.3.9"
 description = "Distribution utilities"
@@ -403,10 +584,10 @@ typing = ["typing-extensions (>=4.12.2) ; python_version < \"3.11\""]
 name = "greenlet"
 version = "3.2.3"
 description = "Lightweight in-process concurrent programming"
-optional = true
+optional = false
 python-versions = ">=3.9"
-groups = ["main"]
-markers = "python_version < \"3.14\" and (platform_machine == \"aarch64\" or platform_machine == \"ppc64le\" or platform_machine == \"x86_64\" or platform_machine == \"amd64\" or platform_machine == \"AMD64\" or platform_machine == \"win32\" or platform_machine == \"WIN32\") and extra == \"sqlalchemy\""
+groups = ["main", "dev"]
+markers = "python_version < \"3.14\" and (platform_machine == \"aarch64\" or platform_machine == \"ppc64le\" or platform_machine == \"x86_64\" or platform_machine == \"amd64\" or platform_machine == \"AMD64\" or platform_machine == \"win32\" or platform_machine == \"WIN32\")"
 files = [
     {file = "greenlet-3.2.3-cp310-cp310-macosx_11_0_universal2.whl", hash = "sha256:1afd685acd5597349ee6d7a88a8bec83ce13c106ac78c196ee9dde7c04fe87be"},
     {file = "greenlet-3.2.3-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:761917cac215c61e9dc7324b2606107b3b292a8349bdebb31503ab4de3f559ac"},
@@ -616,6 +797,18 @@ MarkupSafe = ">=2.0"
 i18n = ["Babel (>=2.7)"]
 
 [[package]]
+name = "jmespath"
+version = "1.0.1"
+description = "JSON Matching Expressions"
+optional = false
+python-versions = ">=3.7"
+groups = ["dev"]
+files = [
+    {file = "jmespath-1.0.1-py3-none-any.whl", hash = "sha256:02e2e4cc71b5bcab88332eebf907519190dd9e6e82107fa7f83b1003a6252980"},
+    {file = "jmespath-1.0.1.tar.gz", hash = "sha256:90261b206d6defd58fdd5e85f478bf633a2901798906be2ad389150c5c60edbe"},
+]
+
+[[package]]
 name = "markdown-it-py"
 version = "3.0.0"
 description = "Python port of markdown-it. Markdown parsing, done right!"
@@ -722,6 +915,52 @@ files = [
     {file = "mdurl-0.1.2-py3-none-any.whl", hash = "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8"},
     {file = "mdurl-0.1.2.tar.gz", hash = "sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba"},
 ]
+
+[[package]]
+name = "moto"
+version = "5.1.5"
+description = "A library that allows you to easily mock out tests based on AWS infrastructure"
+optional = false
+python-versions = ">=3.9"
+groups = ["dev"]
+files = [
+    {file = "moto-5.1.5-py3-none-any.whl", hash = "sha256:866ae85eb5efe11a78f991127531878fd7f49177eb4a6680f47060430eb8932d"},
+    {file = "moto-5.1.5.tar.gz", hash = "sha256:42b362ea9a16181e8e7b615ac212c294b882f020e9ae02f01230f167926df84e"},
+]
+
+[package.dependencies]
+boto3 = ">=1.9.201"
+botocore = ">=1.20.88,<1.35.45 || >1.35.45,<1.35.46 || >1.35.46"
+cryptography = ">=35.0.0"
+Jinja2 = ">=2.10.1"
+python-dateutil = ">=2.1,<3.0.0"
+requests = ">=2.5"
+responses = ">=0.15.0,<0.25.5 || >0.25.5"
+werkzeug = ">=0.5,<2.2.0 || >2.2.0,<2.2.1 || >2.2.1"
+xmltodict = "*"
+
+[package.extras]
+all = ["PyYAML (>=5.1)", "antlr4-python3-runtime", "aws-xray-sdk (>=0.93,!=0.96)", "cfn-lint (>=0.40.0)", "docker (>=3.0.0)", "graphql-core", "joserfc (>=0.9.0)", "jsonpath_ng", "jsonschema", "multipart", "openapi-spec-validator (>=0.5.0)", "py-partiql-parser (==0.6.1)", "pyparsing (>=3.0.7)", "setuptools"]
+apigateway = ["PyYAML (>=5.1)", "joserfc (>=0.9.0)", "openapi-spec-validator (>=0.5.0)"]
+apigatewayv2 = ["PyYAML (>=5.1)", "openapi-spec-validator (>=0.5.0)"]
+appsync = ["graphql-core"]
+awslambda = ["docker (>=3.0.0)"]
+batch = ["docker (>=3.0.0)"]
+cloudformation = ["PyYAML (>=5.1)", "aws-xray-sdk (>=0.93,!=0.96)", "cfn-lint (>=0.40.0)", "docker (>=3.0.0)", "graphql-core", "joserfc (>=0.9.0)", "openapi-spec-validator (>=0.5.0)", "py-partiql-parser (==0.6.1)", "pyparsing (>=3.0.7)", "setuptools"]
+cognitoidp = ["joserfc (>=0.9.0)"]
+dynamodb = ["docker (>=3.0.0)", "py-partiql-parser (==0.6.1)"]
+dynamodbstreams = ["docker (>=3.0.0)", "py-partiql-parser (==0.6.1)"]
+events = ["jsonpath_ng"]
+glue = ["pyparsing (>=3.0.7)"]
+proxy = ["PyYAML (>=5.1)", "antlr4-python3-runtime", "aws-xray-sdk (>=0.93,!=0.96)", "cfn-lint (>=0.40.0)", "docker (>=2.5.1)", "graphql-core", "joserfc (>=0.9.0)", "jsonpath_ng", "multipart", "openapi-spec-validator (>=0.5.0)", "py-partiql-parser (==0.6.1)", "pyparsing (>=3.0.7)", "setuptools"]
+quicksight = ["jsonschema"]
+resourcegroupstaggingapi = ["PyYAML (>=5.1)", "cfn-lint (>=0.40.0)", "docker (>=3.0.0)", "graphql-core", "joserfc (>=0.9.0)", "openapi-spec-validator (>=0.5.0)", "py-partiql-parser (==0.6.1)", "pyparsing (>=3.0.7)"]
+s3 = ["PyYAML (>=5.1)", "py-partiql-parser (==0.6.1)"]
+s3crc32c = ["PyYAML (>=5.1)", "crc32c", "py-partiql-parser (==0.6.1)"]
+server = ["PyYAML (>=5.1)", "antlr4-python3-runtime", "aws-xray-sdk (>=0.93,!=0.96)", "cfn-lint (>=0.40.0)", "docker (>=3.0.0)", "flask (!=2.2.0,!=2.2.1)", "flask-cors", "graphql-core", "joserfc (>=0.9.0)", "jsonpath_ng", "openapi-spec-validator (>=0.5.0)", "py-partiql-parser (==0.6.1)", "pyparsing (>=3.0.7)", "setuptools"]
+ssm = ["PyYAML (>=5.1)"]
+stepfunctions = ["antlr4-python3-runtime", "jsonpath_ng"]
+xray = ["aws-xray-sdk (>=0.93,!=0.96)", "setuptools"]
 
 [[package]]
 name = "mypy"
@@ -1078,6 +1317,19 @@ files = [
 
 [package.dependencies]
 numpy = ">=1.16.6"
+
+[[package]]
+name = "pycparser"
+version = "2.22"
+description = "C parser in Python"
+optional = false
+python-versions = ">=3.8"
+groups = ["dev"]
+markers = "platform_python_implementation != \"PyPy\""
+files = [
+    {file = "pycparser-2.22-py3-none-any.whl", hash = "sha256:c3702b6d3dd8c7abc1afa565d7e63d53a1d0bd86cdc24edd75470f4de499cfcc"},
+    {file = "pycparser-2.22.tar.gz", hash = "sha256:491c8be9c040f5390f5bf44a5b07752bd07f56edf992381b05c701439eec10f6"},
+]
 
 [[package]]
 name = "pydantic"
@@ -1512,6 +1764,24 @@ files = [
 ]
 
 [[package]]
+name = "s3transfer"
+version = "0.13.0"
+description = "An Amazon S3 Transfer Manager"
+optional = false
+python-versions = ">=3.9"
+groups = ["dev"]
+files = [
+    {file = "s3transfer-0.13.0-py3-none-any.whl", hash = "sha256:0148ef34d6dd964d0d8cf4311b2b21c474693e57c2e069ec708ce043d2b527be"},
+    {file = "s3transfer-0.13.0.tar.gz", hash = "sha256:f5e6db74eb7776a37208001113ea7aa97695368242b364d73e91c981ac522177"},
+]
+
+[package.dependencies]
+botocore = ">=1.37.4,<2.0a.0"
+
+[package.extras]
+crt = ["botocore[crt] (>=1.37.4,<2.0a.0)"]
+
+[[package]]
 name = "shellingham"
 version = "1.5.4"
 description = "Tool to Detect Surrounding Shell"
@@ -1753,10 +2023,9 @@ test = ["pytest"]
 name = "sqlalchemy"
 version = "2.0.41"
 description = "Database Abstraction Library"
-optional = true
+optional = false
 python-versions = ">=3.7"
-groups = ["main"]
-markers = "extra == \"sqlalchemy\""
+groups = ["main", "dev"]
 files = [
     {file = "SQLAlchemy-2.0.41-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:6854175807af57bdb6425e47adbce7d20a4d79bbfd6f6d6519cd10bb7109a7f8"},
     {file = "SQLAlchemy-2.0.41-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:05132c906066142103b83d9c250b60508af556982a385d96c4eaa9fb9720ac2b"},
@@ -2016,6 +2285,36 @@ platformdirs = ">=3.9.1,<5"
 docs = ["furo (>=2023.7.26)", "proselint (>=0.13)", "sphinx (>=7.1.2,!=7.3)", "sphinx-argparse (>=0.4)", "sphinxcontrib-towncrier (>=0.2.1a0)", "towncrier (>=23.6)"]
 test = ["covdefaults (>=2.3)", "coverage (>=7.2.7)", "coverage-enable-subprocess (>=1)", "flaky (>=3.7)", "packaging (>=23.1)", "pytest (>=7.4)", "pytest-env (>=0.8.2)", "pytest-freezer (>=0.4.8) ; platform_python_implementation == \"PyPy\" or platform_python_implementation == \"GraalVM\" or platform_python_implementation == \"CPython\" and sys_platform == \"win32\" and python_version >= \"3.13\"", "pytest-mock (>=3.11.1)", "pytest-randomly (>=3.12)", "pytest-timeout (>=2.1)", "setuptools (>=68)", "time-machine (>=2.10) ; platform_python_implementation == \"CPython\""]
 
+[[package]]
+name = "werkzeug"
+version = "3.1.3"
+description = "The comprehensive WSGI web application library."
+optional = false
+python-versions = ">=3.9"
+groups = ["dev"]
+files = [
+    {file = "werkzeug-3.1.3-py3-none-any.whl", hash = "sha256:54b78bf3716d19a65be4fceccc0d1d7b89e608834989dfae50ea87564639213e"},
+    {file = "werkzeug-3.1.3.tar.gz", hash = "sha256:60723ce945c19328679790e3282cc758aa4a6040e4bb330f53d30fa546d44746"},
+]
+
+[package.dependencies]
+MarkupSafe = ">=2.1.1"
+
+[package.extras]
+watchdog = ["watchdog (>=2.3)"]
+
+[[package]]
+name = "xmltodict"
+version = "0.14.2"
+description = "Makes working with XML feel like you are working with JSON"
+optional = false
+python-versions = ">=3.6"
+groups = ["dev"]
+files = [
+    {file = "xmltodict-0.14.2-py2.py3-none-any.whl", hash = "sha256:20cc7d723ed729276e808f26fb6b3599f786cbc37e06c65e192ba77c40f20aac"},
+    {file = "xmltodict-0.14.2.tar.gz", hash = "sha256:201e7c28bb210e374999d1dde6382923ab0ed1a8a5faeece48ab525b7810a553"},
+]
+
 [extras]
 airflow = []
 pandas = ["pandas"]
@@ -2025,4 +2324,4 @@ sqlalchemy = ["SQLAlchemy"]
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.10"
-content-hash = "d58eb4add7cb4b30a59b39cd503afae50ef463a896af6fef2c92f9f4b5c0151f"
+content-hash = "fbb248e438b1fdafe57bb25f2bb4dc27ae0bbb9c0813a3e3908ca8e9916b05f4"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,6 +69,9 @@ isort = "^6.0.1"
 sphinx = "^6.2.0"
 sphinx-autodoc-typehints = "*"
 sphinx-rtd-theme = "^3.0.2"
+boto3 = "^1.34"
+moto = "^5.0"
+sqlalchemy = "^2.0"
 
 [build-system]
 requires = ["poetry-core>=2.0.0,<3.0.0"]

--- a/tests/integration/test_cli_integration.py
+++ b/tests/integration/test_cli_integration.py
@@ -1,0 +1,97 @@
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import imednet.cli as cli
+import pytest
+from typer.testing import CliRunner
+
+
+def test_cli_rejects_missing_credentials(monkeypatch: pytest.MonkeyPatch) -> None:
+    runner = CliRunner()
+    monkeypatch.delenv("IMEDNET_API_KEY", raising=False)
+    monkeypatch.delenv("IMEDNET_SECURITY_KEY", raising=False)
+
+    result = runner.invoke(cli.app, ["studies", "list"])
+
+    assert result.exit_code == 1
+    assert "IMEDNET_API_KEY" in result.stdout
+
+
+def test_studies_list_success(monkeypatch: pytest.MonkeyPatch) -> None:
+    runner = CliRunner()
+    monkeypatch.setenv("IMEDNET_API_KEY", "k")
+    monkeypatch.setenv("IMEDNET_SECURITY_KEY", "s")
+
+    sdk = MagicMock()
+    sdk.studies.list.return_value = ["study1"]
+    monkeypatch.setattr(cli, "get_sdk", MagicMock(return_value=sdk))
+
+    result = runner.invoke(cli.app, ["studies", "list"])
+
+    assert result.exit_code == 0
+    sdk.studies.list.assert_called_once_with()
+    assert "study1" in result.stdout
+
+
+def test_records_list_output_csv(monkeypatch: pytest.MonkeyPatch) -> None:
+    runner = CliRunner()
+    monkeypatch.setenv("IMEDNET_API_KEY", "k")
+    monkeypatch.setenv("IMEDNET_SECURITY_KEY", "s")
+
+    record = MagicMock()
+    record.model_dump.return_value = {"id": 1}
+    sdk = MagicMock()
+    sdk.records.list.return_value = [record]
+    monkeypatch.setattr(cli, "get_sdk", MagicMock(return_value=sdk))
+
+    with runner.isolated_filesystem():
+        result = runner.invoke(cli.app, ["records", "list", "ST", "--output", "csv"])
+        assert result.exit_code == 0
+        assert Path("records.csv").exists()
+    sdk.records.list.assert_called_once_with("ST")
+
+
+def test_extract_records_cli_parses_filters(monkeypatch: pytest.MonkeyPatch) -> None:
+    runner = CliRunner()
+    monkeypatch.setenv("IMEDNET_API_KEY", "k")
+    monkeypatch.setenv("IMEDNET_SECURITY_KEY", "s")
+
+    workflow = MagicMock()
+    workflow.extract_records_by_criteria.return_value = [1]
+    monkeypatch.setattr(cli, "DataExtractionWorkflow", MagicMock(return_value=workflow))
+    monkeypatch.setattr(cli, "get_sdk", MagicMock(return_value=MagicMock()))
+
+    result = runner.invoke(
+        cli.app,
+        [
+            "workflows",
+            "extract-records",
+            "ST",
+            "--record-filter",
+            "form_key=DEMOG",
+            "--subject-filter",
+            "subject_status=Screened",
+            "--visit-filter",
+            "visit_key=BASE",
+        ],
+    )
+
+    assert result.exit_code == 0
+    workflow.extract_records_by_criteria.assert_called_once_with(
+        study_key="ST",
+        record_filter={"form_key": "DEMOG"},
+        subject_filter={"subject_status": "Screened"},
+        visit_filter={"visit_key": "BASE"},
+    )
+
+
+def test_invalid_filter_string(monkeypatch: pytest.MonkeyPatch) -> None:
+    runner = CliRunner()
+    monkeypatch.setenv("IMEDNET_API_KEY", "k")
+    monkeypatch.setenv("IMEDNET_SECURITY_KEY", "s")
+    monkeypatch.setattr(cli, "get_sdk", MagicMock(return_value=MagicMock()))
+
+    result = runner.invoke(cli.app, ["subjects", "list", "ST", "--filter", "badfilter"])
+
+    assert result.exit_code == 1
+    assert "Invalid filter format" in result.stdout

--- a/tests/integration/test_core_client_integration.py
+++ b/tests/integration/test_core_client_integration.py
@@ -1,0 +1,57 @@
+import httpx
+import pytest
+import respx
+from imednet.core import exceptions
+from imednet.core.client import Client
+
+
+@respx.mock
+def test_successful_get_sync_client():
+    client = Client("k", "s", base_url="https://api.test")
+    respx.get("https://api.test/api/v1/edc/studies").respond(status_code=200, json={"data": [1]})
+
+    resp = client.get("/api/v1/edc/studies")
+
+    assert resp.status_code == 200
+    assert resp.json() == {"data": [1]}
+
+
+@respx.mock
+def test_retry_on_transient_500():
+    client = Client("k", "s", base_url="https://api.test", retries=3)
+    call_count = {"n": 0}
+
+    def responder(request):
+        call_count["n"] += 1
+        if call_count["n"] < 3:
+            raise httpx.ReadTimeout("boom", request=request)
+        return httpx.Response(200, json={"ok": True})
+
+    respx.get("https://api.test/api/v1/edc/studies").mock(side_effect=responder)
+
+    resp = client.get("/api/v1/edc/studies")
+
+    assert resp.status_code == 200
+    assert call_count["n"] == 3
+
+
+@respx.mock
+def test_authentication_error():
+    client = Client("k", "s", base_url="https://api.test")
+    respx.get("https://api.test/protected").respond(status_code=401, json={})
+
+    with pytest.raises(exceptions.AuthenticationError):
+        client.get("/protected")
+
+
+@respx.mock
+def test_timeout_handling():
+    client = Client("k", "s", base_url="https://api.test", timeout=1, retries=1)
+
+    def slow(request):
+        raise httpx.ReadTimeout("timeout", request=request)
+
+    respx.get("https://api.test/slow").mock(side_effect=slow)
+
+    with pytest.raises(httpx.ReadTimeout):
+        client.get("/slow")

--- a/tests/integration/test_endpoints_integration.py
+++ b/tests/integration/test_endpoints_integration.py
@@ -1,0 +1,75 @@
+import httpx
+import pytest
+import respx
+from imednet.async_sdk import AsyncImednetSDK
+from imednet.sdk import ImednetSDK
+
+
+@respx.mock
+def test_studies_list_pagination():
+    sdk = ImednetSDK(api_key="k", security_key="s", base_url="https://api.test")
+    calls = []
+
+    def responder(request):
+        calls.append(dict(request.url.params))
+        if len(calls) == 1:
+            return httpx.Response(
+                200,
+                json={
+                    "data": [{"studyKey": "S1"}],
+                    "pagination": {"totalPages": 2},
+                },
+            )
+        return httpx.Response(
+            200,
+            json={
+                "data": [{"studyKey": "S2"}],
+                "pagination": {"totalPages": 2},
+            },
+        )
+
+    respx.get("https://api.test/api/v1/edc/studies").mock(side_effect=responder)
+
+    studies = sdk.studies.list()
+
+    assert [s.study_key for s in studies] == ["S1", "S2"]
+    assert calls[0] == {"page": "0", "size": "100"}
+    assert calls[1] == {"page": "1", "size": "100"}
+
+
+@respx.mock
+def test_records_list_filter_param():
+    sdk = ImednetSDK(api_key="k", security_key="s", base_url="https://api.test")
+
+    route = respx.get("https://api.test/api/v1/edc/studies/ST/records").respond(
+        json={"data": [{"recordId": 1}]}
+    )
+
+    records = sdk.records.list("ST", status="Open")
+
+    sent = route.calls.last.request
+    assert sent.url.params["filter"] == "status==Open;studyKey==ST"
+    assert records[0].record_id == 1
+
+
+@respx.mock
+@pytest.mark.asyncio
+async def test_async_endpoint_mirror():
+    sync_sdk = ImednetSDK(api_key="k", security_key="s", base_url="https://api.test")
+    async_sdk = AsyncImednetSDK(api_key="k", security_key="s", base_url="https://api.test")
+
+    respx.get("https://api.test/api/v1/edc/studies/S1/sites").mock(
+        side_effect=[
+            httpx.Response(200, json={"data": [{"siteId": 1}]}),
+            httpx.Response(200, json={"data": [{"siteId": 1}]}),
+        ]
+    )
+
+    sync_res = sync_sdk.sites.list("S1")
+    async_res = await async_sdk.sites.async_list("S1")
+
+    await async_sdk.aclose()
+
+    assert [s.site_id for s in sync_res] == [1]
+    assert [s.site_id for s in async_res] == [1]
+    assert [s.site_id for s in sync_res] == [s.site_id for s in async_res]

--- a/tests/integration/test_export_airflow_integration.py
+++ b/tests/integration/test_export_airflow_integration.py
@@ -1,0 +1,67 @@
+import sys
+from types import ModuleType, SimpleNamespace
+from unittest.mock import MagicMock
+
+import pandas as pd
+from imednet.integrations import export as export_mod
+
+
+def test_export_to_csv_and_sql(tmp_path, monkeypatch):
+    df = pd.DataFrame({"a": [1]})
+    df.to_sql = MagicMock()
+    mapper_inst = MagicMock(dataframe=MagicMock(return_value=df))
+    monkeypatch.setattr(export_mod, "RecordMapper", MagicMock(return_value=mapper_inst))
+
+    out_csv = tmp_path / "out.csv"
+    export_mod.export_to_csv(MagicMock(), "S", str(out_csv))
+    assert out_csv.exists()
+
+    sa_module = ModuleType("sqlalchemy")
+    engine = MagicMock()
+    sa_module.create_engine = MagicMock(return_value=engine)
+    monkeypatch.setitem(sys.modules, "sqlalchemy", sa_module)
+
+    export_mod.export_to_sql(MagicMock(), "S", "t", "sqlite://")
+    sa_module.create_engine.assert_called_once_with("sqlite://")
+    df.to_sql.assert_called_once()
+
+
+def test_imednet_export_operator(monkeypatch):
+    airflow = ModuleType("airflow")
+    hooks_pkg = ModuleType("airflow.hooks")
+    hooks_base = ModuleType("airflow.hooks.base")
+    models_mod = ModuleType("airflow.models")
+
+    class DummyBaseHook:
+        @classmethod
+        def get_connection(cls, conn_id):
+            return SimpleNamespace(login="K", password="S", extra_dejson={})
+
+    class DummyBaseOperator:
+        template_fields = ()
+
+        def __init__(self, **kwargs):
+            pass
+
+    hooks_base.BaseHook = DummyBaseHook
+    models_mod.BaseOperator = DummyBaseOperator
+    hooks_pkg.base = hooks_base
+    airflow.hooks = hooks_pkg
+    airflow.models = models_mod
+    monkeypatch.setitem(sys.modules, "airflow", airflow)
+    monkeypatch.setitem(sys.modules, "airflow.hooks", hooks_pkg)
+    monkeypatch.setitem(sys.modules, "airflow.hooks.base", hooks_base)
+    monkeypatch.setitem(sys.modules, "airflow.models", models_mod)
+
+    from imednet.integrations.airflow import ImednetExportOperator
+
+    hook = MagicMock(get_conn=MagicMock(return_value=MagicMock()))
+    monkeypatch.setattr("imednet.integrations.airflow.ImednetHook", MagicMock(return_value=hook))
+    monkeypatch.setattr(export_mod, "export_to_csv", MagicMock())
+
+    op = ImednetExportOperator(task_id="t", study_key="S", output_path="p")
+    result = op.execute({})
+
+    export_mod.export_to_csv.assert_called_once_with(hook.get_conn(), "S", "p")
+    assert result == "p"
+    sys.modules.pop("imednet.integrations.airflow", None)

--- a/tests/integration/test_export_airflow_integration.py
+++ b/tests/integration/test_export_airflow_integration.py
@@ -2,28 +2,37 @@ import sys
 from types import ModuleType, SimpleNamespace
 from unittest.mock import MagicMock
 
+import boto3
 import pandas as pd
 from imednet.integrations import export as export_mod
+from moto import mock_aws
 
 
-def test_export_to_csv_and_sql(tmp_path, monkeypatch):
-    df = pd.DataFrame({"a": [1]})
-    df.to_sql = MagicMock()
+def test_export_to_csv(tmp_path, monkeypatch):
+    df = pd.DataFrame({"a": [1, 2]})
     mapper_inst = MagicMock(dataframe=MagicMock(return_value=df))
     monkeypatch.setattr(export_mod, "RecordMapper", MagicMock(return_value=mapper_inst))
 
     out_csv = tmp_path / "out.csv"
     export_mod.export_to_csv(MagicMock(), "S", str(out_csv))
-    assert out_csv.exists()
 
-    sa_module = ModuleType("sqlalchemy")
-    engine = MagicMock()
-    sa_module.create_engine = MagicMock(return_value=engine)
-    monkeypatch.setitem(sys.modules, "sqlalchemy", sa_module)
+    read = pd.read_csv(out_csv)
+    assert len(read) == 2
 
-    export_mod.export_to_sql(MagicMock(), "S", "t", "sqlite://")
-    sa_module.create_engine.assert_called_once_with("sqlite://")
-    df.to_sql.assert_called_once()
+
+def test_export_to_sql(tmp_path, monkeypatch):
+    df = pd.DataFrame({"a": [1, 2]})
+    mapper_inst = MagicMock(dataframe=MagicMock(return_value=df))
+    monkeypatch.setattr(export_mod, "RecordMapper", MagicMock(return_value=mapper_inst))
+
+    db_file = tmp_path / "db.sqlite"
+    export_mod.export_to_sql(MagicMock(), "S", "t", f"sqlite:///{db_file}")
+
+    import sqlalchemy as sa
+
+    eng = sa.create_engine(f"sqlite:///{db_file}")
+    result = pd.read_sql_table("t", eng)
+    assert len(result) == 2
 
 
 def test_imednet_export_operator(monkeypatch):
@@ -65,3 +74,140 @@ def test_imednet_export_operator(monkeypatch):
     export_mod.export_to_csv.assert_called_once_with(hook.get_conn(), "S", "p")
     assert result == "p"
     sys.modules.pop("imednet.integrations.airflow", None)
+
+
+def test_imednet_hook_returns_sdk(monkeypatch):
+    airflow = ModuleType("airflow")
+    hooks_pkg = ModuleType("airflow.hooks")
+    hooks_base = ModuleType("airflow.hooks.base")
+    models_mod = ModuleType("airflow.models")
+
+    class DummyBaseHook:
+        @classmethod
+        def get_connection(cls, conn_id):
+            return SimpleNamespace(
+                login="KEY", password="SEC", extra_dejson={"base_url": "https://x"}
+            )
+
+    class DummyBaseOperator:
+        template_fields = ()
+
+        def __init__(self, **kwargs):
+            pass
+
+    hooks_base.BaseHook = DummyBaseHook
+    models_mod.BaseOperator = DummyBaseOperator
+    hooks_pkg.base = hooks_base
+    airflow.hooks = hooks_pkg
+    airflow.models = models_mod
+    monkeypatch.setitem(sys.modules, "airflow", airflow)
+    monkeypatch.setitem(sys.modules, "airflow.hooks", hooks_pkg)
+    monkeypatch.setitem(sys.modules, "airflow.hooks.base", hooks_base)
+    monkeypatch.setitem(sys.modules, "airflow.models", models_mod)
+
+    from imednet.integrations.airflow import ImednetHook
+
+    hook = ImednetHook()
+    sdk = hook.get_conn()
+
+    assert sdk._client._client.headers["x-api-key"] == "KEY"
+    assert sdk._client._client.headers["x-imn-security-key"] == "SEC"
+    assert sdk._client.base_url == "https://x"
+    sys.modules.pop("imednet.integrations.airflow", None)
+
+
+@mock_aws
+def test_to_s3_operator_uploads(monkeypatch):
+    s3 = boto3.client("s3", region_name="us-east-1")
+    s3.create_bucket(Bucket="bucket")
+
+    airflow = ModuleType("airflow")
+    hooks_pkg = ModuleType("airflow.hooks")
+    hooks_base = ModuleType("airflow.hooks.base")
+    models_mod = ModuleType("airflow.models")
+    providers_mod = ModuleType("airflow.providers")
+    amazon_mod = ModuleType("airflow.providers.amazon")
+    aws_mod = ModuleType("airflow.providers.amazon.aws")
+    hooks_amazon = ModuleType("airflow.providers.amazon.aws.hooks")
+    s3_mod = ModuleType("airflow.providers.amazon.aws.hooks.s3")
+    sensors_pkg = ModuleType("airflow.sensors")
+    sensors_base = ModuleType("airflow.sensors.base")
+    exc_mod = ModuleType("airflow.exceptions")
+
+    class DummyBaseHook:
+        @classmethod
+        def get_connection(cls, conn_id):
+            return SimpleNamespace(login="K", password="S", extra_dejson={})
+
+    class DummyBaseOperator:
+        template_fields = ()
+
+        def __init__(self, **kwargs):
+            pass
+
+    class DummyAirflowException(Exception):
+        pass
+
+    class DummyS3Hook:
+        def __init__(self, aws_conn_id: str = "aws_default") -> None:
+            self.client = s3
+
+        def load_string(self, data: str, key: str, bucket: str, replace: bool = True) -> None:
+            self.client.put_object(Bucket=bucket, Key=key, Body=data)
+
+    class DummySensorOperator:
+        template_fields = ()
+
+        def __init__(self, *a, **kw):
+            pass
+
+    hooks_base.BaseHook = DummyBaseHook
+    models_mod.BaseOperator = DummyBaseOperator
+    s3_mod.S3Hook = DummyS3Hook
+    sensors_base.BaseSensorOperator = DummySensorOperator
+    exc_mod.AirflowException = DummyAirflowException
+
+    hooks_pkg.base = hooks_base
+    airflow.hooks = hooks_pkg
+    airflow.models = models_mod
+    airflow.providers = providers_mod
+    providers_mod.amazon = amazon_mod
+    amazon_mod.aws = aws_mod
+    aws_mod.hooks = hooks_amazon
+    hooks_amazon.s3 = s3_mod
+    airflow.exceptions = exc_mod
+
+    modules = {
+        "airflow": airflow,
+        "airflow.hooks": hooks_pkg,
+        "airflow.hooks.base": hooks_base,
+        "airflow.models": models_mod,
+        "airflow.sensors": sensors_pkg,
+        "airflow.sensors.base": sensors_base,
+        "airflow.providers": providers_mod,
+        "airflow.providers.amazon": amazon_mod,
+        "airflow.providers.amazon.aws": aws_mod,
+        "airflow.providers.amazon.aws.hooks": hooks_amazon,
+        "airflow.providers.amazon.aws.hooks.s3": s3_mod,
+        "airflow.exceptions": exc_mod,
+    }
+    for name, mod in modules.items():
+        monkeypatch.setitem(sys.modules, name, mod)
+
+    import importlib
+
+    from imednet.airflow import operators as ops
+
+    importlib.reload(ops)
+
+    sdk = MagicMock()
+    sdk.records.list.return_value = [SimpleNamespace(model_dump=lambda: {"id": 1})]
+    monkeypatch.setattr(ops, "ImednetSDK", MagicMock(return_value=sdk))
+
+    op = ops.ImednetToS3Operator(task_id="t", study_key="S", s3_bucket="bucket", s3_key="k")
+    result = op.execute({})
+
+    assert result == "k"
+    body = s3.get_object(Bucket="bucket", Key="k")["Body"].read().decode()
+    assert "id" in body
+    sys.modules.pop("imednet.airflow.operators", None)

--- a/tests/integration/test_workflows_integration.py
+++ b/tests/integration/test_workflows_integration.py
@@ -1,0 +1,111 @@
+import re
+import time
+
+import httpx
+import pytest
+import respx
+from imednet.sdk import ImednetSDK
+from imednet.workflows.data_extraction import DataExtractionWorkflow
+from imednet.workflows.query_management import QueryManagementWorkflow
+from imednet.workflows.record_update import RecordUpdateWorkflow
+from imednet.workflows.subject_data import SubjectDataWorkflow
+
+
+@respx.mock
+def test_data_extraction_filters():
+    sdk = ImednetSDK(api_key="k", security_key="s", base_url="https://api.test")
+    respx.get("https://api.test/api/v1/edc/studies/ST/variables").respond(json={"data": []})
+    respx.get("https://api.test/api/v1/edc/studies/ST/subjects").respond(
+        json={"data": [{"subjectKey": "SUB1"}]}
+    )
+    respx.get("https://api.test/api/v1/edc/studies/ST/visits").respond(
+        json={"data": [{"visitId": 1, "subjectKey": "SUB1"}]}
+    )
+    respx.get("https://api.test/api/v1/edc/studies/ST/records").respond(
+        json={
+            "data": [
+                {"recordId": 1, "subjectKey": "SUB1", "visitId": 1, "formId": 10},
+                {"recordId": 2, "subjectKey": "SUB1", "visitId": 2, "formId": 10},
+            ]
+        }
+    )
+
+    wf = DataExtractionWorkflow(sdk)
+    recs = wf.extract_records_by_criteria(
+        "ST",
+        record_filter={"form_id": 10},
+        subject_filter={"status": "active"},
+        visit_filter={"visit_id": 1},
+    )
+
+    assert [r.record_id for r in recs] == [1]
+
+
+@respx.mock
+def test_record_update_submit_and_wait(monkeypatch: pytest.MonkeyPatch):
+    sdk = ImednetSDK(api_key="k", security_key="s", base_url="https://api.test")
+    respx.get(re.compile("https://api.test/api/v1/edc/studies/ST/variables.*")).respond(
+        json={"data": []}
+    )
+    respx.post("https://api.test/api/v1/edc/studies/ST/records").respond(
+        json={"batchId": "B1", "state": "PROCESSING"}
+    )
+    route = respx.get("https://api.test/api/v1/edc/studies/ST/jobs/B1").mock(
+        side_effect=[
+            httpx.Response(200, json={"batchId": "B1", "state": "PROCESSING"}),
+            httpx.Response(200, json={"batchId": "B1", "state": "COMPLETED"}),
+        ]
+    )
+    monkeypatch.setattr(time, "sleep", lambda *_: None)
+
+    wf = RecordUpdateWorkflow(sdk)
+    job = wf.submit_record_batch(
+        "ST", [{"formKey": "F1", "data": {"x": 1}}], wait_for_completion=True, poll_interval=0
+    )
+
+    assert job.state == "COMPLETED"
+    assert route.call_count == 2
+
+
+@respx.mock
+def test_subject_data_aggregation():
+    sdk = ImednetSDK(api_key="k", security_key="s", base_url="https://api.test")
+    respx.get("https://api.test/api/v1/edc/studies/ST/subjects").respond(
+        json={"data": [{"subjectKey": "SUB1"}]}
+    )
+    respx.get("https://api.test/api/v1/edc/studies/ST/visits").respond(
+        json={"data": [{"visitId": 1, "subjectKey": "SUB1"}]}
+    )
+    respx.get("https://api.test/api/v1/edc/studies/ST/records").respond(
+        json={"data": [{"recordId": 1, "subjectKey": "SUB1", "visitId": 1, "formId": 10}]}
+    )
+    respx.get("https://api.test/api/v1/edc/studies/ST/queries").respond(
+        json={"data": [{"queryComments": [{"sequence": 1, "closed": False}]}]}
+    )
+
+    wf = SubjectDataWorkflow(sdk)
+    data = wf.get_all_subject_data("ST", "SUB1")
+
+    assert data.subject_details.subject_key == "SUB1"
+    assert len(data.visits) == 1
+    assert len(data.records) == 1
+    assert len(data.queries) == 1
+
+
+@respx.mock
+def test_query_management_counts():
+    sdk = ImednetSDK(api_key="k", security_key="s", base_url="https://api.test")
+    respx.get("https://api.test/api/v1/edc/studies/ST/queries").respond(
+        json={
+            "data": [
+                {"queryComments": [{"sequence": 1, "closed": False}]},
+                {"queryComments": [{"sequence": 1, "closed": True}]},
+                {"queryComments": []},
+            ]
+        }
+    )
+
+    wf = QueryManagementWorkflow(sdk)
+    counts = wf.get_query_state_counts("ST")
+
+    assert counts == {"open": 1, "closed": 1, "unknown": 1}


### PR DESCRIPTION
## Summary
- add integration test folder
- test core Client behavior for GET, retries, auth, and timeouts
- verify SDK endpoints for pagination, filter params, and async parity

## Testing
- `poetry run ruff check --fix .`
- `poetry run black --check .`
- `poetry run mypy imednet`
- `poetry run pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684c43835614832cb06cbfda6f8e862b