### PR TITLE
Improve workflow tests for filter dictionaries

### DIFF
--- a/tests/unit/test_workflows_data_extraction.py
+++ b/tests/unit/test_workflows_data_extraction.py
@@ -29,8 +29,11 @@ def test_extract_records_by_criteria_filters_subject_and_visit() -> None:
     )
 
     sdk.subjects.list.assert_called_once_with("STUDY", status="active")
+    assert sdk.subjects.list.call_args.kwargs == {"status": "active"}
     sdk.visits.list.assert_called_once_with("STUDY", visit_id=1)
+    assert sdk.visits.list.call_args.kwargs == {"visit_id": 1}
     sdk.records.list.assert_called_once_with(study_key="STUDY", record_data_filter=None)
+    assert sdk.records.list.call_args.kwargs == {"study_key": "STUDY", "record_data_filter": None}
 
     assert [r.record_id for r in result] == [1, 2]
 
@@ -56,4 +59,10 @@ def test_extract_audit_trail_builds_filters_and_dates() -> None:
         start_date="2021-01-01",
         end_date="2021-01-02",
     )
+    assert sdk.record_revisions.list.call_args.kwargs == {
+        "role": "data",
+        "status": "open",
+        "start_date": "2021-01-01",
+        "end_date": "2021-01-02",
+    }
     assert result == revisions

--- a/tests/unit/test_workflows_query_management.py
+++ b/tests/unit/test_workflows_query_management.py
@@ -20,6 +20,7 @@ def test_get_open_queries_filters_latest_comment() -> None:
     result = wf.get_open_queries("STUDY", additional_filter={"state": "new"})
 
     sdk.queries.list.assert_called_once_with("STUDY", state="new")
+    assert sdk.queries.list.call_args.kwargs == {"state": "new"}
     assert result == [query_open]
 
 
@@ -29,6 +30,7 @@ def test_get_queries_for_subject_builds_combined_filter() -> None:
     wf.get_queries_for_subject("STUDY", "SUBJ1", additional_filter={"type": "x"})
 
     sdk.queries.list.assert_called_once_with("STUDY", subject_key="SUBJ1", type="x")
+    assert sdk.queries.list.call_args.kwargs == {"subject_key": "SUBJ1", "type": "x"}
 
 
 def test_get_query_state_counts_aggregates_states() -> None:
@@ -42,4 +44,5 @@ def test_get_query_state_counts_aggregates_states() -> None:
     counts = wf.get_query_state_counts("STUDY")
 
     sdk.queries.list.assert_called_once_with("STUDY")
+    assert sdk.queries.list.call_args.kwargs == {}
     assert counts == {"open": 1, "closed": 1, "unknown": 1}

--- a/tests/unit/test_workflows_subject_data.py
+++ b/tests/unit/test_workflows_subject_data.py
@@ -23,9 +23,13 @@ def test_get_all_subject_data_aggregates_across_endpoints() -> None:
     result = wf.get_all_subject_data("STUDY", "S1")
 
     sdk.subjects.list.assert_called_once_with("STUDY", subject_key="S1")
+    assert sdk.subjects.list.call_args.kwargs == {"subject_key": "S1"}
     sdk.visits.list.assert_called_once_with("STUDY", subject_key="S1")
+    assert sdk.visits.list.call_args.kwargs == {"subject_key": "S1"}
     sdk.records.list.assert_called_once_with("STUDY", subject_key="S1")
+    assert sdk.records.list.call_args.kwargs == {"subject_key": "S1"}
     sdk.queries.list.assert_called_once_with("STUDY", subject_key="S1")
+    assert sdk.queries.list.call_args.kwargs == {"subject_key": "S1"}
 
     assert result.subject_details == subject
     assert result.visits == [visit]


### PR DESCRIPTION
## Summary
- strengthen workflow tests to verify dictionaries passed to endpoint methods

## Testing
- `poetry run ruff check --fix .`
- `poetry run black --check .`
- `poetry run mypy imednet`
- `poetry run pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684caefde634832c8bcfc253fc920de1