### PR TITLE
Refactor get methods to use list filtering

### DIFF
--- a/imednet/endpoints/codings.py
+++ b/imednet/endpoints/codings.py
@@ -2,7 +2,6 @@
 
 from typing import Any, Dict, List, Optional
 
-from imednet.core.exceptions import NotFoundError
 from imednet.core.paginator import AsyncPaginator, Paginator
 from imednet.endpoints.base import BaseEndpoint
 from imednet.models.codings import Coding
@@ -78,24 +77,16 @@ class CodingsEndpoint(BaseEndpoint):
             Coding object
         """
 
-        path = self._build_path(study_key, "codings", coding_id)
-        try:
-            raw = self._client.get(path).json().get("data", [])
-        except NotFoundError:
-            return self._fallback_from_list(study_key, coding_id, "coding_id")
-        if not raw:
+        codings = self.list(study_key=study_key, refresh=True, codingId=coding_id)
+        if not codings:
             raise ValueError(f"Coding {coding_id} not found in study {study_key}")
-        return Coding.from_json(raw[0])
+        return codings[0]
 
     async def async_get(self, study_key: str, coding_id: str) -> Coding:
         """Asynchronous version of :meth:`get`."""
         if self._async_client is None:
             raise RuntimeError("Async client not configured")
-        path = self._build_path(study_key, "codings", coding_id)
-        try:
-            raw = (await self._async_client.get(path)).json().get("data", [])
-        except NotFoundError:
-            return await self._async_fallback_from_list(study_key, coding_id, "coding_id")
-        if not raw:
+        codings = await self.async_list(study_key=study_key, refresh=True, codingId=coding_id)
+        if not codings:
             raise ValueError(f"Coding {coding_id} not found in study {study_key}")
-        return Coding.from_json(raw[0])
+        return codings[0]

--- a/imednet/endpoints/forms.py
+++ b/imednet/endpoints/forms.py
@@ -5,7 +5,6 @@ from typing import Any, Dict, List, Optional
 from imednet.core.async_client import AsyncClient
 from imednet.core.client import Client
 from imednet.core.context import Context
-from imednet.core.exceptions import NotFoundError
 from imednet.core.paginator import AsyncPaginator, Paginator
 from imednet.endpoints.base import BaseEndpoint
 from imednet.models.forms import Form
@@ -108,24 +107,16 @@ class FormsEndpoint(BaseEndpoint):
         Returns:
             Form object
         """
-        path = self._build_path(study_key, "forms", form_id)
-        try:
-            raw = self._client.get(path).json().get("data", [])
-        except NotFoundError:
-            return self._fallback_from_list(study_key, form_id, "form_id")
-        if not raw:
+        forms = self.list(study_key=study_key, refresh=True, formId=form_id)
+        if not forms:
             raise ValueError(f"Form {form_id} not found in study {study_key}")
-        return Form.from_json(raw[0])
+        return forms[0]
 
     async def async_get(self, study_key: str, form_id: int) -> Form:
         """Asynchronous version of :meth:`get`."""
         if self._async_client is None:
             raise RuntimeError("Async client not configured")
-        path = self._build_path(study_key, "forms", form_id)
-        try:
-            raw = (await self._async_client.get(path)).json().get("data", [])
-        except NotFoundError:
-            return await self._async_fallback_from_list(study_key, form_id, "form_id")
-        if not raw:
+        forms = await self.async_list(study_key=study_key, refresh=True, formId=form_id)
+        if not forms:
             raise ValueError(f"Form {form_id} not found in study {study_key}")
-        return Form.from_json(raw[0])
+        return forms[0]

--- a/imednet/endpoints/queries.py
+++ b/imednet/endpoints/queries.py
@@ -2,7 +2,6 @@
 
 from typing import Any, Dict, List, Optional
 
-from imednet.core.exceptions import NotFoundError
 from imednet.core.paginator import AsyncPaginator, Paginator
 from imednet.endpoints.base import BaseEndpoint
 from imednet.models.queries import Query
