### PR TITLE
feat: add option to export with variable names

### DIFF
--- a/imednet/integrations/export.py
+++ b/imednet/integrations/export.py
@@ -10,27 +10,91 @@ from ..sdk import ImednetSDK
 from ..workflows.record_mapper import RecordMapper
 
 
-def export_to_parquet(sdk: ImednetSDK, study_key: str, path: str, **kwargs: Any) -> None:
-    """Export study records to a Parquet file."""
-    df: pd.DataFrame = RecordMapper(sdk).dataframe(study_key)
+def export_to_parquet(
+    sdk: ImednetSDK,
+    study_key: str,
+    path: str,
+    *,
+    use_labels_as_columns: bool = False,
+    **kwargs: Any,
+) -> None:
+    """Export study records to a Parquet file.
+
+    Parameters
+    ----------
+    use_labels_as_columns:
+        When ``True``, variable labels are used for column names instead of
+        variable names.
+    """
+    df: pd.DataFrame = RecordMapper(sdk).dataframe(
+        study_key, use_labels_as_columns=use_labels_as_columns
+    )
     df.to_parquet(path, index=False, **kwargs)
 
 
-def export_to_csv(sdk: ImednetSDK, study_key: str, path: str, **kwargs: Any) -> None:
-    """Export study records to a CSV file."""
-    df: pd.DataFrame = RecordMapper(sdk).dataframe(study_key)
+def export_to_csv(
+    sdk: ImednetSDK,
+    study_key: str,
+    path: str,
+    *,
+    use_labels_as_columns: bool = False,
+    **kwargs: Any,
+) -> None:
+    """Export study records to a CSV file.
+
+    Parameters
+    ----------
+    use_labels_as_columns:
+        When ``True``, variable labels are used for column names instead of
+        variable names.
+    """
+    df: pd.DataFrame = RecordMapper(sdk).dataframe(
+        study_key, use_labels_as_columns=use_labels_as_columns
+    )
     df.to_csv(path, index=False, **kwargs)
 
 
-def export_to_excel(sdk: ImednetSDK, study_key: str, path: str, **kwargs: Any) -> None:
-    """Export study records to an Excel workbook."""
-    df: pd.DataFrame = RecordMapper(sdk).dataframe(study_key)
+def export_to_excel(
+    sdk: ImednetSDK,
+    study_key: str,
+    path: str,
+    *,
+    use_labels_as_columns: bool = False,
+    **kwargs: Any,
+) -> None:
+    """Export study records to an Excel workbook.
+
+    Parameters
+    ----------
+    use_labels_as_columns:
+        When ``True``, variable labels are used for column names instead of
+        variable names.
+    """
+    df: pd.DataFrame = RecordMapper(sdk).dataframe(
+        study_key, use_labels_as_columns=use_labels_as_columns
+    )
     df.to_excel(path, index=False, **kwargs)
 
 
-def export_to_json(sdk: ImednetSDK, study_key: str, path: str, **kwargs: Any) -> None:
-    """Export study records to a JSON file."""
-    df: pd.DataFrame = RecordMapper(sdk).dataframe(study_key)
+def export_to_json(
+    sdk: ImednetSDK,
+    study_key: str,
+    path: str,
+    *,
+    use_labels_as_columns: bool = False,
+    **kwargs: Any,
+) -> None:
+    """Export study records to a JSON file.
+
+    Parameters
+    ----------
+    use_labels_as_columns:
+        When ``True``, variable labels are used for column names instead of
+        variable names.
+    """
+    df: pd.DataFrame = RecordMapper(sdk).dataframe(
+        study_key, use_labels_as_columns=use_labels_as_columns
+    )
     df.to_json(path, index=False, **kwargs)
 
 
@@ -40,11 +104,22 @@ def export_to_sql(
     table: str,
     conn_str: str,
     if_exists: str = "replace",
+    *,
+    use_labels_as_columns: bool = False,
     **kwargs: Any,
 ) -> None:
-    """Export study records to a SQL table."""
+    """Export study records to a SQL table.
+
+    Parameters
+    ----------
+    use_labels_as_columns:
+        When ``True``, variable labels are used for column names instead of
+        variable names.
+    """
     from sqlalchemy import create_engine
 
