### PR TITLE
Clarify refresh keyword in docs

### DIFF
--- a/docs/api_overview.rst
+++ b/docs/api_overview.rst
@@ -39,6 +39,13 @@ Endpoints accept a ``filter`` parameter that matches the syntax documented in th
 Mednet API guide. For clinical data queries, ``recordDataFilter`` can be supplied
 alongside ``filter``. See :mod:`imednet.endpoints.records` for usage examples.
 
+Some endpoints (:class:`~imednet.endpoints.studies.StudiesEndpoint`,
+:class:`~imednet.endpoints.forms.FormsEndpoint`,
+:class:`~imednet.endpoints.intervals.IntervalsEndpoint`, and
+:class:`~imednet.endpoints.variables.VariablesEndpoint`) maintain an internal
+cache. They accept a ``refresh`` argument to force a reload of cached data. This
+flag is not a general filtering option and has no effect on other endpoints.
+
 Dates must use UTC timestamps except where noted. When filtering visits by
 ``startDate``, ``dueDate``, ``endDate`` or ``visitDate``, use ``YYYY-MM-DD``.
 

--- a/imednet/endpoints/codings.py
+++ b/imednet/endpoints/codings.py
@@ -69,6 +69,8 @@ class CodingsEndpoint(BaseEndpoint):
         """
         Get a specific coding by ID.
 
+        The ``coding_id`` value is supplied as a filter to :meth:`list`.
+
         Args:
             study_key: Study identifier
             coding_id: Coding identifier
@@ -83,7 +85,10 @@ class CodingsEndpoint(BaseEndpoint):
         return codings[0]
 
     async def async_get(self, study_key: str, coding_id: str) -> Coding:
-        """Asynchronous version of :meth:`get`."""
+        """Asynchronous version of :meth:`get`.
+
+        This method also filters :meth:`async_list` by ``coding_id``.
+        """
         if self._async_client is None:
             raise RuntimeError("Async client not configured")
         codings = await self.async_list(study_key=study_key, codingId=coding_id)

--- a/imednet/endpoints/forms.py
+++ b/imednet/endpoints/forms.py
@@ -100,6 +100,9 @@ class FormsEndpoint(BaseEndpoint):
         """
         Get a specific form by ID.
 
+        This endpoint caches form listings. ``refresh=True`` is used when
+        calling :meth:`list` so that the most recent data is returned.
+
         Args:
             study_key: Study identifier
             form_id: Form identifier
@@ -113,7 +116,11 @@ class FormsEndpoint(BaseEndpoint):
         return forms[0]
 
     async def async_get(self, study_key: str, form_id: int) -> Form:
-        """Asynchronous version of :meth:`get`."""
+        """Asynchronous version of :meth:`get`.
+
+        ``refresh=True`` is also passed to :meth:`async_list` to bypass the
+        cache.
+        """
         if self._async_client is None:
             raise RuntimeError("Async client not configured")
         forms = await self.async_list(study_key=study_key, refresh=True, formId=form_id)

--- a/imednet/endpoints/intervals.py
+++ b/imednet/endpoints/intervals.py
@@ -94,6 +94,9 @@ class IntervalsEndpoint(BaseEndpoint):
         """
         Get a specific interval by ID.
 
+        ``refresh=True`` is passed to :meth:`list` to override the cached
+        interval list when performing the lookup.
+
         Args:
             study_key: Study identifier
             interval_id: Interval identifier
@@ -107,7 +110,11 @@ class IntervalsEndpoint(BaseEndpoint):
         return intervals[0]
 
     async def async_get(self, study_key: str, interval_id: int) -> Interval:
-        """Asynchronous version of :meth:`get`."""
+        """Asynchronous version of :meth:`get`.
+
+        The asynchronous call also passes ``refresh=True`` to
+        :meth:`async_list`.
+        """
         if self._async_client is None:
             raise RuntimeError("Async client not configured")
         intervals = await self.async_list(study_key=study_key, refresh=True, intervalId=interval_id)

--- a/imednet/endpoints/jobs.py
+++ b/imednet/endpoints/jobs.py
@@ -17,6 +17,9 @@ class JobsEndpoint(BaseEndpoint):
         """
         Get a specific job by batch ID.
 
