### PR TITLE
Add pip-audit to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,9 @@ jobs:
       - name: Install deps
         run: |
           poetry install --with dev
+      - name: Security audit
+        run: |
+          poetry run pip-audit -s osv
       - name: Format code
         run: |
           poetry run black .


### PR DESCRIPTION
## Summary
- audit Python dependencies in CI using `pip-audit`

## Testing
- `poetry run ruff check --fix .`
- `poetry run black --check .`
- `poetry run mypy imednet`
- `poetry run pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684c763a8a8c832cb5215bdc59ee16c1