### PR TITLE
Handle quoting of filter values with spaces

### DIFF
--- a/imednet/utils/filters.py
+++ b/imednet/utils/filters.py
@@ -5,7 +5,6 @@ This module provides functionality to construct filter query parameters
 for iMednet API endpoints based on the reference documentation.
 """
 
-import json
 import re
 from typing import Any, Dict, List, Tuple, Union
 
@@ -53,8 +52,11 @@ def build_filter_string(
     """
 
     def _format(val: Any) -> str:
-        if isinstance(val, str) and re.search(r"[^A-Za-z0-9_.-]", val):
-            return json.dumps(val)
+        if isinstance(val, str):
+            if re.search(r"[^A-Za-z0-9_.-]", val):
+                escaped = val.replace('"', r"\"")
+                return f'"{escaped}"'
+            return val
         return str(val)
 
     parts: List[str] = []

--- a/tests/unit/test_utils_dates_and_filters.py
+++ b/tests/unit/test_utils_dates_and_filters.py
@@ -82,3 +82,8 @@ def test_build_filter_string_snake_list() -> None:
 def test_build_filter_string_quotes() -> None:
     result = build_filter_string({"site_name": "My Site"})
     assert result == 'siteName=="My Site"'
+
+
+def test_build_filter_string_quote_spaces() -> None:
+    result = build_filter_string({"site_name": "A B"})
+    assert result == 'siteName=="A B"'

--- a/tests/unit/test_workflows_query_management.py
+++ b/tests/unit/test_workflows_query_management.py
@@ -71,3 +71,15 @@ def test_get_queries_by_site_returns_empty_if_no_subjects() -> None:
     sdk.subjects.list.assert_called_once_with("STUDY", site_name="SITE")
     sdk.queries.list.assert_not_called()
     assert result == []
+
+
+def test_get_queries_by_site_with_space_in_name() -> None:
+    sdk = MagicMock()
+    sdk.subjects.list.return_value = [Subject(subject_key="S1")]
+    wf = QueryManagementWorkflow(sdk)
+
+    wf.get_queries_by_site("STUDY", "Mock Site")
+
+    sdk.subjects.list.assert_called_once_with("STUDY", site_name="Mock Site")
+    sdk.queries.list.assert_called_once_with("STUDY", subject_key=["S1"])
+    assert sdk.queries.list.call_args.kwargs == {"subject_key": ["S1"]}


### PR DESCRIPTION
## Summary
- quote strings in `build_filter_string` when they contain spaces or special characters
- cover space-containing site names in filter tests
- ensure query workflow handles sites with spaces

## Testing
- `poetry run ruff check --fix .`
- `poetry run black --check .`
- `poetry run mypy imednet`
- `poetry run pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684ce6965cc4832c9df667f0e874b976