### PR TITLE
Use list() filtering for single-object retrieval

### DIFF
--- a/imednet/core/async_client.py
+++ b/imednet/core/async_client.py
@@ -23,7 +23,6 @@ from tenacity import (
     wait_exponential,
 )
 
-from imednet.utils import sanitize_base_url
 from imednet.utils.json_logging import configure_json_logging
 
 from .client import Client
@@ -66,7 +65,7 @@ class AsyncClient:
         self.base_url = self.base_url.rstrip("/")
         if self.base_url.endswith("/api"):
             self.base_url = self.base_url[:-4]
-          
+
         self.timeout = timeout if isinstance(timeout, httpx.Timeout) else httpx.Timeout(timeout)
         self.retries = retries
         self.backoff_factor = backoff_factor

--- a/imednet/core/client.py
+++ b/imednet/core/client.py
@@ -44,7 +44,6 @@ from imednet.core.exceptions import (
     ServerError,
     UnauthorizedError,
 )
-from imednet.utils import sanitize_base_url
 from imednet.utils.json_logging import configure_json_logging
 
 logger = logging.getLogger(__name__)

--- a/imednet/endpoints/codings.py
+++ b/imednet/endpoints/codings.py
@@ -77,18 +77,16 @@ class CodingsEndpoint(BaseEndpoint):
             Coding object
         """
 
-        path = self._build_path(study_key, "codings", coding_id)
-        raw = self._client.get(path).json().get("data", [])
-        if not raw:
+        codings = self.list(study_key=study_key, refresh=True, codingId=coding_id)
+        if not codings:
             raise ValueError(f"Coding {coding_id} not found in study {study_key}")
-        return Coding.from_json(raw[0])
+        return codings[0]
 
     async def async_get(self, study_key: str, coding_id: str) -> Coding:
         """Asynchronous version of :meth:`get`."""
         if self._async_client is None:
             raise RuntimeError("Async client not configured")
-        path = self._build_path(study_key, "codings", coding_id)
-        raw = (await self._async_client.get(path)).json().get("data", [])
-        if not raw:
+        codings = await self.async_list(study_key=study_key, refresh=True, codingId=coding_id)
+        if not codings:
             raise ValueError(f"Coding {coding_id} not found in study {study_key}")
-        return Coding.from_json(raw[0])
+        return codings[0]

--- a/imednet/endpoints/forms.py
+++ b/imednet/endpoints/forms.py
@@ -107,18 +107,16 @@ class FormsEndpoint(BaseEndpoint):
         Returns:
             Form object
         """
-        path = self._build_path(study_key, "forms", form_id)
-        raw = self._client.get(path).json().get("data", [])
-        if not raw:
+        forms = self.list(study_key=study_key, refresh=True, formId=form_id)
+        if not forms:
             raise ValueError(f"Form {form_id} not found in study {study_key}")
-        return Form.from_json(raw[0])
+        return forms[0]
 
     async def async_get(self, study_key: str, form_id: int) -> Form:
         """Asynchronous version of :meth:`get`."""
         if self._async_client is None:
             raise RuntimeError("Async client not configured")
-        path = self._build_path(study_key, "forms", form_id)
-        raw = (await self._async_client.get(path)).json().get("data", [])
-        if not raw:
+        forms = await self.async_list(study_key=study_key, refresh=True, formId=form_id)
+        if not forms:
             raise ValueError(f"Form {form_id} not found in study {study_key}")
-        return Form.from_json(raw[0])
+        return forms[0]

--- a/imednet/endpoints/intervals.py
+++ b/imednet/endpoints/intervals.py
@@ -101,18 +101,16 @@ class IntervalsEndpoint(BaseEndpoint):
         Returns:
             Interval object
         """
-        path = self._build_path(study_key, "intervals", interval_id)
-        raw = self._client.get(path).json().get("data", [])
-        if not raw:
+        intervals = self.list(study_key=study_key, refresh=True, intervalId=interval_id)
+        if not intervals:
             raise ValueError(f"Interval {interval_id} not found in study {study_key}")
-        return Interval.from_json(raw[0])
+        return intervals[0]
 
     async def async_get(self, study_key: str, interval_id: int) -> Interval:
         """Asynchronous version of :meth:`get`."""
         if self._async_client is None:
             raise RuntimeError("Async client not configured")
-        path = self._build_path(study_key, "intervals", interval_id)
-        raw = (await self._async_client.get(path)).json().get("data", [])
-        if not raw:
+        intervals = await self.async_list(study_key=study_key, refresh=True, intervalId=interval_id)
+        if not intervals:
             raise ValueError(f"Interval {interval_id} not found in study {study_key}")
-        return Interval.from_json(raw[0])
+        return intervals[0]

--- a/imednet/endpoints/queries.py
+++ b/imednet/endpoints/queries.py
@@ -67,18 +67,18 @@ class QueriesEndpoint(BaseEndpoint):
         Returns:
             Query object
         """