@@ -68,24 +67,18 @@ class QueriesEndpoint(BaseEndpoint):
         Returns:
             Query object
         """
-        path = self._build_path(study_key, "queries", annotation_id)
-        try:
-            raw = self._client.get(path).json().get("data", [])
-        except NotFoundError:
-            return self._fallback_from_list(study_key, annotation_id, "annotation_id")
-        if not raw:
+        queries = self.list(study_key=study_key, refresh=True, annotationId=annotation_id)
+        if not queries:
             raise ValueError(f"Query {annotation_id} not found in study {study_key}")
-        return Query.from_json(raw[0])
+        return queries[0]
 
     async def async_get(self, study_key: str, annotation_id: int) -> Query:
         """Asynchronous version of :meth:`get`."""
         if self._async_client is None:
             raise RuntimeError("Async client not configured")
-        path = self._build_path(study_key, "queries", annotation_id)
-        try:
-            raw = (await self._async_client.get(path)).json().get("data", [])
-        except NotFoundError:
-            return await self._async_fallback_from_list(study_key, annotation_id, "annotation_id")
-        if not raw:
+        queries = await self.async_list(
+            study_key=study_key, refresh=True, annotationId=annotation_id
+        )
+        if not queries:
             raise ValueError(f"Query {annotation_id} not found in study {study_key}")
-        return Query.from_json(raw[0])
+        return queries[0]

--- a/imednet/endpoints/record_revisions.py
+++ b/imednet/endpoints/record_revisions.py
@@ -2,7 +2,6 @@
 
 from typing import Any, Dict, List, Optional
 
-from imednet.core.exceptions import NotFoundError
 from imednet.core.paginator import AsyncPaginator, Paginator
 from imednet.endpoints.base import BaseEndpoint
 from imednet.models.record_revisions import RecordRevision
@@ -70,28 +69,20 @@ class RecordRevisionsEndpoint(BaseEndpoint):
         Returns:
             RecordRevision object
         """
-        path = self._build_path(study_key, "recordRevisions", record_revision_id)
-        try:
-            raw = self._client.get(path).json().get("data", [])
-        except NotFoundError:
-            return self._fallback_from_list(study_key, record_revision_id, "record_revision_id")
-        if not raw:
+        revisions = self.list(
+            study_key=study_key, refresh=True, recordRevisionId=record_revision_id
+        )
+        if not revisions:
             raise ValueError(f"Record revision {record_revision_id} not found in study {study_key}")
-        return RecordRevision.from_json(raw[0])
+        return revisions[0]
 
     async def async_get(self, study_key: str, record_revision_id: int) -> RecordRevision:
         """Asynchronous version of :meth:`get`."""
         if self._async_client is None:
             raise RuntimeError("Async client not configured")
-        path = self._build_path(study_key, "recordRevisions", record_revision_id)
-        try:
-            raw = (await self._async_client.get(path)).json().get("data", [])
-        except NotFoundError:
-            return await self._async_fallback_from_list(
-                study_key,
-                record_revision_id,
-                "record_revision_id",
-            )
-        if not raw:
+        revisions = await self.async_list(
+            study_key=study_key, refresh=True, recordRevisionId=record_revision_id
+        )
+        if not revisions:
             raise ValueError(f"Record revision {record_revision_id} not found in study {study_key}")
-        return RecordRevision.from_json(raw[0])
+        return revisions[0]

--- a/imednet/endpoints/records.py
+++ b/imednet/endpoints/records.py
@@ -2,7 +2,6 @@
 
 from typing import Any, Dict, List, Optional, Union
 
-from imednet.core.exceptions import NotFoundError
 from imednet.core.paginator import AsyncPaginator, Paginator
 from imednet.endpoints.base import BaseEndpoint
 from imednet.models.jobs import Job
