### PR TITLE
fix: simplify filter passing to records list

### DIFF
--- a/imednet/workflows/data_extraction.py
+++ b/imednet/workflows/data_extraction.py
@@ -73,8 +73,7 @@ class DataExtractionWorkflow:
 
         records = self._sdk.records.list(
             study_key=study_key,
-            record_data_filter=None,
-            **final_record_filter_dict,
+            **final_record_filter_dict,  # type: ignore[arg-type]
         )
 
         # Client-side filtering fallback

--- a/imednet/workflows/record_mapper.py
+++ b/imednet/workflows/record_mapper.py
@@ -89,11 +89,14 @@ class RecordMapper:
         try:
             return self.sdk.records.list(
                 study_key=study_key,
-                record_data_filter=None,
-                **filters,
+                **filters,  # type: ignore[arg-type]
             )
         except Exception as exc:  # pragma: no cover - unexpected
-            logger.error("Failed to fetch records for study '%s': %s", study_key, exc)
+            logger.error(
+                "Failed to fetch records for study '%s': %s",
+                study_key,
+                exc,
+            )
             return []
 
     def _parse_records(

--- a/tests/unit/test_record_mapper.py
+++ b/tests/unit/test_record_mapper.py
@@ -32,7 +32,7 @@ def test_dataframe_builds_expected_structure() -> None:
     df = mapper.dataframe("STUDY", visit_key="1")
 
     sdk.variables.list.assert_called_once_with(study_key="STUDY")
-    sdk.records.list.assert_called_once_with(study_key="STUDY", record_data_filter=None, visitId=1)
+    sdk.records.list.assert_called_once_with(study_key="STUDY", visitId=1)
 
     expected_columns = [
         "recordId",
@@ -68,7 +68,7 @@ def test_invalid_visit_key_logs_warning(caplog) -> None:
 
     assert df.empty
     assert "Invalid visit_key" in caplog.text
-    sdk.records.list.assert_called_once_with(study_key="S", record_data_filter=None)
+    sdk.records.list.assert_called_once_with(study_key="S")
 
 
 def test_records_fetch_error_returns_empty(caplog) -> None:

--- a/tests/unit/test_workflows_data_extraction.py
+++ b/tests/unit/test_workflows_data_extraction.py
@@ -30,7 +30,7 @@ def test_extract_records_by_criteria_filters_subject_and_visit() -> None:
 
     sdk.subjects.list.assert_called_once_with("STUDY", status="active")
     sdk.visits.list.assert_called_once_with("STUDY", visit_id=1)
-    sdk.records.list.assert_called_once_with(study_key="STUDY", record_data_filter=None)
+    sdk.records.list.assert_called_once_with(study_key="STUDY")
 
     assert [r.record_id for r in result] == [1, 2]
 


### PR DESCRIPTION
## Summary
- pass filter kwargs instead of record_data_filter in RecordMapper
- use `**filters` when extracting records in workflows
- update tests for filter kwargs

## Testing
- `poetry run ruff check --fix .`
- `poetry run black --check .`
- `poetry run mypy imednet`
- `poetry run pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684caecd4280832c9621481861a36f09