### PR TITLE
Add camelCase conversion in filter builder

### DIFF
--- a/imednet/utils/filters.py
+++ b/imednet/utils/filters.py
@@ -8,6 +8,16 @@ for iMednet API endpoints based on the reference documentation.
 from typing import Any, Dict, List, Tuple, Union
 
 
+def _snake_to_camel(text: str) -> str:
+    """Convert a snake_case string to camelCase."""
+
+    if "_" not in text:
+        return text
+    parts = text.split("_")
+    first, rest = parts[0], parts[1:]
+    return first + "".join(word.capitalize() for word in rest)
+
+
 def build_filter_string(
     filters: Dict[str, Union[Any, Tuple[str, Any], List[Any]]],
     and_connector: str = ";",
@@ -40,12 +50,13 @@ def build_filter_string(
 
     parts: List[str] = []
     for key, value in filters.items():
+        camel_key = _snake_to_camel(key)
         if isinstance(value, tuple) and len(value) == 2:
             op, val = value
-            parts.append(f"{key}{op}{val}")
+            parts.append(f"{camel_key}{op}{val}")
         elif isinstance(value, list):
-            subparts = [f"{key}=={v}" for v in value]
+            subparts = [f"{camel_key}=={v}" for v in value]
             parts.append(or_connector.join(subparts))
         else:
-            parts.append(f"{key}=={value}")
+            parts.append(f"{camel_key}=={value}")
     return and_connector.join(parts)

--- a/tests/unit/test_utils_dates_and_filters.py
+++ b/tests/unit/test_utils_dates_and_filters.py
@@ -67,3 +67,13 @@ def test_build_filter_string_bool_and_none() -> None:
 
 def test_build_filter_string_empty() -> None:
     assert build_filter_string({}) == ""
+
+
+def test_build_filter_string_snake_to_camel() -> None:
+    result = build_filter_string({"form_name": "Demo", "visit_date": (">=", "2024")})
+    assert result == "formName==Demo;visitDate>=2024"
+
+
+def test_build_filter_string_snake_list() -> None:
+    result = build_filter_string({"field_name": ["A", "B"]})
+    assert result == "fieldName==A,fieldName==B"


### PR DESCRIPTION
## Summary
- convert snake_case filter keys to camelCase
- cover camelCase conversion in test suite

## Testing
- `poetry run ruff check --fix .`
- `poetry run black --check .`
- `poetry run mypy imednet`
- `poetry run pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684cc8666bac832cac1c75c5b894ed45