### PR TITLE
Add architecture diagram

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,6 +176,7 @@ imednet subjects list --help
 
 - See the full API reference in the [HTML docs](docs/_build/html/index.html).
 - More examples can be found in the `imednet/examples/` directory.
+- An architecture diagram is available in `docs/architecture.rst`.
 
 ### Airflow Integration
 

--- a/docs/architecture.rst
+++ b/docs/architecture.rst
@@ -1,0 +1,15 @@
+Architecture Overview
+=====================
+
+The SDK is organized around a core HTTP client, endpoint wrappers, higher level workflows,
+and a command line interface. The diagram below illustrates how these pieces interact.
+
+.. mermaid::
+
+   graph TD
+       CLI[CLI] --> |uses| Workflows
+       CLI --> |calls| SDK
+       Workflows --> |call| SDK
+       SDK --> |wraps| Endpoints
+       Endpoints --> |use| HTTPClient
+

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -7,6 +7,7 @@ Welcome to imednet-sdk's documentation!
 
    logging_and_tracing
    api_overview
+   architecture
    cli
    airflow
    live_test_plan


### PR DESCRIPTION
## Summary
- document SDK architecture with a Mermaid diagram
- link new architecture page from docs index
- mention architecture diagram in README

## Testing
- `poetry run ruff check --fix .`
- `poetry run black --check .`
- `poetry run mypy imednet`
- `poetry run pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684c707e61a8832c83eecb8ad4d032b5