-        path = self._build_path(study_key, "queries", annotation_id)
-        raw = self._client.get(path).json().get("data", [])
-        if not raw:
+        queries = self.list(study_key=study_key, refresh=True, annotationId=annotation_id)
+        if not queries:
             raise ValueError(f"Query {annotation_id} not found in study {study_key}")
-        return Query.from_json(raw[0])
+        return queries[0]
 
     async def async_get(self, study_key: str, annotation_id: int) -> Query:
         """Asynchronous version of :meth:`get`."""
         if self._async_client is None:
             raise RuntimeError("Async client not configured")
-        path = self._build_path(study_key, "queries", annotation_id)
-        raw = (await self._async_client.get(path)).json().get("data", [])
-        if not raw:
+        queries = await self.async_list(
+            study_key=study_key, refresh=True, annotationId=annotation_id
+        )
+        if not queries:
             raise ValueError(f"Query {annotation_id} not found in study {study_key}")
-        return Query.from_json(raw[0])
+        return queries[0]

--- a/imednet/endpoints/record_revisions.py
+++ b/imednet/endpoints/record_revisions.py
@@ -69,18 +69,24 @@ class RecordRevisionsEndpoint(BaseEndpoint):
         Returns:
             RecordRevision object
         """
-        path = self._build_path(study_key, "recordRevisions", record_revision_id)
-        raw = self._client.get(path).json().get("data", [])
-        if not raw:
+        revisions = self.list(
+            study_key=study_key,
+            refresh=True,
+            recordRevisionId=record_revision_id,
+        )
+        if not revisions:
             raise ValueError(f"Record revision {record_revision_id} not found in study {study_key}")
-        return RecordRevision.from_json(raw[0])
+        return revisions[0]
 
     async def async_get(self, study_key: str, record_revision_id: int) -> RecordRevision:
         """Asynchronous version of :meth:`get`."""
         if self._async_client is None:
             raise RuntimeError("Async client not configured")
-        path = self._build_path(study_key, "recordRevisions", record_revision_id)
-        raw = (await self._async_client.get(path)).json().get("data", [])
-        if not raw:
+        revisions = await self.async_list(
+            study_key=study_key,
+            refresh=True,
+            recordRevisionId=record_revision_id,
+        )
+        if not revisions:
             raise ValueError(f"Record revision {record_revision_id} not found in study {study_key}")
-        return RecordRevision.from_json(raw[0])
+        return revisions[0]

--- a/imednet/endpoints/records.py
+++ b/imednet/endpoints/records.py
@@ -82,21 +82,19 @@ class RecordsEndpoint(BaseEndpoint):
         Returns:
             Record object
         """
-        path = self._build_path(study_key, "records", record_id)
-        raw = self._client.get(path).json().get("data", [])
-        if not raw:
+        records = self.list(study_key=study_key, refresh=True, recordId=record_id)
+        if not records:
             raise ValueError(f"Record {record_id} not found in study {study_key}")
-        return Record.from_json(raw[0])
+        return records[0]
 
     async def async_get(self, study_key: str, record_id: Union[str, int]) -> Record:
         """Asynchronous version of :meth:`get`."""
         if self._async_client is None:
             raise RuntimeError("Async client not configured")
-        path = self._build_path(study_key, "records", record_id)
-        raw = (await self._async_client.get(path)).json().get("data", [])
-        if not raw:
+        records = await self.async_list(study_key=study_key, refresh=True, recordId=record_id)
+        if not records:
             raise ValueError(f"Record {record_id} not found in study {study_key}")
