### PR TITLE
Refactor record updates with job poller

### DIFF
--- a/imednet/core/__init__.py
+++ b/imednet/core/__init__.py
@@ -9,6 +9,7 @@ from .exceptions import (
     AuthenticationError,
     AuthorizationError,
     ImednetError,
+    JobTimeoutError,
     NotFoundError,
     RateLimitError,
     RequestError,
@@ -29,5 +30,6 @@ __all__ = [
     "RateLimitError",
     "ServerError",
     "ValidationError",
+    "JobTimeoutError",
     "Paginator",
 ]

--- a/imednet/core/exceptions.py
+++ b/imednet/core/exceptions.py
@@ -95,3 +95,9 @@ class ValidationError(ApiError):
     """
 
     pass
+
+
+class JobTimeoutError(ImednetError):
+    """Raised when a background job does not complete within the allotted time."""
+
+    pass

--- a/imednet/workflows/job_poller.py
+++ b/imednet/workflows/job_poller.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+import time
+from typing import TYPE_CHECKING
+
+from imednet.core.exceptions import JobTimeoutError
+from imednet.models import Job
+
+if TYPE_CHECKING:  # pragma: no cover - for type checkers only
+    from imednet.sdk import ImednetSDK
+
+TERMINAL_JOB_STATES = {"COMPLETED", "FAILED", "CANCELLED"}
+
+
+class JobPoller:
+    """Utility class to wait for an asynchronous job to finish."""
+
+    def __init__(
+        self,
+        sdk: "ImednetSDK",
+        study_key: str,
+        job_id: str,
+        timeout_s: int = 300,
+        poll_interval_s: int = 5,
+    ) -> None:
+        self._sdk = sdk
+        self._study_key = study_key
+        self._job_id = job_id
+        self._timeout_s = timeout_s
+        self._poll_interval_s = poll_interval_s
+
+    def wait(self) -> Job:
+        """Poll the job status until it reaches a terminal state or times out."""
+        start_time = time.monotonic()
+        status = self._sdk.jobs.get(self._study_key, self._job_id)
+        while True:
+            if status.state.upper() in TERMINAL_JOB_STATES:
+                return status
+            if time.monotonic() - start_time >= self._timeout_s:
+                raise JobTimeoutError(
+                    f"Timeout ({self._timeout_s}s) waiting for job '{self._job_id}' to complete."
+                )
+            time.sleep(self._poll_interval_s)
+            status = self._sdk.jobs.get(self._study_key, self._job_id)

--- a/imednet/workflows/record_update.py
+++ b/imednet/workflows/record_update.py
@@ -1,15 +1,13 @@
 """Placeholder for Record Creation/Update workflows."""
 
-import time
+import warnings
 from typing import TYPE_CHECKING, Any, Dict, List, Literal, Union
 
 from ..models import Job
+from .job_poller import JobPoller
 
 if TYPE_CHECKING:
     from ..sdk import ImednetSDK
-
-# Define terminal states for job polling
-TERMINAL_JOB_STATES = {"COMPLETED", "FAILED", "CANCELLED"}  # Adjust if needed based on API
 
 
 class RecordUpdateWorkflow:
@@ -24,7 +22,7 @@ class RecordUpdateWorkflow:
     def __init__(self, sdk: "ImednetSDK"):
         self._sdk = sdk
 
-    def submit_record_batch(
+    def create_or_update_records(
         self,
         study_key: str,
         records_data: List[Dict[str, Any]],
@@ -32,8 +30,7 @@ class RecordUpdateWorkflow:
         timeout: int = 300,
         poll_interval: int = 5,
     ) -> Job:
-        """
-        Submits a batch of record data for creation or update.
+        """Submits a batch of record data for creation or update.
 
         Optionally waits for the background job to complete by polling its status.
 
@@ -54,45 +51,36 @@ class RecordUpdateWorkflow:
             if `wait_for_completion` is True.
 
         Raises:
-            TimeoutError: If `wait_for_completion` is True and the job does not
-                          complete within the specified timeout.
+            JobTimeoutError: If `wait_for_completion` is True and the job does
+                not complete within the specified timeout.
             # ImednetApiError: If the initial submission or status polling fails.
             # Commented out as not defined here
         """
-        # Call the SDK's records.create method - Pass records_data directly
         initial_job_status = self._sdk.records.create(study_key, records_data)
 
         if not wait_for_completion:
             return initial_job_status
 
         if not initial_job_status.batch_id:
-            # Should not happen if API call was successful, but good practice to check
             raise ValueError("Submission successful but no batch_id received.")
 
-        start_time = time.monotonic()
-        batch_id = initial_job_status.batch_id
-        current_job_status = initial_job_status
+        poller = JobPoller(
+            self._sdk,
+            study_key,
+            initial_job_status.batch_id,
+            timeout_s=timeout,
+            poll_interval_s=poll_interval,
+        )
+        return poller.wait()
 
-        while True:
-            if current_job_status.state.upper() in TERMINAL_JOB_STATES:
-                return current_job_status
-
-            elapsed_time = time.monotonic() - start_time
-            if elapsed_time >= timeout:
-                raise TimeoutError(
-                    f"Timeout ({timeout}s) waiting for job batch '{batch_id}' "
-                    f"to complete. Last state: {current_job_status.state}"
-                )
-
-            # Wait before polling again
-            time.sleep(poll_interval)
-
-            # Poll the job status using the batch_id
-            # Assuming sdk.jobs.get expects study_key and batch_id
-            current_job_status = self._sdk.jobs.get(study_key, batch_id)  # Added study_key
-
-        # This line is technically unreachable due to the loop structure but ensures return type
-        return current_job_status
+    def submit_record_batch(self, *args: Any, **kwargs: Any) -> Job:
+        """Deprecated alias for :meth:`create_or_update_records`."""
+        warnings.warn(
+            "submit_record_batch is deprecated; use create_or_update_records instead",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return self.create_or_update_records(*args, **kwargs)
 
     def register_subject(
         self,
@@ -128,7 +116,7 @@ class RecordUpdateWorkflow:
             "siteName" if site_identifier_type == "name" else "siteId": site_identifier,
             "data": data,
         }
-        return self.submit_record_batch(
+        return self.create_or_update_records(
             study_key=study_key,
             records_data=[record],
             wait_for_completion=wait_for_completion,
@@ -178,7 +166,7 @@ class RecordUpdateWorkflow:
             ): interval_identifier,
             "data": data,
         }
-        return self.submit_record_batch(
+        return self.create_or_update_records(
             study_key=study_key,
             records_data=[record],
             wait_for_completion=wait_for_completion,
@@ -221,7 +209,7 @@ class RecordUpdateWorkflow:
             subject_id_field_map[subject_identifier_type]: subject_identifier,
             "data": data,
         }
-        return self.submit_record_batch(
+        return self.create_or_update_records(
             study_key=study_key,
             records_data=[record],
             wait_for_completion=wait_for_completion,
@@ -232,5 +220,5 @@ class RecordUpdateWorkflow:
 
 # Integration:
 # - Accessed via the main SDK instance
-#       (e.g., `sdk.workflows.record_update.submit_record_batch(...)`).
+#       (e.g., `sdk.workflows.record_update.create_or_update_records(...)`).
 # - Simplifies the process of submitting data and optionally monitoring the asynchronous job.

--- a/tests/unit/test_job_poller.py
+++ b/tests/unit/test_job_poller.py
@@ -1,0 +1,42 @@
+from types import SimpleNamespace
+
+import pytest
+from imednet.core.exceptions import JobTimeoutError
+from imednet.models.jobs import Job
+from imednet.workflows.job_poller import JobPoller
+
+
+def make_sdk(mock_get):
+    return SimpleNamespace(jobs=SimpleNamespace(get=mock_get))
+
+
+def test_wait_success(monkeypatch):
+    states = ["IN_PROGRESS", "IN_PROGRESS", "COMPLETED"]
+
+    def fake_get(study_key, job_id):
+        return Job(job_id="j1", batch_id=job_id, state=states.pop(0))
+
+    sdk = make_sdk(fake_get)
+    poller = JobPoller(sdk, "study", "b1", timeout_s=2, poll_interval_s=0)
+    monkeypatch.setattr("time.sleep", lambda s: None)
+    result = poller.wait()
+    assert result.state == "COMPLETED"
+
+
+def test_wait_timeout(monkeypatch):
+    def fake_get(study_key, job_id):
+        return Job(job_id="j1", batch_id=job_id, state="IN_PROGRESS")
+
+    sdk = make_sdk(fake_get)
+    poller = JobPoller(sdk, "study", "b1", timeout_s=0.01, poll_interval_s=0)
+
+    times = [0.0]
+
+    def fake_monotonic():
+        times[0] += 0.005
+        return times[0]
+
+    monkeypatch.setattr("time.sleep", lambda s: None)
+    monkeypatch.setattr("time.monotonic", fake_monotonic)
+    with pytest.raises(JobTimeoutError):
+        poller.wait()


### PR DESCRIPTION
## Summary
- extract JobPoller utility to wait on asynchronous jobs
- use JobPoller in `RecordUpdateWorkflow` and rename record batch method
- add deprecated alias `submit_record_batch`
- expose new JobTimeoutError
- test JobPoller wait logic

## Testing
- `pre-commit run --files imednet/workflows/job_poller.py imednet/workflows/record_update.py imednet/core/exceptions.py imednet/core/__init__.py tests/unit/test_job_poller.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684ca1d6bedc832c995a52709abe759c