### PR TITLE
Fix async endpoint 404 handling

### DIFF
--- a/imednet/core/async_client.py
+++ b/imednet/core/async_client.py
@@ -23,7 +23,6 @@ from tenacity import (
     wait_exponential,
 )
 
-from imednet.utils import sanitize_base_url
 from imednet.utils.json_logging import configure_json_logging
 
 from .client import Client
@@ -66,7 +65,7 @@ class AsyncClient:
         self.base_url = self.base_url.rstrip("/")
         if self.base_url.endswith("/api"):
             self.base_url = self.base_url[:-4]
-          
+
         self.timeout = timeout if isinstance(timeout, httpx.Timeout) else httpx.Timeout(timeout)
         self.retries = retries
         self.backoff_factor = backoff_factor

--- a/imednet/core/client.py
+++ b/imednet/core/client.py
@@ -44,7 +44,6 @@ from imednet.core.exceptions import (
     ServerError,
     UnauthorizedError,
 )
-from imednet.utils import sanitize_base_url
 from imednet.utils.json_logging import configure_json_logging
 
 logger = logging.getLogger(__name__)

--- a/imednet/endpoints/base.py
+++ b/imednet/endpoints/base.py
@@ -38,3 +38,19 @@ class BaseEndpoint:
         # join path segments after base path
         segments = [self.PATH.strip("/")] + [str(a).strip("/") for a in args]
         return "/" + "/".join(segments)
+
+    # ------------------------------------------------------------------
+    # Helper methods
+    # ------------------------------------------------------------------
+    def _fallback_from_list(self, study_key: str, item_id: Any, attr: str):
+        """Return an item from ``list`` when direct ``get`` fails."""
+        for item in self.list(study_key):  # type: ignore[attr-defined]
+            if str(getattr(item, attr)) == str(item_id):
+                return item
+        raise ValueError(f"{attr} {item_id} not found in study {study_key}")
+
+    async def _async_fallback_from_list(self, study_key: str, item_id: Any, attr: str):
+        for item in await self.async_list(study_key):  # type: ignore[attr-defined]
+            if str(getattr(item, attr)) == str(item_id):
+                return item
+        raise ValueError(f"{attr} {item_id} not found in study {study_key}")

--- a/imednet/endpoints/intervals.py
+++ b/imednet/endpoints/intervals.py
@@ -5,6 +5,7 @@ from typing import Any, Dict, List, Optional
 from imednet.core.async_client import AsyncClient
 from imednet.core.client import Client
 from imednet.core.context import Context
+from imednet.core.exceptions import NotFoundError
 from imednet.core.paginator import AsyncPaginator, Paginator
 from imednet.endpoints.base import BaseEndpoint
 from imednet.models.intervals import Interval
@@ -102,7 +103,10 @@ class IntervalsEndpoint(BaseEndpoint):
             Interval object
         """
         path = self._build_path(study_key, "intervals", interval_id)
-        raw = self._client.get(path).json().get("data", [])
+        try:
+            raw = self._client.get(path).json().get("data", [])
+        except NotFoundError:
+            return self._fallback_from_list(study_key, interval_id, "interval_id")
         if not raw:
             raise ValueError(f"Interval {interval_id} not found in study {study_key}")
         return Interval.from_json(raw[0])
@@ -112,7 +116,10 @@ class IntervalsEndpoint(BaseEndpoint):
         if self._async_client is None:
             raise RuntimeError("Async client not configured")
         path = self._build_path(study_key, "intervals", interval_id)
-        raw = (await self._async_client.get(path)).json().get("data", [])
+        try:
+            raw = (await self._async_client.get(path)).json().get("data", [])
+        except NotFoundError:
+            return await self._async_fallback_from_list(study_key, interval_id, "interval_id")
         if not raw:
             raise ValueError(f"Interval {interval_id} not found in study {study_key}")
         return Interval.from_json(raw[0])

--- a/imednet/endpoints/queries.py
+++ b/imednet/endpoints/queries.py
@@ -2,6 +2,7 @@
 
 from typing import Any, Dict, List, Optional
 
+from imednet.core.exceptions import NotFoundError
 from imednet.core.paginator import AsyncPaginator, Paginator
 from imednet.endpoints.base import BaseEndpoint
 from imednet.models.queries import Query
@@ -68,7 +69,10 @@ class QueriesEndpoint(BaseEndpoint):
             Query object
         """
         path = self._build_path(study_key, "queries", annotation_id)
