### PR TITLE
Refactor AsyncImednetSDK location

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ Use `AsyncImednetSDK` when working with asyncio:
 
 ```python
 import os
-from imednet.async_sdk import AsyncImednetSDK
+from imednet.sdk import AsyncImednetSDK
 
 async def main():
     study_key = os.getenv("IMEDNET_STUDY_KEY", "your_study_key_here")

--- a/imednet/__init__.py
+++ b/imednet/__init__.py
@@ -1,11 +1,11 @@
 from importlib import metadata as _metadata
 
-from .sdk import ImednetSDK
+from .sdk import AsyncImednetSDK, ImednetSDK
 
 # Provide a backward-compatible alias
 ImednetClient = ImednetSDK
 
-__all__ = ["ImednetSDK", "ImednetClient", "__version__"]
+__all__ = ["ImednetSDK", "AsyncImednetSDK", "ImednetClient", "__version__"]
 
 try:
     __version__: str = _metadata.version("imednet-sdk")

--- a/imednet/async_sdk.py
+++ b/imednet/async_sdk.py
@@ -1,22 +1,9 @@
-"""Asynchronous entry point for the iMednet SDK."""
+import importlib
+import warnings
 
-from __future__ import annotations
-
-from typing import Any
-
-from .sdk import ImednetSDK
-
-
-class AsyncImednetSDK(ImednetSDK):
-    """Async variant of :class:`ImednetSDK` using the async HTTP client."""
-
-    def __init__(self, *args: Any, **kwargs: Any) -> None:  # pragma: no cover - thin wrapper
-        kwargs["enable_async"] = True
-        super().__init__(*args, **kwargs)
-
-    async def __aenter__(self) -> "AsyncImednetSDK":
-        await super().__aenter__()
-        return self
-
-    async def __aexit__(self, exc_type, exc_val, exc_tb) -> None:
-        await super().__aexit__(exc_type, exc_val, exc_tb)
+warnings.warn(
+    "imednet.async_sdk is deprecated; use imednet.sdk instead",
+    DeprecationWarning,
+    stacklevel=2,
+)
+AsyncImednetSDK = importlib.import_module("imednet.sdk").AsyncImednetSDK

--- a/imednet/sdk.py
+++ b/imednet/sdk.py
@@ -295,3 +295,21 @@ class ImednetSDK:
                 raise TimeoutError(f"Timeout ({timeout}s) waiting for job {batch_id}")
 
             time.sleep(interval)
+
+
+class AsyncImednetSDK(ImednetSDK):
+    """Async variant of :class:`ImednetSDK` using the async HTTP client."""
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:  # pragma: no cover - thin wrapper
+        kwargs["enable_async"] = True
+        super().__init__(*args, **kwargs)
+
+    async def __aenter__(self) -> "AsyncImednetSDK":
+        await super().__aenter__()
+        return self
+
+    async def __aexit__(self, exc_type, exc_val, exc_tb) -> None:
+        await super().__aexit__(exc_type, exc_val, exc_tb)
+
+
+__all__ = ["ImednetSDK", "AsyncImednetSDK"]

--- a/tests/integration/test_endpoints_integration.py
+++ b/tests/integration/test_endpoints_integration.py
@@ -1,8 +1,7 @@
 import httpx
 import pytest
 import respx
-from imednet.async_sdk import AsyncImednetSDK
-from imednet.sdk import ImednetSDK
+from imednet.sdk import AsyncImednetSDK, ImednetSDK
 
 
 @respx.mock

--- a/tests/live/test_endpoints_async_live.py
+++ b/tests/live/test_endpoints_async_live.py
@@ -3,8 +3,7 @@ from typing import AsyncIterator, Iterator
 
 import pytest
 import pytest_asyncio
-from imednet.async_sdk import AsyncImednetSDK
-from imednet.sdk import ImednetSDK
+from imednet.sdk import AsyncImednetSDK, ImednetSDK
 
 API_KEY = os.getenv("IMEDNET_API_KEY")
 SECURITY_KEY = os.getenv("IMEDNET_SECURITY_KEY")


### PR DESCRIPTION
## Summary
- fold AsyncImednetSDK into the main SDK module
- deprecate `imednet.async_sdk` with a small shim
- update docs and tests to import from `imednet.sdk`

## Testing
- `poetry run ruff check --fix .`
- `poetry run black --check .`
- `poetry run mypy imednet`
- `poetry run pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684c8b90a5e8832cb10e12f619bd108b