### PR TITLE
Fix CLI filter handling

### DIFF
--- a/imednet/cli/subjects.py
+++ b/imednet/cli/subjects.py
@@ -6,7 +6,6 @@ import typer
 from rich import print
 
 from ..core.exceptions import ApiError
-from ..utils.filters import build_filter_string
 from .utils import parse_filter_args
 
 app = typer.Typer(name="subjects", help="Manage subjects within a study.")
@@ -28,10 +27,9 @@ def list_subjects(
     sdk = get_sdk()
     try:
         parsed_filter = parse_filter_args(subject_filter)
-        filter_str = build_filter_string(parsed_filter) if parsed_filter else None
 
         print(f"Fetching subjects for study '{study_key}'...")
-        subjects_list = sdk.subjects.list(study_key, filter=filter_str)
+        subjects_list = sdk.subjects.list(study_key, **(parsed_filter or {}))
         if subjects_list:
             print(f"Found {len(subjects_list)} subjects:")
             print(subjects_list)

--- a/imednet/core/async_client.py
+++ b/imednet/core/async_client.py
@@ -23,7 +23,6 @@ from tenacity import (
     wait_exponential,
 )
 
-from imednet.utils import sanitize_base_url
 from imednet.utils.json_logging import configure_json_logging
 
 from .client import Client
@@ -66,7 +65,7 @@ class AsyncClient:
         self.base_url = self.base_url.rstrip("/")
         if self.base_url.endswith("/api"):
             self.base_url = self.base_url[:-4]
-          
+
         self.timeout = timeout if isinstance(timeout, httpx.Timeout) else httpx.Timeout(timeout)
         self.retries = retries
         self.backoff_factor = backoff_factor

--- a/imednet/core/client.py
+++ b/imednet/core/client.py
@@ -44,7 +44,6 @@ from imednet.core.exceptions import (
     ServerError,
     UnauthorizedError,
 )
-from imednet.utils import sanitize_base_url
 from imednet.utils.json_logging import configure_json_logging
 
 logger = logging.getLogger(__name__)

--- a/imednet/workflows/query_management.py
+++ b/imednet/workflows/query_management.py
@@ -3,7 +3,6 @@
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, Union
 
 from ..models import Query
-from ..utils.filters import build_filter_string
 
 if TYPE_CHECKING:
     from ..sdk import ImednetSDK
@@ -43,11 +42,10 @@ class QueryManagementWorkflow:
         Returns:
             A list of open Query objects matching the criteria.
         """
-        # Build filter string from dictionary
-        filter_str = build_filter_string(additional_filter) if additional_filter else None
+        filters = dict(additional_filter) if additional_filter else {}
 
         # Fetch potentially relevant queries
-        all_matching_queries = self._sdk.queries.list(study_key, filter=filter_str, **kwargs)
+        all_matching_queries = self._sdk.queries.list(study_key, **filters, **kwargs)
 
         open_queries: List[Query] = []
         for query in all_matching_queries:
@@ -87,14 +85,9 @@ class QueryManagementWorkflow:
         # Build filter dictionary
         final_filter_dict: Dict[str, Any] = {"subject_key": subject_key}
         if additional_filter:
-            # Simple merge, assumes no key conflicts. API filter string uses ';' (AND) by default.
             final_filter_dict.update(additional_filter)
 
-        filter_str = build_filter_string(final_filter_dict)
-
-        return self._sdk.queries.list(
-            study_key, filter=filter_str if filter_str else None, **kwargs
-        )
+        return self._sdk.queries.list(study_key, **final_filter_dict, **kwargs)
 
     def get_queries_by_site(
         self,
@@ -118,14 +111,9 @@ class QueryManagementWorkflow:
         # Build filter dictionary
         final_filter_dict: Dict[str, Any] = {"site_key": site_key}
         if additional_filter:
-            # Simple merge, assumes no key conflicts. API filter string uses ';' (AND) by default.
             final_filter_dict.update(additional_filter)
 
-        filter_str = build_filter_string(final_filter_dict)
-
-        return self._sdk.queries.list(
-            study_key, filter=filter_str if filter_str else None, **kwargs
-        )
+        return self._sdk.queries.list(study_key, **final_filter_dict, **kwargs)
 
     def get_query_state_counts(self, study_key: str, **kwargs: Any) -> Dict[str, int]:
         """

--- a/imednet/workflows/record_mapper.py
+++ b/imednet/workflows/record_mapper.py
@@ -6,7 +6,6 @@ from pydantic import BaseModel, Field, ValidationError, create_model
 
 from imednet.endpoints.records import Record as RecordModel  # type: ignore[attr-defined]
 from imednet.endpoints.variables import Variable as VariableModel  # type: ignore[attr-defined]
-from imednet.utils.filters import build_filter_string
 
 if TYPE_CHECKING:
     from ..sdk import ImednetSDK
@@ -87,9 +86,12 @@ class RecordMapper:
                     "Invalid visit_key '%s'. Should be convertible to int. Fetching all records.",
                     visit_key,
                 )