-        raw = self._client.get(path).json().get("data", [])
+        try:
+            raw = self._client.get(path).json().get("data", [])
+        except NotFoundError:
+            return self._fallback_from_list(study_key, annotation_id, "annotation_id")
         if not raw:
             raise ValueError(f"Query {annotation_id} not found in study {study_key}")
         return Query.from_json(raw[0])
@@ -78,7 +82,10 @@ class QueriesEndpoint(BaseEndpoint):
         if self._async_client is None:
             raise RuntimeError("Async client not configured")
         path = self._build_path(study_key, "queries", annotation_id)
-        raw = (await self._async_client.get(path)).json().get("data", [])
+        try:
+            raw = (await self._async_client.get(path)).json().get("data", [])
+        except NotFoundError:
+            return await self._async_fallback_from_list(study_key, annotation_id, "annotation_id")
         if not raw:
             raise ValueError(f"Query {annotation_id} not found in study {study_key}")
         return Query.from_json(raw[0])

--- a/imednet/endpoints/record_revisions.py
+++ b/imednet/endpoints/record_revisions.py
@@ -2,6 +2,7 @@
 
 from typing import Any, Dict, List, Optional
 
+from imednet.core.exceptions import NotFoundError
 from imednet.core.paginator import AsyncPaginator, Paginator
 from imednet.endpoints.base import BaseEndpoint
 from imednet.models.record_revisions import RecordRevision
@@ -70,7 +71,10 @@ class RecordRevisionsEndpoint(BaseEndpoint):
             RecordRevision object
         """
         path = self._build_path(study_key, "recordRevisions", record_revision_id)
-        raw = self._client.get(path).json().get("data", [])
+        try:
+            raw = self._client.get(path).json().get("data", [])
+        except NotFoundError:
+            return self._fallback_from_list(study_key, record_revision_id, "record_revision_id")
         if not raw:
             raise ValueError(f"Record revision {record_revision_id} not found in study {study_key}")
         return RecordRevision.from_json(raw[0])
@@ -80,7 +84,14 @@ class RecordRevisionsEndpoint(BaseEndpoint):
         if self._async_client is None:
             raise RuntimeError("Async client not configured")
         path = self._build_path(study_key, "recordRevisions", record_revision_id)
-        raw = (await self._async_client.get(path)).json().get("data", [])
+        try:
+            raw = (await self._async_client.get(path)).json().get("data", [])
+        except NotFoundError:
+            return await self._async_fallback_from_list(
+                study_key,
+                record_revision_id,
+                "record_revision_id",
+            )
         if not raw:
             raise ValueError(f"Record revision {record_revision_id} not found in study {study_key}")
         return RecordRevision.from_json(raw[0])

--- a/imednet/endpoints/sites.py
+++ b/imednet/endpoints/sites.py
@@ -2,6 +2,7 @@
 
 from typing import Any, Dict, List, Optional
 
+from imednet.core.exceptions import NotFoundError
 from imednet.core.paginator import AsyncPaginator, Paginator
 from imednet.endpoints.base import BaseEndpoint
 from imednet.models.sites import Site
@@ -76,7 +77,10 @@ class SitesEndpoint(BaseEndpoint):
             Site object
         """
         path = self._build_path(study_key, "sites", site_id)
-        raw = self._client.get(path).json().get("data", [])
+        try:
+            raw = self._client.get(path).json().get("data", [])
+        except NotFoundError:
+            return self._fallback_from_list(study_key, site_id, "site_id")
         if not raw:
             raise ValueError(f"Site {site_id} not found in study {study_key}")
         return Site.from_json(raw[0])