+        This method performs a direct API request using the provided
+        ``batch_id``; it does not use caching or the ``refresh`` flag.
+
         Args:
             study_key: Study identifier
             batch_id: Batch ID of the job
@@ -34,7 +37,11 @@ class JobsEndpoint(BaseEndpoint):
         return JobStatus.from_json(data)
 
     async def async_get(self, study_key: str, batch_id: str) -> JobStatus:
-        """Asynchronous version of :meth:`get`."""
+        """Asynchronous version of :meth:`get`.
+
+        Like the sync variant, it simply issues a request by ``batch_id``
+        without any caching.
+        """
         if self._async_client is None:
             raise RuntimeError("Async client not configured")
         endpoint = self._build_path(study_key, "jobs", batch_id)

--- a/imednet/endpoints/queries.py
+++ b/imednet/endpoints/queries.py
@@ -60,6 +60,8 @@ class QueriesEndpoint(BaseEndpoint):
         """
         Get a specific query by annotation ID.
 
+        The annotation ID filter is forwarded to :meth:`list`.
+
         Args:
             study_key: Study identifier
             annotation_id: Query annotation identifier
@@ -73,7 +75,10 @@ class QueriesEndpoint(BaseEndpoint):
         return queries[0]
 
     async def async_get(self, study_key: str, annotation_id: int) -> Query:
-        """Asynchronous version of :meth:`get`."""
+        """Asynchronous version of :meth:`get`.
+
+        This call filters :meth:`async_list` by ``annotation_id``.
+        """
         if self._async_client is None:
             raise RuntimeError("Async client not configured")
         queries = await self.async_list(study_key=study_key, annotationId=annotation_id)

--- a/imednet/endpoints/record_revisions.py
+++ b/imednet/endpoints/record_revisions.py
@@ -62,6 +62,8 @@ class RecordRevisionsEndpoint(BaseEndpoint):
         """
         Get a specific record revision by ID.
 
+        The ID is forwarded to :meth:`list` as a filter; no caching is used.
+
         Args:
             study_key: Study identifier
             record_revision_id: Record revision identifier
@@ -75,7 +77,10 @@ class RecordRevisionsEndpoint(BaseEndpoint):
         return revisions[0]
 
     async def async_get(self, study_key: str, record_revision_id: int) -> RecordRevision:
-        """Asynchronous version of :meth:`get`."""
+        """Asynchronous version of :meth:`get`.
+
+        This call also filters :meth:`async_list` by ``record_revision_id``.
+        """
         if self._async_client is None:
             raise RuntimeError("Async client not configured")
         revisions = await self.async_list(study_key=study_key, recordRevisionId=record_revision_id)

--- a/imednet/endpoints/records.py
+++ b/imednet/endpoints/records.py
@@ -75,6 +75,8 @@ class RecordsEndpoint(BaseEndpoint):
         """
         Get a specific record by ID.
 
+        ``record_id`` is provided to :meth:`list` as a filter value.
+
         Args:
             study_key: Study identifier
             record_id: Record identifier (can be string or integer)
@@ -88,7 +90,10 @@ class RecordsEndpoint(BaseEndpoint):
         return records[0]
 
     async def async_get(self, study_key: str, record_id: Union[str, int]) -> Record:
-        """Asynchronous version of :meth:`get`."""
+        """Asynchronous version of :meth:`get`.
+
+        This method also filters :meth:`async_list` by ``record_id``.
+        """
         if self._async_client is None:
             raise RuntimeError("Async client not configured")
         records = await self.async_list(study_key=study_key, recordId=record_id)

--- a/imednet/endpoints/sites.py
+++ b/imednet/endpoints/sites.py
@@ -68,6 +68,8 @@ class SitesEndpoint(BaseEndpoint):
         """
         Get a specific site by ID.
 
+        The ``site_id`` is applied as a filter when calling :meth:`list`.
+
         Args:
             study_key: Study identifier
             site_id: Site identifier
@@ -81,7 +83,10 @@ class SitesEndpoint(BaseEndpoint):
         return sites[0]
 
     async def async_get(self, study_key: str, site_id: int) -> Site:
-        """Asynchronous version of :meth:`get`."""
+        """Asynchronous version of :meth:`get`.
+
+        This method also filters :meth:`async_list` by ``site_id``.
+        """
         if self._async_client is None:
             raise RuntimeError("Async client not configured")
         sites = await self.async_list(study_key=study_key, siteId=site_id)

