### PR TITLE
Update ruff config and rename endpoint path constants

### DIFF
--- a/imednet/endpoints/base.py
+++ b/imednet/endpoints/base.py
@@ -16,7 +16,7 @@ class BaseEndpoint:
     Handles context injection and filtering.
     """
 
-    path: str  # to be set in subclasses
+    PATH: str  # to be set in subclasses
 
     def __init__(
         self,
@@ -36,5 +36,5 @@ class BaseEndpoint:
 
     def _build_path(self, *args: Any) -> str:
         # join path segments after base path
-        segments = [self.path.strip("/")] + [str(a).strip("/") for a in args]
+        segments = [self.PATH.strip("/")] + [str(a).strip("/") for a in args]
         return "/" + "/".join(segments)

--- a/imednet/endpoints/codings.py
+++ b/imednet/endpoints/codings.py
@@ -15,7 +15,7 @@ class CodingsEndpoint(BaseEndpoint):
     Provides methods to list and retrieve individual codings.
     """
 
-    path = "/api/v1/edc/studies"
+    PATH = "/api/v1/edc/studies"
 
     def list(self, study_key: Optional[str] = None, **filters) -> List[Coding]:
         """

--- a/imednet/endpoints/forms.py
+++ b/imednet/endpoints/forms.py
@@ -18,7 +18,7 @@ class FormsEndpoint(BaseEndpoint):
     Provides methods to list and retrieve individual forms.
     """
 