-        return Record.from_json(raw[0])
+        return records[0]
 
     def create(
         self,

--- a/imednet/endpoints/sites.py
+++ b/imednet/endpoints/sites.py
@@ -75,18 +75,16 @@ class SitesEndpoint(BaseEndpoint):
         Returns:
             Site object
         """
-        path = self._build_path(study_key, "sites", site_id)
-        raw = self._client.get(path).json().get("data", [])
-        if not raw:
+        sites = self.list(study_key=study_key, refresh=True, siteId=site_id)
+        if not sites:
             raise ValueError(f"Site {site_id} not found in study {study_key}")
-        return Site.from_json(raw[0])
+        return sites[0]
 
     async def async_get(self, study_key: str, site_id: int) -> Site:
         """Asynchronous version of :meth:`get`."""
         if self._async_client is None:
             raise RuntimeError("Async client not configured")
-        path = self._build_path(study_key, "sites", site_id)
-        raw = (await self._async_client.get(path)).json().get("data", [])
-        if not raw:
+        sites = await self.async_list(study_key=study_key, refresh=True, siteId=site_id)
+        if not sites:
             raise ValueError(f"Site {site_id} not found in study {study_key}")
-        return Site.from_json(raw[0])
+        return sites[0]

--- a/imednet/endpoints/subjects.py
+++ b/imednet/endpoints/subjects.py
@@ -67,18 +67,16 @@ class SubjectsEndpoint(BaseEndpoint):
         Returns:
             Subject object
         """
-        path = self._build_path(study_key, "subjects", subject_key)
-        raw = self._client.get(path).json().get("data", [])
-        if not raw:
+        subjects = self.list(study_key=study_key, refresh=True, subjectKey=subject_key)
+        if not subjects:
             raise ValueError(f"Subject {subject_key} not found in study {study_key}")
-        return Subject.from_json(raw[0])
+        return subjects[0]
 
     async def async_get(self, study_key: str, subject_key: str) -> Subject:
         """Asynchronous version of :meth:`get`."""
         if self._async_client is None:
             raise RuntimeError("Async client not configured")
-        path = self._build_path(study_key, "subjects", subject_key)
-        raw = (await self._async_client.get(path)).json().get("data", [])
-        if not raw:
+        subjects = await self.async_list(study_key=study_key, refresh=True, subjectKey=subject_key)
+        if not subjects:
             raise ValueError(f"Subject {subject_key} not found in study {study_key}")
-        return Subject.from_json(raw[0])
+        return subjects[0]

--- a/imednet/endpoints/users.py
+++ b/imednet/endpoints/users.py
@@ -64,18 +64,18 @@ class UsersEndpoint(BaseEndpoint):
         Returns:
             User object
         """
-        path = self._build_path(study_key, "users", user_id)
-        raw = self._client.get(path).json().get("data", [])
-        if not raw:
+        users = self.list(study_key=study_key)
+        filtered = [u for u in users if str(u.user_id) == str(user_id)]
+        if not filtered:
             raise ValueError(f"User {user_id} not found in study {study_key}")
-        return User.from_json(raw[0])
+        return filtered[0]
 
     async def async_get(self, study_key: str, user_id: Union[str, int]) -> User:
         """Asynchronous version of :meth:`get`."""
         if self._async_client is None:
             raise RuntimeError("Async client not configured")
-        path = self._build_path(study_key, "users", user_id)
-        raw = (await self._async_client.get(path)).json().get("data", [])
-        if not raw:
+        users = await self.async_list(study_key=study_key)
+        filtered = [u for u in users if str(u.user_id) == str(user_id)]
+        if not filtered:
             raise ValueError(f"User {user_id} not found in study {study_key}")
-        return User.from_json(raw[0])
+        return filtered[0]

--- a/imednet/endpoints/variables.py
+++ b/imednet/endpoints/variables.py
@@ -101,18 +101,16 @@ class VariablesEndpoint(BaseEndpoint):
         Returns:
             Variable object
         """
-        path = self._build_path(study_key, "variables", variable_id)
-        raw = self._client.get(path).json().get("data", [])
-        if not raw:
+        variables = self.list(study_key=study_key, refresh=True, variableId=variable_id)
+        if not variables:
             raise ValueError(f"Variable {variable_id} not found in study {study_key}")
-        return Variable.from_json(raw[0])
+        return variables[0]
 
     async def async_get(self, study_key: str, variable_id: int) -> Variable:
         """Asynchronous version of :meth:`get`."""
         if self._async_client is None:
             raise RuntimeError("Async client not configured")
-        path = self._build_path(study_key, "variables", variable_id)
-        raw = (await self._async_client.get(path)).json().get("data", [])
-        if not raw:
+        variables = await self.async_list(study_key=study_key, refresh=True, variableId=variable_id)
+        if not variables:
             raise ValueError(f"Variable {variable_id} not found in study {study_key}")
-        return Variable.from_json(raw[0])
+        return variables[0]

--- a/imednet/endpoints/visits.py
+++ b/imednet/endpoints/visits.py
@@ -67,18 +67,16 @@ class VisitsEndpoint(BaseEndpoint):
         Returns:
             Visit object
         """
-        path = self._build_path(study_key, "visits", visit_id)
-        raw = self._client.get(path).json().get("data", [])
-        if not raw:
+        visits = self.list(study_key=study_key, refresh=True, visitId=visit_id)
+        if not visits:
             raise ValueError(f"Visit {visit_id} not found in study {study_key}")
-        return Visit.from_json(raw[0])
+        return visits[0]
 
     async def async_get(self, study_key: str, visit_id: int) -> Visit:
         """Asynchronous version of :meth:`get`."""
         if self._async_client is None:
             raise RuntimeError("Async client not configured")
-        path = self._build_path(study_key, "visits", visit_id)
-        raw = (await self._async_client.get(path)).json().get("data", [])
-        if not raw:
+        visits = await self.async_list(study_key=study_key, refresh=True, visitId=visit_id)
+        if not visits:
             raise ValueError(f"Visit {visit_id} not found in study {study_key}")
-        return Visit.from_json(raw[0])
+        return visits[0]

--- a/tests/unit/endpoints/test_codings_endpoint.py
+++ b/tests/unit/endpoints/test_codings_endpoint.py
@@ -19,8 +19,8 @@ def test_list_requires_study_key(dummy_client, context, paginator_factory, patch
     assert isinstance(result[0], Coding)
 
 
-def test_get_not_found(dummy_client, context, response_factory):
+def test_get_not_found(dummy_client, context, monkeypatch):
     ep = codings.CodingsEndpoint(dummy_client, context)
-    dummy_client.get.return_value = response_factory({"data": []})
+    monkeypatch.setattr(ep, "list", lambda **kwargs: [])
     with pytest.raises(ValueError):
         ep.get("S1", "x")

--- a/tests/unit/endpoints/test_endpoints_async.py
+++ b/tests/unit/endpoints/test_endpoints_async.py
@@ -156,26 +156,33 @@ async def test_async_get_job(dummy_client, context, response_factory):
 
 
 @pytest.mark.asyncio
-async def test_async_get_record(dummy_client, context, response_factory):
+async def test_async_get_record(dummy_client, context, monkeypatch):
     ep = records.RecordsEndpoint(dummy_client, context, async_client=dummy_client)
+    captured = {}
 
-    async def fake_get(path):
-        assert path == "/api/v1/edc/studies/S1/records/1"
-        return response_factory({"data": [{"recordId": 1}]})
+    async def fake_list(study_key=None, refresh=False, **filters):
+        captured["study_key"] = study_key
+        captured["refresh"] = refresh
+        captured["filters"] = filters
+        return [Record(record_id=1)]
 
-    dummy_client.get = fake_get
+    monkeypatch.setattr(ep, "async_list", fake_list)
+
     rec = await ep.async_get("S1", 1)
+
+    assert captured == {"study_key": "S1", "refresh": True, "filters": {"recordId": 1}}
     assert isinstance(rec, Record)
 
 
 @pytest.mark.asyncio
-async def test_async_get_record_not_found(dummy_client, context, response_factory):
+async def test_async_get_record_not_found(dummy_client, context, monkeypatch):
     ep = records.RecordsEndpoint(dummy_client, context, async_client=dummy_client)
 
-    async def fake_get(path):
-        return response_factory({"data": []})
+    async def fake_list(**kwargs):
+        return []
 
-    dummy_client.get = fake_get
+    monkeypatch.setattr(ep, "async_list", fake_list)
+
     with pytest.raises(ValueError):
         await ep.async_get("S1", 1)
 

--- a/tests/unit/endpoints/test_intervals_endpoint.py
+++ b/tests/unit/endpoints/test_intervals_endpoint.py
@@ -20,9 +20,9 @@ def test_list_uses_default_study_and_page_size(
     assert isinstance(result[0], Interval)
 
 
-def test_get_not_found(dummy_client, context, response_factory):
+def test_get_not_found(dummy_client, context, monkeypatch):
     ep = intervals.IntervalsEndpoint(dummy_client, context)
-    dummy_client.get.return_value = response_factory({"data": []})
+    monkeypatch.setattr(ep, "list", lambda **kwargs: [])
     with pytest.raises(ValueError):
         ep.get("S1", 1)
 

--- a/tests/unit/endpoints/test_queries_endpoint.py
+++ b/tests/unit/endpoints/test_queries_endpoint.py
@@ -17,8 +17,8 @@ def test_list_builds_path_and_filters(dummy_client, context, paginator_factory, 
     assert isinstance(result[0], Query)
 
 
-def test_get_not_found(dummy_client, context, response_factory):
+def test_get_not_found(dummy_client, context, monkeypatch):
     ep = queries.QueriesEndpoint(dummy_client, context)
-    dummy_client.get.return_value = response_factory({"data": []})
+    monkeypatch.setattr(ep, "list", lambda **kwargs: [])
     with pytest.raises(ValueError):
         ep.get("S1", 1)

--- a/tests/unit/endpoints/test_record_revisions_endpoint.py
+++ b/tests/unit/endpoints/test_record_revisions_endpoint.py
@@ -17,8 +17,8 @@ def test_list_uses_filters(dummy_client, context, paginator_factory, patch_build
     assert isinstance(result[0], RecordRevision)
 
 
-def test_get_not_found(dummy_client, context, response_factory):
+def test_get_not_found(dummy_client, context, monkeypatch):
     ep = record_revisions.RecordRevisionsEndpoint(dummy_client, context)
-    dummy_client.get.return_value = response_factory({"data": []})
+    monkeypatch.setattr(ep, "list", lambda **kwargs: [])
     with pytest.raises(ValueError):
         ep.get("S1", 1)

--- a/tests/unit/endpoints/test_sites_endpoint.py
+++ b/tests/unit/endpoints/test_sites_endpoint.py
@@ -19,8 +19,8 @@ def test_list_requires_study_key(dummy_client, context, paginator_factory, patch
     assert isinstance(result[0], Site)
 
 
-def test_get_not_found(dummy_client, context, response_factory):
+def test_get_not_found(dummy_client, context, monkeypatch):
     ep = sites.SitesEndpoint(dummy_client, context)
-    dummy_client.get.return_value = response_factory({"data": []})
+    monkeypatch.setattr(ep, "list", lambda **kwargs: [])
     with pytest.raises(ValueError):
         ep.get("S1", 1)

--- a/tests/unit/endpoints/test_subjects_endpoint.py
+++ b/tests/unit/endpoints/test_subjects_endpoint.py
@@ -19,8 +19,8 @@ def test_list_builds_path_with_default(
     assert isinstance(result[0], Subject)
 
 
-def test_get_not_found(dummy_client, context, response_factory):
+def test_get_not_found(dummy_client, context, monkeypatch):
     ep = subjects.SubjectsEndpoint(dummy_client, context)
-    dummy_client.get.return_value = response_factory({"data": []})
+    monkeypatch.setattr(ep, "list", lambda **kwargs: [])
     with pytest.raises(ValueError):
         ep.get("S1", "X")

--- a/tests/unit/endpoints/test_users_endpoint.py
+++ b/tests/unit/endpoints/test_users_endpoint.py
@@ -17,8 +17,8 @@ def test_list_requires_study_key_and_include_inactive(dummy_client, context, pag
     assert isinstance(result[0], User)
 
 
-def test_get_not_found(dummy_client, context, response_factory):
+def test_get_not_found(dummy_client, context, monkeypatch):
     ep = users.UsersEndpoint(dummy_client, context)
-    dummy_client.get.return_value = response_factory({"data": []})
+    monkeypatch.setattr(ep, "list", lambda **kwargs: [])
     with pytest.raises(ValueError):
         ep.get("S1", 1)

--- a/tests/unit/endpoints/test_variables_endpoint.py
+++ b/tests/unit/endpoints/test_variables_endpoint.py
@@ -22,9 +22,9 @@ def test_list_requires_study_key_page_size(
     assert isinstance(result[0], Variable)
 
 
-def test_get_not_found(dummy_client, context, response_factory):
+def test_get_not_found(dummy_client, context, monkeypatch):
     ep = variables.VariablesEndpoint(dummy_client, context)
-    dummy_client.get.return_value = response_factory({"data": []})
+    monkeypatch.setattr(ep, "list", lambda **kwargs: [])
     with pytest.raises(ValueError):
         ep.get("S1", 1)
 

--- a/tests/unit/endpoints/test_visits_endpoint.py
+++ b/tests/unit/endpoints/test_visits_endpoint.py
@@ -17,8 +17,8 @@ def test_list_filters_and_path(dummy_client, context, paginator_factory, patch_b
     assert isinstance(result[0], Visit)
 
 
-def test_get_not_found(dummy_client, context, response_factory):
+def test_get_not_found(dummy_client, context, monkeypatch):
     ep = visits.VisitsEndpoint(dummy_client, context)
-    dummy_client.get.return_value = response_factory({"data": []})
+    monkeypatch.setattr(ep, "list", lambda **kwargs: [])
     with pytest.raises(ValueError):
         ep.get("S1", 1)


### PR DESCRIPTION
## Summary
- fetch single objects via list/async_list when retrieving endpoints
- update unit tests for new get logic
- lint with ruff/black and update types

## Testing
- `poetry run ruff check --fix .`
- `poetry run black --check .`
- `poetry run mypy imednet`
- `poetry run pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684cac46b60c832c8776fca12f16b6d7