### PR TITLE
Fix export column duplication

### DIFF
--- a/imednet/workflows/query_management.py
+++ b/imednet/workflows/query_management.py
@@ -101,7 +101,7 @@ class QueryManagementWorkflow:
 
         Args:
             study_key: The key identifying the study.
-            site_key: The key identifying the site.
+            site_key: The name of the site.
             additional_filter: An optional dictionary of conditions to combine with the site filter.
             **kwargs: Additional keyword arguments passed directly to `sdk.queries.list`.
 
@@ -109,7 +109,7 @@ class QueryManagementWorkflow:
             A list of Query objects for the specified site.
         """
         # Build filter dictionary
-        final_filter_dict: Dict[str, Any] = {"site_key": site_key}
+        final_filter_dict: Dict[str, Any] = {"site_name": site_key}
         if additional_filter:
             final_filter_dict.update(additional_filter)
 


### PR DESCRIPTION
## Summary
- deduplicate DataFrame columns before exporting
- query management workflow filters by site name
- test duplicate column handling

## Testing
- `poetry run ruff check --fix .`
- `poetry run black --check .`
- `poetry run mypy imednet`
- `poetry run pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684ccc188938832c9a718281d68cd68f