### PR TITLE
Refactor type checking registry

### DIFF
--- a/imednet/core/exceptions.py
+++ b/imednet/core/exceptions.py
@@ -119,3 +119,9 @@ class ConflictError(ApiError):
     """Raised for HTTP 409 conflict errors."""
 
     pass
+
+
+class UnknownVariableTypeError(ValidationError):
+    """Raised when an unrecognized variable type is encountered."""
+
+    pass

--- a/tests/unit/test_utils_schema.py
+++ b/tests/unit/test_utils_schema.py
@@ -1,7 +1,7 @@
 from unittest.mock import MagicMock
 
 import pytest
-from imednet.core.exceptions import ValidationError
+from imednet.core.exceptions import UnknownVariableTypeError, ValidationError
 from imednet.models.forms import Form
 from imednet.models.variables import Variable
 from imednet.utils.schema import (
@@ -34,9 +34,9 @@ def test_schema_cache_refresh() -> None:
 
 def test_check_type_int() -> None:
     var = _make_var("age")
-    _check_type(var, 5)
+    _check_type(var.variable_type, 5)
     with pytest.raises(ValidationError):
-        _check_type(var, "bad")
+        _check_type(var.variable_type, "bad")
 
 
 def test_check_type_other_types() -> None:
@@ -44,16 +44,21 @@ def test_check_type_other_types() -> None:
     float_var = _make_var("score", "float")
     str_var = _make_var("name", "string")
 
-    _check_type(bool_var, True)
-    _check_type(float_var, 1.5)
-    _check_type(str_var, "ok")
+    _check_type(bool_var.variable_type, True)
+    _check_type(float_var.variable_type, 1.5)
+    _check_type(str_var.variable_type, "ok")
 
     with pytest.raises(ValidationError):
-        _check_type(bool_var, "nope")
+        _check_type(bool_var.variable_type, "nope")
     with pytest.raises(ValidationError):
-        _check_type(float_var, "nan")
+        _check_type(float_var.variable_type, "nan")
     with pytest.raises(ValidationError):
-        _check_type(str_var, 123)
+        _check_type(str_var.variable_type, 123)
+
+
+def test_check_type_unknown_type() -> None:
+    with pytest.raises(UnknownVariableTypeError):
+        _check_type("weird", "x")
 
 
 def test_validate_record_data_errors() -> None:


### PR DESCRIPTION
## Summary
- add `UnknownVariableTypeError`
- refactor `_check_type` to use registry instead of elif ladder
- update schema utils tests for new API

## Testing
- `./scripts/setup.sh`
- `poetry run ruff check --fix .`
- `poetry run black --check .`
- `poetry run mypy imednet`
- `poetry run pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684c915b8ca8832c9362c945c8be34f2