### PR TITLE
Fix duplicate forms in study_structure workflow

### DIFF
--- a/imednet/workflows/study_structure.py
+++ b/imednet/workflows/study_structure.py
@@ -48,23 +48,13 @@ def get_study_structure(sdk: "ImednetSDK", study_key: str) -> StudyStructure:
         interval_structures: List[IntervalStructure] = []
         for interval in intervals:
             form_structures: List[FormStructure] = []
-            # Assuming interval.forms contains summaries or just IDs/Keys
-            # We need to look up the full Form object and its variables
-            for form_summary in interval.forms:  # Assuming interval.forms exists
+            for form_summary in interval.forms:
                 full_form = forms_by_id.get(form_summary.form_id)
                 if full_form:
                     form_vars = variables_by_form_id.get(full_form.form_id, [])
-                    form_struct = FormStructure(
-                        **full_form.model_dump(),  # Pass Form fields
-                        variables=form_vars,  # Add fetched variables
-                    )
-                    form_structures.append(form_struct)
+                    form_structures.append(FormStructure.from_form(full_form, form_vars))
 
-            interval_struct = IntervalStructure(
-                **interval.model_dump(),  # Pass Interval fields
-                forms=form_structures,  # Add nested FormStructures
-            )
-            interval_structures.append(interval_struct)
+            interval_structures.append(IntervalStructure.from_interval(interval, form_structures))
 
         return StudyStructure(study_key=study_key, intervals=interval_structures)  # type: ignore[call-arg]
 
@@ -96,19 +86,9 @@ async def async_get_study_structure(sdk: "ImednetSDK", study_key: str) -> StudyS
                 full_form = forms_by_id.get(form_summary.form_id)
                 if full_form:
                     form_vars = variables_by_form_id.get(full_form.form_id, [])
-                    form_structures.append(
-                        FormStructure(
-                            **full_form.model_dump(),
-                            variables=form_vars,
-                        )
-                    )
+                    form_structures.append(FormStructure.from_form(full_form, form_vars))
 
-            interval_structures.append(
-                IntervalStructure(
-                    **interval.model_dump(),
-                    forms=form_structures,
-                )
-            )
+            interval_structures.append(IntervalStructure.from_interval(interval, form_structures))
 
         return StudyStructure(
             study_key=study_key, intervals=interval_structures

--- a/tests/unit/async/test_workflows_study_structure.py
+++ b/tests/unit/async/test_workflows_study_structure.py
@@ -8,7 +8,7 @@ from imednet.workflows.study_structure import async_get_study_structure
 
 
 @pytest.mark.asyncio
-async def test_async_get_study_structure_aggregates_related_data(monkeypatch) -> None:
+async def test_async_get_study_structure_aggregates_related_data() -> None:
     sdk = MagicMock()
     interval = Interval(
         interval_id=1,
@@ -24,13 +24,6 @@ async def test_async_get_study_structure_aggregates_related_data(monkeypatch) ->
     sdk.intervals.async_list = AsyncMock(return_value=[interval])
     sdk.forms.async_list = AsyncMock(return_value=[form])
     sdk.variables.async_list = AsyncMock(return_value=[variable])
-
-    orig_dump = Interval.model_dump
-    monkeypatch.setattr(
-        Interval,
-        "model_dump",
-        lambda self: {k: v for k, v in orig_dump(self).items() if k != "forms"},
-    )
 
     structure = await async_get_study_structure(sdk, "STUDY")
 

--- a/tests/unit/test_study_structure.py
+++ b/tests/unit/test_study_structure.py
@@ -6,7 +6,7 @@ from imednet.models.variables import Variable
 from imednet.workflows.study_structure import get_study_structure
 
 
-def test_get_study_structure_aggregates_related_data(monkeypatch) -> None:
+def test_get_study_structure_aggregates_related_data() -> None:
     sdk = MagicMock()
     interval = Interval(
         interval_id=1,
@@ -22,14 +22,6 @@ def test_get_study_structure_aggregates_related_data(monkeypatch) -> None:
     sdk.intervals.list.return_value = [interval]
     sdk.forms.list.return_value = [form]
     sdk.variables.list.return_value = [variable]
-
-    # patch model_dump to exclude forms key to avoid duplicate parameters
-    orig_dump = Interval.model_dump
-    monkeypatch.setattr(
-        Interval,
-        "model_dump",
-        lambda self: {k: v for k, v in orig_dump(self).items() if k != "forms"},
-    )
 
     structure = get_study_structure(sdk, "STUDY")
 


### PR DESCRIPTION
## Summary
- build `FormStructure` using `from_form`
- call `IntervalStructure.from_interval` to avoid duplicate `forms` argument
- update study structure tests

## Testing
- `poetry run ruff check --fix .`
- `poetry run black --check .`
- `poetry run mypy imednet`
- `poetry run pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684cc50c8d34832cbcebb0ff1fa347b1