-    df: pd.DataFrame = RecordMapper(sdk).dataframe(study_key)
+    df: pd.DataFrame = RecordMapper(sdk).dataframe(
+        study_key, use_labels_as_columns=use_labels_as_columns
+    )
     engine = create_engine(conn_str)
     df.to_sql(table, engine, if_exists=if_exists, index=False, **kwargs)  # type: ignore[arg-type]

--- a/tests/unit/test_integrations_export.py
+++ b/tests/unit/test_integrations_export.py
@@ -11,51 +11,55 @@ def _setup_mapper(monkeypatch):
     mapper_inst.dataframe.return_value = df
     mapper_cls = MagicMock(return_value=mapper_inst)
     monkeypatch.setattr(export_mod, "RecordMapper", mapper_cls)
-    return df, mapper_cls
+    return df, mapper_cls, mapper_inst
 
 
 def test_export_to_csv(monkeypatch):
-    df, mapper_cls = _setup_mapper(monkeypatch)
+    df, mapper_cls, mapper_inst = _setup_mapper(monkeypatch)
     sdk = MagicMock()
 
     export_mod.export_to_csv(sdk, "STUDY", "out.csv", sep=";")
 
     mapper_cls.assert_called_once_with(sdk)
+    mapper_inst.dataframe.assert_called_once_with("STUDY", use_labels_as_columns=False)
     df.to_csv.assert_called_once_with("out.csv", index=False, sep=";")
 
 
 def test_export_to_excel(monkeypatch):
-    df, mapper_cls = _setup_mapper(monkeypatch)
+    df, mapper_cls, mapper_inst = _setup_mapper(monkeypatch)
     sdk = MagicMock()
 
     export_mod.export_to_excel(sdk, "STUDY", "out.xlsx")
 
     mapper_cls.assert_called_once_with(sdk)
+    mapper_inst.dataframe.assert_called_once_with("STUDY", use_labels_as_columns=False)
     df.to_excel.assert_called_once_with("out.xlsx", index=False)
 
 
 def test_export_to_json(monkeypatch):
-    df, mapper_cls = _setup_mapper(monkeypatch)
+    df, mapper_cls, mapper_inst = _setup_mapper(monkeypatch)
     sdk = MagicMock()
 
     export_mod.export_to_json(sdk, "STUDY", "out.json", orient="records")
 
     mapper_cls.assert_called_once_with(sdk)
+    mapper_inst.dataframe.assert_called_once_with("STUDY", use_labels_as_columns=False)
     df.to_json.assert_called_once_with("out.json", orient="records", index=False)
 
 
 def test_export_to_parquet(monkeypatch):
-    df, mapper_cls = _setup_mapper(monkeypatch)
+    df, mapper_cls, mapper_inst = _setup_mapper(monkeypatch)
     sdk = MagicMock()
 
     export_mod.export_to_parquet(sdk, "STUDY", "out.parquet", compression="snappy")
 
     mapper_cls.assert_called_once_with(sdk)
+    mapper_inst.dataframe.assert_called_once_with("STUDY", use_labels_as_columns=False)
     df.to_parquet.assert_called_once_with("out.parquet", index=False, compression="snappy")
 
 
 def test_export_to_sql(monkeypatch):
-    df, mapper_cls = _setup_mapper(monkeypatch)
+    df, mapper_cls, mapper_inst = _setup_mapper(monkeypatch)
     sdk = MagicMock()
 
     sa_module = ModuleType("sqlalchemy")
@@ -66,5 +70,6 @@ def test_export_to_sql(monkeypatch):
     export_mod.export_to_sql(sdk, "STUDY", "table", "sqlite://", if_exists="append")
 
     mapper_cls.assert_called_once_with(sdk)
+    mapper_inst.dataframe.assert_called_once_with("STUDY", use_labels_as_columns=False)
     create_engine.assert_called_once_with("sqlite://")
     df.to_sql.assert_called_once_with("table", "engine", if_exists="append", index=False)


### PR DESCRIPTION
## Summary
- allow export functions to choose variable names vs. labels
- test that export functions pass `use_labels_as_columns=False`

## Testing
- `poetry run ruff check --fix .`
- `poetry run black --check .`
- `poetry run mypy imednet`
- `poetry run pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684cc1cc26e8832cb5427be03dc0c34a