### PR TITLE
Update record endpoint tests

### DIFF
--- a/tests/unit/endpoints/test_endpoints_async.py
+++ b/tests/unit/endpoints/test_endpoints_async.py
@@ -160,9 +160,8 @@ async def test_async_get_record(monkeypatch, dummy_client, context, response_fac
     ep = records.RecordsEndpoint(dummy_client, context, async_client=dummy_client)
     called = {}
 
-    async def fake_list(self, study_key=None, refresh=False, **filters):
+    async def fake_list(self, study_key=None, **filters):
         called["study_key"] = study_key
-        called["refresh"] = refresh
         called["filters"] = filters
         return [Record(record_id=1)]
 
@@ -170,7 +169,7 @@ async def test_async_get_record(monkeypatch, dummy_client, context, response_fac
 
     rec = await ep.async_get("S1", 1)
 
-    assert called == {"study_key": "S1", "refresh": False, "filters": {"recordId": 1}}
+    assert called == {"study_key": "S1", "filters": {"recordId": 1}}
     assert isinstance(rec, Record)
 
 

--- a/tests/unit/endpoints/test_records_endpoint.py
+++ b/tests/unit/endpoints/test_records_endpoint.py
@@ -29,9 +29,8 @@ def test_get_success(monkeypatch, dummy_client, context):
     ep = records.RecordsEndpoint(dummy_client, context)
     called = {}
 
-    def fake_list(self, study_key=None, refresh=False, **filters):
+    def fake_list(self, study_key=None, **filters):
         called["study_key"] = study_key
-        called["refresh"] = refresh
         called["filters"] = filters
         return [Record(record_id=1)]
 
@@ -39,7 +38,7 @@ def test_get_success(monkeypatch, dummy_client, context):
 
     res = ep.get("S1", 1)
 
-    assert called == {"study_key": "S1", "refresh": False, "filters": {"recordId": 1}}
+    assert called == {"study_key": "S1", "filters": {"recordId": 1}}
     assert isinstance(res, Record)
 
 


### PR DESCRIPTION
## Summary
- reflect removed `refresh` arg in records endpoint tests

## Testing
- `poetry run ruff check --fix .`
- `poetry run black --check .`
- `poetry run mypy imednet`
- `poetry run pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684cbafdf0bc832cb02fbc9ce56a7132