@@ -83,27 +82,19 @@ class RecordsEndpoint(BaseEndpoint):
         Returns:
             Record object
         """
-        path = self._build_path(study_key, "records", record_id)
-        try:
-            raw = self._client.get(path).json().get("data", [])
-        except NotFoundError:
-            return self._fallback_from_list(study_key, record_id, "record_id")
-        if not raw:
+        records = self.list(study_key=study_key, refresh=True, recordId=record_id)
+        if not records:
             raise ValueError(f"Record {record_id} not found in study {study_key}")
-        return Record.from_json(raw[0])
+        return records[0]
 
     async def async_get(self, study_key: str, record_id: Union[str, int]) -> Record:
         """Asynchronous version of :meth:`get`."""
         if self._async_client is None:
             raise RuntimeError("Async client not configured")
-        path = self._build_path(study_key, "records", record_id)
-        try:
-            raw = (await self._async_client.get(path)).json().get("data", [])
-        except NotFoundError:
-            return await self._async_fallback_from_list(study_key, record_id, "record_id")
-        if not raw:
+        records = await self.async_list(study_key=study_key, refresh=True, recordId=record_id)
+        if not records:
             raise ValueError(f"Record {record_id} not found in study {study_key}")
-        return Record.from_json(raw[0])
+        return records[0]
 
     def create(
         self,

--- a/imednet/endpoints/sites.py
+++ b/imednet/endpoints/sites.py
@@ -2,7 +2,6 @@
 
 from typing import Any, Dict, List, Optional
 
-from imednet.core.exceptions import NotFoundError
 from imednet.core.paginator import AsyncPaginator, Paginator
 from imednet.endpoints.base import BaseEndpoint
 from imednet.models.sites import Site
@@ -76,24 +75,16 @@ class SitesEndpoint(BaseEndpoint):
         Returns:
             Site object
         """
-        path = self._build_path(study_key, "sites", site_id)
-        try:
-            raw = self._client.get(path).json().get("data", [])
-        except NotFoundError:
-            return self._fallback_from_list(study_key, site_id, "site_id")
-        if not raw:
+        sites = self.list(study_key=study_key, refresh=True, siteId=site_id)
+        if not sites:
             raise ValueError(f"Site {site_id} not found in study {study_key}")
-        return Site.from_json(raw[0])
+        return sites[0]
 
     async def async_get(self, study_key: str, site_id: int) -> Site:
         """Asynchronous version of :meth:`get`."""
         if self._async_client is None:
             raise RuntimeError("Async client not configured")
-        path = self._build_path(study_key, "sites", site_id)
-        try:
-            raw = (await self._async_client.get(path)).json().get("data", [])
-        except NotFoundError:
-            return await self._async_fallback_from_list(study_key, site_id, "site_id")
-        if not raw:
+        sites = await self.async_list(study_key=study_key, refresh=True, siteId=site_id)
+        if not sites:
             raise ValueError(f"Site {site_id} not found in study {study_key}")
-        return Site.from_json(raw[0])
+        return sites[0]

--- a/imednet/endpoints/subjects.py
+++ b/imednet/endpoints/subjects.py
@@ -2,7 +2,6 @@
 
 from typing import Any, Dict, List, Optional
 
-from imednet.core.exceptions import NotFoundError
 from imednet.core.paginator import AsyncPaginator, Paginator
 from imednet.endpoints.base import BaseEndpoint
 from imednet.models.subjects import Subject
@@ -68,24 +67,16 @@ class SubjectsEndpoint(BaseEndpoint):
         Returns:
             Subject object
         """
-        path = self._build_path(study_key, "subjects", subject_key)
-        try:
-            raw = self._client.get(path).json().get("data", [])
-        except NotFoundError:
-            return self._fallback_from_list(study_key, subject_key, "subject_key")
-        if not raw:
+        subjects = self.list(study_key=study_key, refresh=True, subjectKey=subject_key)
+        if not subjects:
             raise ValueError(f"Subject {subject_key} not found in study {study_key}")
-        return Subject.from_json(raw[0])
+        return subjects[0]
 
     async def async_get(self, study_key: str, subject_key: str) -> Subject:
         """Asynchronous version of :meth:`get`."""
         if self._async_client is None:
             raise RuntimeError("Async client not configured")
-        path = self._build_path(study_key, "subjects", subject_key)
-        try:
-            raw = (await self._async_client.get(path)).json().get("data", [])
-        except NotFoundError:
-            return await self._async_fallback_from_list(study_key, subject_key, "subject_key")
-        if not raw:
+        subjects = await self.async_list(study_key=study_key, refresh=True, subjectKey=subject_key)
+        if not subjects:
             raise ValueError(f"Subject {subject_key} not found in study {study_key}")
-        return Subject.from_json(raw[0])
+        return subjects[0]

--- a/imednet/endpoints/variables.py
+++ b/imednet/endpoints/variables.py
@@ -5,7 +5,6 @@ from typing import Any, Dict, List, Optional
 from imednet.core.async_client import AsyncClient
 from imednet.core.client import Client
 from imednet.core.context import Context
-from imednet.core.exceptions import NotFoundError
 from imednet.core.paginator import AsyncPaginator, Paginator
 from imednet.endpoints.base import BaseEndpoint
 from imednet.models.variables import Variable
@@ -102,24 +101,16 @@ class VariablesEndpoint(BaseEndpoint):
         Returns:
             Variable object
         """