--- a/imednet/endpoints/studies.py
+++ b/imednet/endpoints/studies.py
@@ -73,6 +73,9 @@ class StudiesEndpoint(BaseEndpoint):
         """
         Get a specific study by key.
 
+        This endpoint maintains a local cache. ``refresh=True`` is passed to
+        :meth:`list` to ensure the latest data is fetched for the lookup.
+
         Args:
             study_key: Study identifier
 
@@ -85,7 +88,11 @@ class StudiesEndpoint(BaseEndpoint):
         return studies[0]
 
     async def async_get(self, study_key: str) -> Study:
-        """Asynchronous version of :meth:`get`."""
+        """Asynchronous version of :meth:`get`.
+
+        Like the synchronous variant, this call passes ``refresh=True`` to
+        :meth:`async_list` to bypass the cache.
+        """
         if self._async_client is None:
             raise RuntimeError("Async client not configured")
         studies = await self.async_list(refresh=True, studyKey=study_key)

--- a/imednet/endpoints/subjects.py
+++ b/imednet/endpoints/subjects.py
@@ -60,6 +60,8 @@ class SubjectsEndpoint(BaseEndpoint):
         """
         Get a specific subject by key.
 
+        The ``subject_key`` is passed as a filter to :meth:`list`.
+
         Args:
             study_key: Study identifier
             subject_key: Subject identifier
@@ -73,7 +75,10 @@ class SubjectsEndpoint(BaseEndpoint):
         return subjects[0]
 
     async def async_get(self, study_key: str, subject_key: str) -> Subject:
-        """Asynchronous version of :meth:`get`."""
+        """Asynchronous version of :meth:`get`.
+
+        This call also filters :meth:`async_list` by ``subject_key``.
+        """
         if self._async_client is None:
             raise RuntimeError("Async client not configured")
         subjects = await self.async_list(study_key=study_key, subjectKey=subject_key)

--- a/imednet/endpoints/variables.py
+++ b/imednet/endpoints/variables.py
@@ -94,6 +94,9 @@ class VariablesEndpoint(BaseEndpoint):
         """
         Get a specific variable by ID.
 
+        The variables list is cached, so ``refresh=True`` is used when
+        calling :meth:`list` to retrieve the latest data.
+
         Args:
             study_key: Study identifier
             variable_id: Variable identifier
@@ -107,7 +110,11 @@ class VariablesEndpoint(BaseEndpoint):
         return variables[0]
 
     async def async_get(self, study_key: str, variable_id: int) -> Variable:
-        """Asynchronous version of :meth:`get`."""
+        """Asynchronous version of :meth:`get`.
+
+        ``refresh=True`` is also passed to :meth:`async_list` to bypass the
+        cache.
+        """
         if self._async_client is None:
             raise RuntimeError("Async client not configured")
         variables = await self.async_list(study_key=study_key, refresh=True, variableId=variable_id)

--- a/imednet/endpoints/visits.py
+++ b/imednet/endpoints/visits.py
@@ -60,6 +60,8 @@ class VisitsEndpoint(BaseEndpoint):
         """
         Get a specific visit by ID.
 
+        ``visit_id`` is sent as a filter to :meth:`list` for retrieval.
+
         Args:
             study_key: Study identifier
             visit_id: Visit identifier
@@ -73,7 +75,10 @@ class VisitsEndpoint(BaseEndpoint):
         return visits[0]
 
     async def async_get(self, study_key: str, visit_id: int) -> Visit:
-        """Asynchronous version of :meth:`get`."""
+        """Asynchronous version of :meth:`get`.
+
+        The asynchronous call also filters by ``visit_id``.
+        """
         if self._async_client is None:
             raise RuntimeError("Async client not configured")
         visits = await self.async_list(study_key=study_key, visitId=visit_id)


### PR DESCRIPTION
## Summary
- document `refresh` cache behavior in api overview
- explain refresh usage in get/async_get docstrings for cached endpoints
- clarify other endpoints filter by ID

## Testing
- `poetry run ruff check --fix .`
- `poetry run black --check .`
- `poetry run mypy imednet`
- `poetry run pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684cbc41cb7c832c91d19c355d76b49c