@@ -86,7 +90,10 @@ class SitesEndpoint(BaseEndpoint):
         if self._async_client is None:
             raise RuntimeError("Async client not configured")
         path = self._build_path(study_key, "sites", site_id)
-        raw = (await self._async_client.get(path)).json().get("data", [])
+        try:
+            raw = (await self._async_client.get(path)).json().get("data", [])
+        except NotFoundError:
+            return await self._async_fallback_from_list(study_key, site_id, "site_id")
         if not raw:
             raise ValueError(f"Site {site_id} not found in study {study_key}")
         return Site.from_json(raw[0])

--- a/imednet/endpoints/subjects.py
+++ b/imednet/endpoints/subjects.py
@@ -2,6 +2,7 @@
 
 from typing import Any, Dict, List, Optional
 
+from imednet.core.exceptions import NotFoundError
 from imednet.core.paginator import AsyncPaginator, Paginator
 from imednet.endpoints.base import BaseEndpoint
 from imednet.models.subjects import Subject
@@ -68,7 +69,10 @@ class SubjectsEndpoint(BaseEndpoint):
             Subject object
         """
         path = self._build_path(study_key, "subjects", subject_key)
-        raw = self._client.get(path).json().get("data", [])
+        try:
+            raw = self._client.get(path).json().get("data", [])
+        except NotFoundError:
+            return self._fallback_from_list(study_key, subject_key, "subject_key")
         if not raw:
             raise ValueError(f"Subject {subject_key} not found in study {study_key}")
         return Subject.from_json(raw[0])
@@ -78,7 +82,10 @@ class SubjectsEndpoint(BaseEndpoint):
         if self._async_client is None:
             raise RuntimeError("Async client not configured")
         path = self._build_path(study_key, "subjects", subject_key)
-        raw = (await self._async_client.get(path)).json().get("data", [])
+        try:
+            raw = (await self._async_client.get(path)).json().get("data", [])
+        except NotFoundError:
+            return await self._async_fallback_from_list(study_key, subject_key, "subject_key")
         if not raw:
             raise ValueError(f"Subject {subject_key} not found in study {study_key}")
         return Subject.from_json(raw[0])

--- a/imednet/endpoints/visits.py
+++ b/imednet/endpoints/visits.py
@@ -2,6 +2,7 @@
 
 from typing import Any, Dict, List, Optional
 
+from imednet.core.exceptions import NotFoundError
 from imednet.core.paginator import AsyncPaginator, Paginator
 from imednet.endpoints.base import BaseEndpoint
 from imednet.models.visits import Visit
@@ -68,7 +69,10 @@ class VisitsEndpoint(BaseEndpoint):
             Visit object
         """
         path = self._build_path(study_key, "visits", visit_id)
-        raw = self._client.get(path).json().get("data", [])
+        try:
+            raw = self._client.get(path).json().get("data", [])
+        except NotFoundError:
+            return self._fallback_from_list(study_key, visit_id, "visit_id")
         if not raw:
             raise ValueError(f"Visit {visit_id} not found in study {study_key}")
         return Visit.from_json(raw[0])
@@ -78,7 +82,10 @@ class VisitsEndpoint(BaseEndpoint):
         if self._async_client is None:
             raise RuntimeError("Async client not configured")
         path = self._build_path(study_key, "visits", visit_id)
-        raw = (await self._async_client.get(path)).json().get("data", [])
+        try:
+            raw = (await self._async_client.get(path)).json().get("data", [])
+        except NotFoundError:
+            return await self._async_fallback_from_list(study_key, visit_id, "visit_id")
         if not raw:
             raise ValueError(f"Visit {visit_id} not found in study {study_key}")
         return Visit.from_json(raw[0])


### PR DESCRIPTION
## Summary
- add fallback helpers to BaseEndpoint
- handle 404 errors by falling back to list lookup for single-record endpoints
- remove unused sanitize_base_url imports

## Testing
- `poetry run ruff check --fix .`
- `poetry run black --check .`
- `poetry run mypy imednet`
- `poetry run pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684caa8128a0832c911905cf85db57f2