-        path = self._build_path(study_key, "variables", variable_id)
-        try:
-            raw = self._client.get(path).json().get("data", [])
-        except NotFoundError:
-            return self._fallback_from_list(study_key, variable_id, "variable_id")
-        if not raw:
+        variables = self.list(study_key=study_key, refresh=True, variableId=variable_id)
+        if not variables:
             raise ValueError(f"Variable {variable_id} not found in study {study_key}")
-        return Variable.from_json(raw[0])
+        return variables[0]
 
     async def async_get(self, study_key: str, variable_id: int) -> Variable:
         """Asynchronous version of :meth:`get`."""
         if self._async_client is None:
             raise RuntimeError("Async client not configured")
-        path = self._build_path(study_key, "variables", variable_id)
-        try:
-            raw = (await self._async_client.get(path)).json().get("data", [])
-        except NotFoundError:
-            return await self._async_fallback_from_list(study_key, variable_id, "variable_id")
-        if not raw:
+        variables = await self.async_list(study_key=study_key, refresh=True, variableId=variable_id)
+        if not variables:
             raise ValueError(f"Variable {variable_id} not found in study {study_key}")
-        return Variable.from_json(raw[0])
+        return variables[0]

--- a/imednet/endpoints/visits.py
+++ b/imednet/endpoints/visits.py
@@ -2,7 +2,6 @@
 
 from typing import Any, Dict, List, Optional
 
-from imednet.core.exceptions import NotFoundError
 from imednet.core.paginator import AsyncPaginator, Paginator
 from imednet.endpoints.base import BaseEndpoint
 from imednet.models.visits import Visit
