### PR TITLE
Refactor Airflow integration layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,7 +191,7 @@ Example DAG:
 ```python
 from datetime import datetime
 from airflow import DAG
-from imednet.airflow import ImednetToS3Operator, ImednetJobSensor
+from imednet.integrations.airflow import ImednetToS3Operator, ImednetJobSensor
 
 default_args = {"start_date": datetime(2024, 1, 1)}
 

--- a/docs/airflow.rst
+++ b/docs/airflow.rst
@@ -19,7 +19,7 @@ Example DAG
 
    from datetime import datetime
    from airflow import DAG
-   from imednet.airflow import ImednetToS3Operator, ImednetJobSensor
+   from imednet.integrations.airflow import ImednetToS3Operator, ImednetJobSensor
 
    default_args = {"start_date": datetime(2024, 1, 1)}
 

--- a/docs/live_test_plan.rst
+++ b/docs/live_test_plan.rst
@@ -101,7 +101,7 @@ The integration helpers require validation using temporary files or buckets:
 - ``export_to_json``
 - ``export_to_parquet``
 - ``export_to_sql``
-- ``ImednetToS3Operator`` and ``ImednetJobSensor`` from the Airflow module
-- ``ImednetExportOperator`` from the Airflow module
+- ``ImednetToS3Operator`` and ``ImednetJobSensor`` from ``imednet.integrations.airflow``
+- ``ImednetExportOperator`` from ``imednet.integrations.airflow``
 - ``ImednetHook`` for connection retrieval
 

--- a/examples/airflow/imednet_job_sensor_dag.py
+++ b/examples/airflow/imednet_job_sensor_dag.py
@@ -1,6 +1,6 @@
 from datetime import datetime
 
-from imednet.airflow import ImednetJobSensor
+from imednet.integrations.airflow import ImednetJobSensor
 
 from airflow import DAG
 

--- a/examples/airflow/imednet_to_s3_dag.py
+++ b/examples/airflow/imednet_to_s3_dag.py
@@ -1,6 +1,6 @@
 from datetime import datetime
 
-from imednet.airflow import ImednetToS3Operator
+from imednet.integrations.airflow import ImednetToS3Operator
 
 from airflow import DAG
 

--- a/imednet/airflow/__init__.py
+++ b/imednet/airflow/__init__.py
@@ -1,3 +1,23 @@
-from .operators import ImednetJobSensor, ImednetToS3Operator
+"""Deprecated Airflow integration location."""
 
-__all__ = ["ImednetToS3Operator", "ImednetJobSensor"]
+import warnings
+
+from imednet.integrations.airflow import (
+    ImednetExportOperator,
+    ImednetHook,
+    ImednetJobSensor,
+    ImednetToS3Operator,
+)
+
+warnings.warn(
+    "`imednet.airflow` is deprecated; use `imednet.integrations.airflow` instead",
+    DeprecationWarning,
+    stacklevel=2,
+)
+
+__all__ = [
+    "ImednetHook",
+    "ImednetToS3Operator",
+    "ImednetJobSensor",
+    "ImednetExportOperator",
+]

--- a/imednet/integrations/airflow/__init__.py
+++ b/imednet/integrations/airflow/__init__.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+import sys
+from importlib import reload
+
+from .. import export
+
+if "imednet.integrations.airflow.hook" in sys.modules:
+    reload(sys.modules["imednet.integrations.airflow.hook"])
+if "imednet.integrations.airflow.export_operator" in sys.modules:
+    reload(sys.modules["imednet.integrations.airflow.export_operator"])
+if "imednet.integrations.airflow.operators" in sys.modules:
+    reload(sys.modules["imednet.integrations.airflow.operators"])
+
+from .export_operator import ImednetExportOperator
+from .hook import ImednetHook
+
+try:  # pragma: no cover - optional Airflow dependencies may be missing
+    from .operators import ImednetJobSensor, ImednetToS3Operator
+except Exception:  # pragma: no cover - operators require Airflow extras
+    ImednetJobSensor = ImednetToS3Operator = None  # type: ignore
+
+__all__ = [
+    "ImednetHook",
+    "ImednetToS3Operator",
+    "ImednetJobSensor",
+    "ImednetExportOperator",
+    "export",
+]

--- a/imednet/integrations/airflow/hook.py
+++ b/imednet/integrations/airflow/hook.py
@@ -1,0 +1,32 @@
+"""Airflow hook for retrieving an :class:`ImednetSDK` instance."""
+
+from __future__ import annotations
+
+import os
+
+from airflow.hooks.base import BaseHook
+
+from ...sdk import ImednetSDK
+
+
+class ImednetHook(BaseHook):
+    """Retrieve an :class:`ImednetSDK` instance from an Airflow connection."""
+
+    def __init__(self, imednet_conn_id: str = "imednet_default") -> None:
+        super().__init__()
+        self.imednet_conn_id = imednet_conn_id
+
+    def get_conn(self) -> ImednetSDK:  # type: ignore[override]
+        from airflow.hooks.base import BaseHook
+
+        conn = BaseHook.get_connection(self.imednet_conn_id)
+        extras = conn.extra_dejson
+        api_key = extras.get("api_key") or conn.login or os.getenv("IMEDNET_API_KEY")
+        security_key = (
+            extras.get("security_key") or conn.password or os.getenv("IMEDNET_SECURITY_KEY")
+        )
+        base_url = extras.get("base_url") or os.getenv("IMEDNET_BASE_URL")
+        return ImednetSDK(api_key=api_key, security_key=security_key, base_url=base_url)
+
+
+__all__ = ["ImednetHook"]

--- a/imednet/integrations/airflow/operators.py
+++ b/imednet/integrations/airflow/operators.py
@@ -12,7 +12,7 @@ from airflow.models import BaseOperator
 from airflow.providers.amazon.aws.hooks.s3 import S3Hook
 from airflow.sensors.base import BaseSensorOperator
 
-from ..sdk import ImednetSDK
+from ...sdk import ImednetSDK
 
 
 class ImednetToS3Operator(BaseOperator):

--- a/tests/integration/test_export_airflow_integration.py
+++ b/tests/integration/test_export_airflow_integration.py
@@ -196,7 +196,7 @@ def test_to_s3_operator_uploads(monkeypatch):
 
     import importlib
 
-    from imednet.airflow import operators as ops
+    from imednet.integrations.airflow import operators as ops
 
     importlib.reload(ops)
 
@@ -210,4 +210,4 @@ def test_to_s3_operator_uploads(monkeypatch):
     assert result == "k"
     body = s3.get_object(Bucket="bucket", Key="k")["Body"].read().decode()
     assert "id" in body
-    sys.modules.pop("imednet.airflow.operators", None)
+    sys.modules.pop("imednet.integrations.airflow.operators", None)

--- a/tests/unit/test_airflow_operators.py
+++ b/tests/unit/test_airflow_operators.py
@@ -73,7 +73,7 @@ def _setup_airflow(monkeypatch):
 
 def _import_operators(monkeypatch):
     _setup_airflow(monkeypatch)
-    import imednet.airflow.operators as ops
+    import imednet.integrations.airflow.operators as ops
 
     importlib.reload(ops)
     return ops


### PR DESCRIPTION
## Summary
- move all Airflow modules under `imednet/integrations/airflow`
- add deprecation stub in old `imednet.airflow` package
- split old Airflow helper into `hook` and `export_operator`
- update docs, examples and tests for new import path

## Testing
- `ruff check .`
- `black --check .`
- `poetry run mypy imednet`
- `poetry run pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684c87ed1e30832c8cdbc944eb77cfdc