### PR TITLE
Update get_queries_by_site to filter via subjects

### DIFF
--- a/imednet/workflows/query_management.py
+++ b/imednet/workflows/query_management.py
@@ -102,14 +102,18 @@ class QueryManagementWorkflow:
         Args:
             study_key: The key identifying the study.
             site_key: The name of the site.
-            additional_filter: An optional dictionary of conditions to combine with the site filter.
+            additional_filter: Extra conditions to combine with the subject filter.
             **kwargs: Additional keyword arguments passed directly to `sdk.queries.list`.
 
         Returns:
             A list of Query objects for the specified site.
         """
-        # Build filter dictionary
-        final_filter_dict: Dict[str, Any] = {"site_name": site_key}
+        subjects = self._sdk.subjects.list(study_key, site_name=site_key)
+        subject_keys = [s.subject_key for s in subjects]
+        if not subject_keys:
+            return []
+
+        final_filter_dict: Dict[str, Any] = {"subject_key": subject_keys}
         if additional_filter:
             final_filter_dict.update(additional_filter)
 

--- a/tests/unit/test_workflows_query_management.py
+++ b/tests/unit/test_workflows_query_management.py
@@ -1,6 +1,7 @@
 from unittest.mock import MagicMock
 
 from imednet.models.queries import Query, QueryComment
+from imednet.models.subjects import Subject
 from imednet.workflows.query_management import QueryManagementWorkflow
 
 
@@ -46,3 +47,27 @@ def test_get_query_state_counts_aggregates_states() -> None:
     sdk.queries.list.assert_called_once_with("STUDY")
     assert sdk.queries.list.call_args.kwargs == {}
     assert counts == {"open": 1, "closed": 1, "unknown": 1}
+
+
+def test_get_queries_by_site_filters_using_subjects() -> None:
+    sdk = MagicMock()
+    sdk.subjects.list.return_value = [Subject(subject_key="S1"), Subject(subject_key="S2")]
+    wf = QueryManagementWorkflow(sdk)
+
+    wf.get_queries_by_site("STUDY", "SITE", additional_filter={"state": "open"})
+
+    sdk.subjects.list.assert_called_once_with("STUDY", site_name="SITE")
+    sdk.queries.list.assert_called_once_with("STUDY", subject_key=["S1", "S2"], state="open")
+    assert sdk.queries.list.call_args.kwargs == {"subject_key": ["S1", "S2"], "state": "open"}
+
+
+def test_get_queries_by_site_returns_empty_if_no_subjects() -> None:
+    sdk = MagicMock()
+    sdk.subjects.list.return_value = []
+    wf = QueryManagementWorkflow(sdk)
+
+    result = wf.get_queries_by_site("STUDY", "SITE")
+
+    sdk.subjects.list.assert_called_once_with("STUDY", site_name="SITE")
+    sdk.queries.list.assert_not_called()
+    assert result == []


### PR DESCRIPTION
## Summary
- fetch subjects for a site before querying
- return empty if a site has no subjects
- test `get_queries_by_site` behavior

## Testing
- `poetry run ruff check --fix .`
- `poetry run black --check .`
- `poetry run mypy imednet`
- `poetry run pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684ce3956dfc832c85d60193cf1da7a3