### PR TITLE
Add JobPoller class and refactor record update workflow

### DIFF
--- a/docs/live_test_plan.rst
+++ b/docs/live_test_plan.rst
@@ -67,7 +67,7 @@ non-destructive calls. Each bullet corresponds to a separate live test.
 - ``QueryManagementWorkflow.get_queries_by_site``
 - ``QueryManagementWorkflow.get_query_state_counts``
 - ``RecordMapper.dataframe``
-- ``RecordUpdateWorkflow.submit_record_batch``
+- ``RecordUpdateWorkflow.create_or_update_records``
 - ``RecordUpdateWorkflow.register_subject``
 - ``RecordUpdateWorkflow.update_scheduled_record``
 - ``RecordUpdateWorkflow.create_new_record``

--- a/imednet/workflows/__init__.py
+++ b/imednet/workflows/__init__.py
@@ -1,5 +1,6 @@
 """Workflow helpers built on top of the iMednet SDK."""
 
+from .job_poller import JobPoller, JobTimeoutError
 from .query_management import QueryManagementWorkflow
 from .record_mapper import RecordMapper
 from .record_update import RecordUpdateWorkflow
@@ -11,6 +12,8 @@ __all__ = [
     "QueryManagementWorkflow",
     "RecordMapper",
     "RecordUpdateWorkflow",
+    "JobPoller",
+    "JobTimeoutError",
     "RegisterSubjectsWorkflow",
     "SubjectDataWorkflow",
     "get_study_structure",

--- a/imednet/workflows/job_poller.py
+++ b/imednet/workflows/job_poller.py
@@ -1,0 +1,47 @@
+"""Utility for polling job status."""
+
+from __future__ import annotations
+
+import time
+from typing import TYPE_CHECKING
+
+from ..models import JobStatus
+
+if TYPE_CHECKING:  # pragma: no cover - import for type checking only
+    from ..sdk import ImednetSDK
+
+TERMINAL_JOB_STATES = {"COMPLETED", "FAILED", "CANCELLED"}
+
+
+class JobTimeoutError(TimeoutError):
+    """Raised when a job does not finish before the timeout."""
+
+
+class JobPoller:
+    """Poll a job until it reaches a terminal state."""
+
+    def __init__(
+        self,
+        sdk: "ImednetSDK",
+        study_key: str,
+        job_id: str,
+        *,
+        timeout_s: int = 300,
+        poll_interval_s: int = 5,
+    ) -> None:
+        self._sdk = sdk
+        self._study_key = study_key
+        self._job_id = job_id
+        self._timeout = timeout_s
+        self._interval = poll_interval_s
+
+    def wait(self) -> JobStatus:
+        """Block until the job completes or raise :class:`JobTimeoutError`."""
+        start = time.monotonic()
+        status = self._sdk.jobs.get(self._study_key, self._job_id)
+        while status.state.upper() not in TERMINAL_JOB_STATES:
+            if time.monotonic() - start >= self._timeout:
+                raise JobTimeoutError(f"Timeout ({self._timeout}s) waiting for job {self._job_id}")
+            time.sleep(self._interval)
+            status = self._sdk.jobs.get(self._study_key, self._job_id)
+        return status

--- a/tests/integration/test_workflows_integration.py
+++ b/tests/integration/test_workflows_integration.py
@@ -59,7 +59,7 @@ def test_record_update_submit_and_wait(monkeypatch: pytest.MonkeyPatch):
     monkeypatch.setattr(time, "sleep", lambda *_: None)
 
     wf = RecordUpdateWorkflow(sdk)
-    job = wf.submit_record_batch(
+    job = wf.create_or_update_records(
         "ST", [{"formKey": "F1", "data": {"x": 1}}], wait_for_completion=True, poll_interval=0
     )
 
@@ -157,7 +157,7 @@ def test_record_update_timeout(monkeypatch: pytest.MonkeyPatch) -> None:
 
     wf = RecordUpdateWorkflow(sdk)
     with pytest.raises(TimeoutError):
-        wf.submit_record_batch(
+        wf.create_or_update_records(
             "ST",
             [{"formKey": "F1", "data": {"x": 1}}],
             wait_for_completion=True,

--- a/tests/live/test_workflows_live.py
+++ b/tests/live/test_workflows_live.py
@@ -127,7 +127,7 @@ def test_record_mapper_dataframe(sdk: ImednetSDK, study_key: str) -> None:
 def test_record_update_submit_batch(sdk: ImednetSDK, study_key: str) -> None:
     if os.getenv("IMEDNET_ALLOW_MUTATION") != "1":
         pytest.skip("Mutating tests are disabled")
-    job = sdk.workflows.record_update.submit_record_batch(study_key, [])
+    job = sdk.workflows.record_update.create_or_update_records(study_key, [])
     assert job.batch_id
 
 

--- a/tests/unit/test_job_poller.py
+++ b/tests/unit/test_job_poller.py
@@ -1,0 +1,31 @@
+from unittest.mock import MagicMock
+
+import pytest
+from imednet.models.jobs import Job
+from imednet.workflows.job_poller import JobPoller, JobTimeoutError
+
+
+def test_wait_success(monkeypatch) -> None:
+    sdk = MagicMock()
+    states = [Job(batch_id="1", state="PROCESSING"), Job(batch_id="1", state="COMPLETED")]
+    sdk.jobs.get.side_effect = lambda s, b: states.pop(0)
+    monkeypatch.setattr("time.sleep", lambda *_: None)
+    poller = JobPoller(sdk, "ST", "1", timeout_s=5, poll_interval_s=0)
+    result = poller.wait()
+    assert result.state == "COMPLETED"
+
+
+def test_wait_timeout(monkeypatch) -> None:
+    sdk = MagicMock()
+    sdk.jobs.get.return_value = Job(batch_id="1", state="PROCESSING")
+    tick = {"v": 0}
+
+    def monotonic() -> int:
+        tick["v"] += 1
+        return tick["v"]
+
+    monkeypatch.setattr("time.monotonic", monotonic)
+    monkeypatch.setattr("time.sleep", lambda *_: None)
+    poller = JobPoller(sdk, "ST", "1", timeout_s=1, poll_interval_s=0)
+    with pytest.raises(JobTimeoutError):
+        poller.wait()

--- a/tests/unit/test_workflows_record_update.py
+++ b/tests/unit/test_workflows_record_update.py
@@ -7,19 +7,19 @@ from imednet.models.variables import Variable
 from imednet.workflows.record_update import RecordUpdateWorkflow
 
 
-def test_submit_record_batch_no_wait() -> None:
+def test_create_or_update_records_no_wait() -> None:
     sdk = MagicMock()
     job = Job(batch_id="1", state="PROCESSING")
     sdk.records.create.return_value = job
 
     wf = RecordUpdateWorkflow(sdk)
-    result = wf.submit_record_batch("STUDY", [{"a": 1}])
+    result = wf.create_or_update_records("STUDY", [{"a": 1}])
 
     sdk.records.create.assert_called_once_with("STUDY", [{"a": 1}], schema=wf._schema)
     assert result == job
 
 
-def test_submit_record_batch_wait_for_completion(monkeypatch) -> None:
+def test_create_or_update_records_wait_for_completion(monkeypatch) -> None:
     sdk = MagicMock()
     initial_job = Job(batch_id="1", state="PROCESSING")
     completed_job = Job(batch_id="1", state="COMPLETED")
@@ -29,7 +29,7 @@ def test_submit_record_batch_wait_for_completion(monkeypatch) -> None:
     wf = RecordUpdateWorkflow(sdk)
     # patch sleep to avoid delay
     monkeypatch.setattr("time.sleep", lambda *args: None)
-    result = wf.submit_record_batch(
+    result = wf.create_or_update_records(
         "STUDY",
         [{"a": 1}],
         wait_for_completion=True,
@@ -45,7 +45,7 @@ def test_submit_record_batch_wait_for_completion(monkeypatch) -> None:
 def test_update_scheduled_record_builds_payload() -> None:
     sdk = MagicMock()
     wf = RecordUpdateWorkflow(sdk)
-    wf.submit_record_batch = MagicMock(return_value="job")
+    wf.create_or_update_records = MagicMock(return_value="job")  # type: ignore[method-assign]
 
     result = wf.update_scheduled_record(
         "STUDY",
@@ -56,8 +56,8 @@ def test_update_scheduled_record_builds_payload() -> None:
         subject_identifier_type="oid",
     )
 
-    wf.submit_record_batch.assert_called_once()
-    called = wf.submit_record_batch.call_args.kwargs
+    wf.create_or_update_records.assert_called_once()
+    called = wf.create_or_update_records.call_args.kwargs
     assert called["records_data"] == [
         {
             "formKey": "F1",
@@ -69,18 +69,18 @@ def test_update_scheduled_record_builds_payload() -> None:
     assert result == "job"
 
 
-def test_submit_record_batch_validation() -> None:
+def test_create_or_update_records_validation() -> None:
     sdk = MagicMock()
     var = Variable(variable_name="age", variable_type="integer", form_id=1, form_key="F1")
     sdk.variables.list.return_value = [var]
     wf = RecordUpdateWorkflow(sdk)
 
     with pytest.raises(ValidationError):
-        wf.submit_record_batch("STUDY", [{"formKey": "F1", "data": {"bad": 1}}])
+        wf.create_or_update_records("STUDY", [{"formKey": "F1", "data": {"bad": 1}}])
     sdk.records.create.assert_not_called()
 
     sdk.records.create.return_value = Job(batch_id="1", state="PROCESSING")
-    wf.submit_record_batch("STUDY", [{"formKey": "F1", "data": {"age": 5}}])
+    wf.create_or_update_records("STUDY", [{"formKey": "F1", "data": {"age": 5}}])
     sdk.variables.list.assert_called_once_with(study_key="STUDY", refresh=True)
     sdk.records.create.assert_called_once_with(
         "STUDY", [{"formKey": "F1", "data": {"age": 5}}], schema=wf._schema


### PR DESCRIPTION
## Summary
- extract polling logic into `JobPoller` utility
- refactor `RecordUpdateWorkflow` to use `JobPoller`
- rename `submit_record_batch` to `create_or_update_records` and keep deprecated alias
- update docs and tests for new API
- export `JobPoller` in workflow package
- add coverage tests for `JobPoller`

## Testing
- `poetry run ruff check --fix .`
- `poetry run black --check .`
- `poetry run mypy imednet`
- `poetry run pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684ca5984324832ca949251882de5d9d