-    path = "/api/v1/edc/studies"
+    PATH = "/api/v1/edc/studies"
 
     def __init__(
         self,

--- a/imednet/endpoints/intervals.py
+++ b/imednet/endpoints/intervals.py
@@ -18,7 +18,7 @@ class IntervalsEndpoint(BaseEndpoint):
     Provides methods to list and retrieve individual intervals.
     """
 
-    path = "/api/v1/edc/studies"
+    PATH = "/api/v1/edc/studies"
 
     def __init__(
         self,

--- a/imednet/endpoints/jobs.py
+++ b/imednet/endpoints/jobs.py
@@ -11,7 +11,7 @@ class JobsEndpoint(BaseEndpoint):
     Provides a method to fetch a job by its batch ID.
     """
 
-    path = "/api/v1/edc/studies"
+    PATH = "/api/v1/edc/studies"
 
     def get(self, study_key: str, batch_id: str) -> JobStatus:
         """

--- a/imednet/endpoints/queries.py
+++ b/imednet/endpoints/queries.py
@@ -15,7 +15,7 @@ class QueriesEndpoint(BaseEndpoint):
     Provides methods to list and retrieve queries.
     """
 
-    path = "/api/v1/edc/studies"
+    PATH = "/api/v1/edc/studies"
 
     def list(self, study_key: Optional[str] = None, **filters) -> List[Query]:
         """

--- a/imednet/endpoints/record_revisions.py
+++ b/imednet/endpoints/record_revisions.py
@@ -15,7 +15,7 @@ class RecordRevisionsEndpoint(BaseEndpoint):
     Provides methods to list and retrieve record revisions.
     """
 
-    path = "/api/v1/edc/studies"
+    PATH = "/api/v1/edc/studies"
 
     def list(self, study_key: Optional[str] = None, **filters) -> List[RecordRevision]:
         """

--- a/imednet/endpoints/records.py
+++ b/imednet/endpoints/records.py
@@ -17,7 +17,7 @@ class RecordsEndpoint(BaseEndpoint):
     Provides methods to list, retrieve, and create records.
     """
 
-    path = "/api/v1/edc/studies"
+    PATH = "/api/v1/edc/studies"
 
     def list(
         self, study_key: Optional[str] = None, record_data_filter: Optional[str] = None, **filters

--- a/imednet/endpoints/sites.py
+++ b/imednet/endpoints/sites.py
@@ -15,7 +15,7 @@ class SitesEndpoint(BaseEndpoint):
     Provides methods to list and retrieve individual sites.
     """
 
-    path = "/api/v1/edc/studies"
+    PATH = "/api/v1/edc/studies"
 
     def list(self, study_key: Optional[str] = None, **filters) -> List[Site]:
         """

--- a/imednet/endpoints/studies.py
+++ b/imednet/endpoints/studies.py
@@ -18,7 +18,7 @@ class StudiesEndpoint(BaseEndpoint):
     Provides methods to list available studies and retrieve specific studies.
     """
 
-    path = "/api/v1/edc/studies"
+    PATH = "/api/v1/edc/studies"
 
     def __init__(
         self,
@@ -46,7 +46,7 @@ class StudiesEndpoint(BaseEndpoint):
         params: Dict[str, Any] = {}
         if filters:
             params["filter"] = build_filter_string(filters)
-        paginator = Paginator(self._client, self.path, params=params)
+        paginator = Paginator(self._client, self.PATH, params=params)
         result = [Study.model_validate(item) for item in paginator]
         if not filters:
             self._studies_cache = result
@@ -63,7 +63,7 @@ class StudiesEndpoint(BaseEndpoint):
         params: Dict[str, Any] = {}
         if filters:
             params["filter"] = build_filter_string(filters)
-        paginator = AsyncPaginator(self._async_client, self.path, params=params)
+        paginator = AsyncPaginator(self._async_client, self.PATH, params=params)
         result = [Study.model_validate(item) async for item in paginator]
         if not filters:
             self._studies_cache = result

--- a/imednet/endpoints/subjects.py
+++ b/imednet/endpoints/subjects.py
@@ -15,7 +15,7 @@ class SubjectsEndpoint(BaseEndpoint):
     Provides methods to list and retrieve individual subjects.
     """
 
-    path = "/api/v1/edc/studies"
+    PATH = "/api/v1/edc/studies"
 
     def list(self, study_key: Optional[str] = None, **filters) -> List[Subject]:
         """

--- a/imednet/endpoints/users.py
+++ b/imednet/endpoints/users.py
@@ -14,7 +14,7 @@ class UsersEndpoint(BaseEndpoint):
     Provides methods to list and retrieve user information.
     """
 
-    path = "/api/v1/edc/studies"
+    PATH = "/api/v1/edc/studies"
 
     def list(self, study_key: Optional[str] = None, include_inactive: bool = False) -> List[User]:
         """

--- a/imednet/endpoints/variables.py
+++ b/imednet/endpoints/variables.py
@@ -18,7 +18,7 @@ class VariablesEndpoint(BaseEndpoint):
     Provides methods to list and retrieve individual variables.
     """
 
-    path = "/api/v1/edc/studies"
+    PATH = "/api/v1/edc/studies"
 
     def __init__(
         self,

--- a/imednet/endpoints/visits.py
+++ b/imednet/endpoints/visits.py
@@ -15,7 +15,7 @@ class VisitsEndpoint(BaseEndpoint):
     Provides methods to list and retrieve individual visits.
     """
 
-    path = "/api/v1/edc/studies"
+    PATH = "/api/v1/edc/studies"
 
     def list(self, study_key: Optional[str] = None, **filters) -> List[Visit]:
         """

--- a/imednet/workflows/record_mapper.py
+++ b/imednet/workflows/record_mapper.py
@@ -81,7 +81,7 @@ class RecordMapper:
                 Field(None, alias=key, description=label_map.get(key, key)),
             )  # Use get for safety
 
-        RecordDataModel: Type[BaseModel] = create_model(
+        record_data_model: Type[BaseModel] = create_model(
             "RecordData",
             __base__=BaseModel,
             **fields,  # type: ignore
@@ -129,7 +129,7 @@ class RecordMapper:
                 # Parse recordData through dynamic model
                 # Ensure record_data is a dict before attempting to parse
                 record_data_dict = r.record_data if isinstance(r.record_data, dict) else {}
-                parsed_data = RecordDataModel(**record_data_dict).model_dump(by_alias=False)
+                parsed_data = record_data_model(**record_data_dict).model_dump(by_alias=False)
                 rows.append({**meta, **parsed_data})
             except (ValidationError, TypeError) as e:
                 parsing_errors += 1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -89,8 +89,11 @@ line-length = 100
 src = ["imednet"]
 
 [tool.ruff.lint]
-select = ["E", "F", "I"]
+select = ["E", "F", "I", "N"]
 ignore = ["D", "ANN", "S101"]
+
+[tool.ruff.lint.pep8-naming]
+classmethod-decorators = ["field_validator", "model_validator"]
 
 [tool.mypy]
 python_version = "3.10"

--- a/tests/integration/test_export_airflow_integration.py
+++ b/tests/integration/test_export_airflow_integration.py
@@ -145,7 +145,7 @@ def test_to_s3_operator_uploads(monkeypatch):
         def __init__(self, **kwargs):
             pass
 
-    class DummyAirflowException(Exception):
+    class DummyAirflowError(Exception):
         pass
 
     class DummyS3Hook:
@@ -165,7 +165,7 @@ def test_to_s3_operator_uploads(monkeypatch):
     models_mod.BaseOperator = DummyBaseOperator
     s3_mod.S3Hook = DummyS3Hook
     sensors_base.BaseSensorOperator = DummySensorOperator
-    exc_mod.AirflowException = DummyAirflowException
+    exc_mod.AirflowException = DummyAirflowError
 
     hooks_pkg.base = hooks_base
     airflow.hooks = hooks_pkg

--- a/tests/unit/test_airflow_operators.py
+++ b/tests/unit/test_airflow_operators.py
@@ -36,10 +36,10 @@ def _setup_airflow(monkeypatch):
     models_mod.BaseOperator = DummyBaseOperator
     sensors_base.BaseSensorOperator = DummySensorOperator
 
-    class DummyAirflowException(Exception):
+    class DummyAirflowError(Exception):
         pass
 
-    exc_mod.AirflowException = DummyAirflowException
+    exc_mod.AirflowException = DummyAirflowError
     s3_mod.S3Hook = MagicMock
 
     hooks_pkg.base = hooks_base

--- a/tests/unit/test_utils_init.py
+++ b/tests/unit/test_utils_init.py
@@ -15,12 +15,12 @@ def test_lazy_load_pandas_functions() -> None:
 
 def test_lazy_load_schema_objects() -> None:
     cache_cls = utils.SchemaCache
-    from imednet.utils.schema import SchemaCache as expected_cache
-    from imednet.utils.schema import SchemaValidator as expected_validator
+    from imednet.utils.schema import SchemaCache as ExpectedCache
+    from imednet.utils.schema import SchemaValidator as ExpectedValidator
     from imednet.utils.schema import validate_record_data as expected_validate
 
-    assert cache_cls is expected_cache
-    assert utils.SchemaValidator is expected_validator
+    assert cache_cls is ExpectedCache
+    assert utils.SchemaValidator is ExpectedValidator
     assert utils.validate_record_data is expected_validate
 
 


### PR DESCRIPTION
## Summary
- enable pep8-naming in ruff and allow pydantic validators
- rename endpoint class paths to `PATH`
- adjust tests and workflow utilities for naming rules

## Testing
- `poetry run ruff check --fix .`
- `poetry run black --check .`
- `poetry run mypy imednet`
- `poetry run pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684c7ed73ee8832c8788077b6407802d