@@ -68,24 +67,16 @@ class VisitsEndpoint(BaseEndpoint):
         Returns:
             Visit object
         """
-        path = self._build_path(study_key, "visits", visit_id)
-        try:
-            raw = self._client.get(path).json().get("data", [])
-        except NotFoundError:
-            return self._fallback_from_list(study_key, visit_id, "visit_id")
-        if not raw:
+        visits = self.list(study_key=study_key, refresh=True, visitId=visit_id)
+        if not visits:
             raise ValueError(f"Visit {visit_id} not found in study {study_key}")
-        return Visit.from_json(raw[0])
+        return visits[0]
 
     async def async_get(self, study_key: str, visit_id: int) -> Visit:
         """Asynchronous version of :meth:`get`."""
         if self._async_client is None:
             raise RuntimeError("Async client not configured")
-        path = self._build_path(study_key, "visits", visit_id)
-        try:
-            raw = (await self._async_client.get(path)).json().get("data", [])
-        except NotFoundError:
-            return await self._async_fallback_from_list(study_key, visit_id, "visit_id")
-        if not raw:
+        visits = await self.async_list(study_key=study_key, refresh=True, visitId=visit_id)
+        if not visits:
             raise ValueError(f"Visit {visit_id} not found in study {study_key}")
-        return Visit.from_json(raw[0])
+        return visits[0]

--- a/tests/unit/endpoints/test_codings_endpoint.py
+++ b/tests/unit/endpoints/test_codings_endpoint.py
@@ -19,8 +19,13 @@ def test_list_requires_study_key(dummy_client, context, paginator_factory, patch
     assert isinstance(result[0], Coding)
 
 
-def test_get_not_found(dummy_client, context, response_factory):
+def test_get_not_found(monkeypatch, dummy_client, context):
     ep = codings.CodingsEndpoint(dummy_client, context)
-    dummy_client.get.return_value = response_factory({"data": []})
+
+    def fake_list(self, study_key=None, refresh=False, **filters):
+        return []
+
+    monkeypatch.setattr(codings.CodingsEndpoint, "list", fake_list)
+
     with pytest.raises(ValueError):
         ep.get("S1", "x")

--- a/tests/unit/endpoints/test_intervals_endpoint.py
+++ b/tests/unit/endpoints/test_intervals_endpoint.py
@@ -20,9 +20,14 @@ def test_list_uses_default_study_and_page_size(
     assert isinstance(result[0], Interval)
 
 
-def test_get_not_found(dummy_client, context, response_factory):
+def test_get_not_found(monkeypatch, dummy_client, context):
     ep = intervals.IntervalsEndpoint(dummy_client, context)
-    dummy_client.get.return_value = response_factory({"data": []})
+
+    def fake_list(self, study_key=None, refresh=False, **filters):
+        return []
+
+    monkeypatch.setattr(intervals.IntervalsEndpoint, "list", fake_list)
+
     with pytest.raises(ValueError):
         ep.get("S1", 1)
 

--- a/tests/unit/endpoints/test_queries_endpoint.py
+++ b/tests/unit/endpoints/test_queries_endpoint.py
@@ -17,8 +17,13 @@ def test_list_builds_path_and_filters(dummy_client, context, paginator_factory, 
     assert isinstance(result[0], Query)
 
 
-def test_get_not_found(dummy_client, context, response_factory):
+def test_get_not_found(monkeypatch, dummy_client, context):
     ep = queries.QueriesEndpoint(dummy_client, context)
-    dummy_client.get.return_value = response_factory({"data": []})
+
+    def fake_list(self, study_key=None, refresh=False, **filters):
+        return []
+
+    monkeypatch.setattr(queries.QueriesEndpoint, "list", fake_list)
+
     with pytest.raises(ValueError):
         ep.get("S1", 1)

--- a/tests/unit/endpoints/test_record_revisions_endpoint.py
+++ b/tests/unit/endpoints/test_record_revisions_endpoint.py
@@ -17,8 +17,13 @@ def test_list_uses_filters(dummy_client, context, paginator_factory, patch_build
     assert isinstance(result[0], RecordRevision)
 
 
-def test_get_not_found(dummy_client, context, response_factory):
+def test_get_not_found(monkeypatch, dummy_client, context):
     ep = record_revisions.RecordRevisionsEndpoint(dummy_client, context)
-    dummy_client.get.return_value = response_factory({"data": []})
+
+    def fake_list(self, study_key=None, refresh=False, **filters):
+        return []
+
+    monkeypatch.setattr(record_revisions.RecordRevisionsEndpoint, "list", fake_list)
+
     with pytest.raises(ValueError):
         ep.get("S1", 1)

--- a/tests/unit/endpoints/test_records_endpoint.py
+++ b/tests/unit/endpoints/test_records_endpoint.py
@@ -25,19 +25,32 @@ def test_list_builds_path_filters_and_data_filter(
     assert isinstance(result[0], Record)
 
 
-def test_get_success(dummy_client, context, response_factory):
+def test_get_success(monkeypatch, dummy_client, context):
     ep = records.RecordsEndpoint(dummy_client, context)
-    dummy_client.get.return_value = response_factory({"data": [{"recordId": 1}]})
+    called = {}
+
+    def fake_list(self, study_key=None, refresh=False, **filters):
+        called["study_key"] = study_key
+        called["refresh"] = refresh
+        called["filters"] = filters
+        return [Record(record_id=1)]
+
+    monkeypatch.setattr(records.RecordsEndpoint, "list", fake_list)
 
     res = ep.get("S1", 1)
 
-    dummy_client.get.assert_called_once_with("/api/v1/edc/studies/S1/records/1")
+    assert called == {"study_key": "S1", "refresh": True, "filters": {"recordId": 1}}
     assert isinstance(res, Record)
 
 
-def test_get_not_found(dummy_client, context, response_factory):
+def test_get_not_found(monkeypatch, dummy_client, context):
     ep = records.RecordsEndpoint(dummy_client, context)
-    dummy_client.get.return_value = response_factory({"data": []})
+
+    def fake_list(self, study_key=None, refresh=False, **filters):
+        return []
+
+    monkeypatch.setattr(records.RecordsEndpoint, "list", fake_list)
+
     with pytest.raises(ValueError):
         ep.get("S1", 1)
 

--- a/tests/unit/endpoints/test_sites_endpoint.py
+++ b/tests/unit/endpoints/test_sites_endpoint.py
@@ -19,8 +19,13 @@ def test_list_requires_study_key(dummy_client, context, paginator_factory, patch
     assert isinstance(result[0], Site)
 
 
-def test_get_not_found(dummy_client, context, response_factory):
+def test_get_not_found(monkeypatch, dummy_client, context):
     ep = sites.SitesEndpoint(dummy_client, context)
-    dummy_client.get.return_value = response_factory({"data": []})
+
+    def fake_list(self, study_key=None, refresh=False, **filters):
+        return []
+
+    monkeypatch.setattr(sites.SitesEndpoint, "list", fake_list)
+
     with pytest.raises(ValueError):
         ep.get("S1", 1)

--- a/tests/unit/endpoints/test_subjects_endpoint.py
+++ b/tests/unit/endpoints/test_subjects_endpoint.py
@@ -19,8 +19,13 @@ def test_list_builds_path_with_default(
     assert isinstance(result[0], Subject)
 
 
-def test_get_not_found(dummy_client, context, response_factory):
+def test_get_not_found(monkeypatch, dummy_client, context):
     ep = subjects.SubjectsEndpoint(dummy_client, context)
-    dummy_client.get.return_value = response_factory({"data": []})
+
+    def fake_list(self, study_key=None, refresh=False, **filters):
+        return []
+
+    monkeypatch.setattr(subjects.SubjectsEndpoint, "list", fake_list)
+
     with pytest.raises(ValueError):
         ep.get("S1", "X")

--- a/tests/unit/endpoints/test_users_endpoint.py
+++ b/tests/unit/endpoints/test_users_endpoint.py
@@ -17,8 +17,13 @@ def test_list_requires_study_key_and_include_inactive(dummy_client, context, pag
     assert isinstance(result[0], User)
 
 
-def test_get_not_found(dummy_client, context, response_factory):
+def test_get_not_found(monkeypatch, dummy_client, context):
     ep = users.UsersEndpoint(dummy_client, context)
-    dummy_client.get.return_value = response_factory({"data": []})
+
+    def fake_list(self, study_key=None, refresh=False, **filters):
+        return []
+
+    monkeypatch.setattr(users.UsersEndpoint, "list", fake_list)
+
     with pytest.raises(ValueError):
         ep.get("S1", 1)

--- a/tests/unit/endpoints/test_variables_endpoint.py
+++ b/tests/unit/endpoints/test_variables_endpoint.py
@@ -22,9 +22,14 @@ def test_list_requires_study_key_page_size(
     assert isinstance(result[0], Variable)
 
 
-def test_get_not_found(dummy_client, context, response_factory):
+def test_get_not_found(monkeypatch, dummy_client, context):
     ep = variables.VariablesEndpoint(dummy_client, context)
-    dummy_client.get.return_value = response_factory({"data": []})
+
+    def fake_list(self, study_key=None, refresh=False, **filters):
+        return []
+
+    monkeypatch.setattr(variables.VariablesEndpoint, "list", fake_list)
+
     with pytest.raises(ValueError):
         ep.get("S1", 1)
 

--- a/tests/unit/endpoints/test_visits_endpoint.py
+++ b/tests/unit/endpoints/test_visits_endpoint.py
@@ -17,8 +17,13 @@ def test_list_filters_and_path(dummy_client, context, paginator_factory, patch_b
     assert isinstance(result[0], Visit)
 
 
-def test_get_not_found(dummy_client, context, response_factory):
+def test_get_not_found(monkeypatch, dummy_client, context):
     ep = visits.VisitsEndpoint(dummy_client, context)
-    dummy_client.get.return_value = response_factory({"data": []})
+
+    def fake_list(self, study_key=None, refresh=False, **filters):
+        return []
+
+    monkeypatch.setattr(visits.VisitsEndpoint, "list", fake_list)
+
     with pytest.raises(ValueError):
         ep.get("S1", 1)


### PR DESCRIPTION
## Summary
- query objects using list filters instead of direct endpoints
- update tests for list-based retrieval logic
- allow user listing to support filters

## Testing
- `poetry run ruff check --fix .`
- `poetry run black --check .`
- `poetry run mypy imednet`
- `poetry run pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684cafb74a38832c922a17b705ca2109