-        filter_str = build_filter_string(filters) if filters else None
         try:
-            return self.sdk.records.list(study_key=study_key, filter=filter_str)
+            return self.sdk.records.list(
+                study_key=study_key,
+                record_data_filter=None,
+                **filters,
+            )
         except Exception as exc:  # pragma: no cover - unexpected
             logger.error("Failed to fetch records for study '%s': %s", study_key, exc)
             return []

--- a/imednet/workflows/subject_data.py
+++ b/imednet/workflows/subject_data.py
@@ -5,7 +5,6 @@ from typing import TYPE_CHECKING, Any, Dict, List, Optional
 from pydantic import BaseModel, Field
 
 from ..models import Query, Record, Subject, Visit
-from ..utils.filters import build_filter_string
 
 if TYPE_CHECKING:
     from ..sdk import ImednetSDK
@@ -48,21 +47,20 @@ class SubjectDataWorkflow:
         """
         results = SubjectComprehensiveData(subject_details=None)
         subject_filter_dict: Dict[str, Any] = {"subject_key": subject_key}
-        subject_filter_str = build_filter_string(subject_filter_dict)
 
         # Fetch Subject Details
-        subject_list = self._sdk.subjects.list(study_key, filter=subject_filter_str)
+        subject_list = self._sdk.subjects.list(study_key, **subject_filter_dict)
         if subject_list:
             results.subject_details = subject_list[0]
 
         # Fetch Visits
-        results.visits = self._sdk.visits.list(study_key, filter=subject_filter_str)
+        results.visits = self._sdk.visits.list(study_key, **subject_filter_dict)
 
         # Fetch Records
-        results.records = self._sdk.records.list(study_key, filter=subject_filter_str)
+        results.records = self._sdk.records.list(study_key, **subject_filter_dict)
 
         # Fetch Queries
-        results.queries = self._sdk.queries.list(study_key, filter=subject_filter_str)
+        results.queries = self._sdk.queries.list(study_key, **subject_filter_dict)
 
         return results
 

--- a/tests/unit/cli/test_cli.py
+++ b/tests/unit/cli/test_cli.py
@@ -77,7 +77,7 @@ def test_subjects_list_success(runner: CliRunner, sdk: MagicMock) -> None:
         ["subjects", "list", "STUDY", "--filter", "subject_status=Screened"],
     )
     assert result.exit_code == 0
-    sdk.subjects.list.assert_called_once_with("STUDY", filter="subject_status==Screened")
+    sdk.subjects.list.assert_called_once_with("STUDY", subject_status="Screened")
 
 
 def test_subjects_list_invalid_filter(runner: CliRunner, sdk: MagicMock) -> None:

--- a/tests/unit/test_record_mapper.py
+++ b/tests/unit/test_record_mapper.py
@@ -32,7 +32,7 @@ def test_dataframe_builds_expected_structure() -> None:
     df = mapper.dataframe("STUDY", visit_key="1")
 
     sdk.variables.list.assert_called_once_with(study_key="STUDY")
-    sdk.records.list.assert_called_once_with(study_key="STUDY", filter="visitId==1")
+    sdk.records.list.assert_called_once_with(study_key="STUDY", record_data_filter=None, visitId=1)
 
     expected_columns = [
         "recordId",
@@ -68,7 +68,7 @@ def test_invalid_visit_key_logs_warning(caplog) -> None:
 
     assert df.empty
     assert "Invalid visit_key" in caplog.text
-    sdk.records.list.assert_called_once_with(study_key="S", filter=None)
+    sdk.records.list.assert_called_once_with(study_key="S", record_data_filter=None)
 
 
 def test_records_fetch_error_returns_empty(caplog) -> None:

--- a/tests/unit/test_workflows_data_extraction.py
+++ b/tests/unit/test_workflows_data_extraction.py
@@ -28,9 +28,9 @@ def test_extract_records_by_criteria_filters_subject_and_visit() -> None:
         visit_filter={"visit_id": 1},
     )
 
-    sdk.subjects.list.assert_called_once_with("STUDY", filter="status==active")
-    sdk.visits.list.assert_called_once_with("STUDY", filter="visit_id==1")
-    sdk.records.list.assert_called_once_with("STUDY", filter=None)
+    sdk.subjects.list.assert_called_once_with("STUDY", status="active")
+    sdk.visits.list.assert_called_once_with("STUDY", visit_id=1)
+    sdk.records.list.assert_called_once_with(study_key="STUDY", record_data_filter=None)
 
     assert [r.record_id for r in result] == [1, 2]
 
@@ -51,7 +51,8 @@ def test_extract_audit_trail_builds_filters_and_dates() -> None:
 
     sdk.record_revisions.list.assert_called_once_with(
         "STUDY",
-        filter="role==data;status==open",
+        role="data",
+        status="open",
         start_date="2021-01-01",
         end_date="2021-01-02",
     )

--- a/tests/unit/test_workflows_query_management.py
+++ b/tests/unit/test_workflows_query_management.py
@@ -19,7 +19,7 @@ def test_get_open_queries_filters_latest_comment() -> None:
     wf = QueryManagementWorkflow(sdk)
     result = wf.get_open_queries("STUDY", additional_filter={"state": "new"})
 
-    sdk.queries.list.assert_called_once_with("STUDY", filter="state==new")
+    sdk.queries.list.assert_called_once_with("STUDY", state="new")
     assert result == [query_open]
 
 
@@ -28,7 +28,7 @@ def test_get_queries_for_subject_builds_combined_filter() -> None:
     wf = QueryManagementWorkflow(sdk)
     wf.get_queries_for_subject("STUDY", "SUBJ1", additional_filter={"type": "x"})
 
-    sdk.queries.list.assert_called_once_with("STUDY", filter="subject_key==SUBJ1;type==x")
+    sdk.queries.list.assert_called_once_with("STUDY", subject_key="SUBJ1", type="x")
 
 
 def test_get_query_state_counts_aggregates_states() -> None:

--- a/tests/unit/test_workflows_subject_data.py
+++ b/tests/unit/test_workflows_subject_data.py
@@ -22,10 +22,10 @@ def test_get_all_subject_data_aggregates_across_endpoints() -> None:
     wf = SubjectDataWorkflow(sdk)
     result = wf.get_all_subject_data("STUDY", "S1")
 
-    sdk.subjects.list.assert_called_once_with("STUDY", filter="subject_key==S1")
-    sdk.visits.list.assert_called_once_with("STUDY", filter="subject_key==S1")
-    sdk.records.list.assert_called_once_with("STUDY", filter="subject_key==S1")
-    sdk.queries.list.assert_called_once_with("STUDY", filter="subject_key==S1")
+    sdk.subjects.list.assert_called_once_with("STUDY", subject_key="S1")
+    sdk.visits.list.assert_called_once_with("STUDY", subject_key="S1")
+    sdk.records.list.assert_called_once_with("STUDY", subject_key="S1")
+    sdk.queries.list.assert_called_once_with("STUDY", subject_key="S1")
 
     assert result.subject_details == subject
     assert result.visits == [visit]


### PR DESCRIPTION
## Summary
- pass filter dictionaries directly to endpoint clients
- adjust workflows to use dict filters
- update unit tests for new behavior
- clean up unused imports

## Testing
- `poetry run ruff check --fix .`
- `poetry run black --check .`
- `poetry run mypy imednet`
- `poetry run pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684ca9fa290c832c99898b71969fa292