### PR TITLE
Update site query workflow

### DIFF
--- a/imednet/workflows/query_management.py
+++ b/imednet/workflows/query_management.py
@@ -108,8 +108,14 @@ class QueryManagementWorkflow:
         Returns:
             A list of Query objects for the specified site.
         """
-        # Build filter dictionary
-        final_filter_dict: Dict[str, Any] = {"site_name": site_key}
+        # Fetch subjects for the site and gather their subject keys
+        subjects = self._sdk.subjects.list(study_key, site_name=site_key)
+        subject_keys = [s.subject_key for s in subjects]
+        if not subject_keys:
+            return []
+
+        # Build filter dictionary using OR filter for subject keys
+        final_filter_dict: Dict[str, Any] = {"subject_key": subject_keys}
         if additional_filter:
             final_filter_dict.update(additional_filter)
 


### PR DESCRIPTION
## Summary
- update `get_queries_by_site` workflow helper to pull subjects first
- add unit tests covering site query logic

## Testing
- `poetry run ruff check --fix .`
- `poetry run black --check .`
- `poetry run mypy imednet`
- `poetry run pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684ce3956dfc832c85d60193cf1da7a3