### PR TITLE
Fix export duplicate handling

### DIFF
--- a/imednet/integrations/export.py
+++ b/imednet/integrations/export.py
@@ -99,7 +99,7 @@ def export_to_json(
     # forms or revisions. Skip if the object does not expose a pandas-like
     # interface (e.g. unit tests using mocks).
     if isinstance(df, pd.DataFrame):
-        df = df.loc[:, ~df.columns.duplicated()]
+        df = df.loc[:, ~df.columns.str.lower().duplicated()]
     df.to_json(path, index=False, **kwargs)
 
 
@@ -130,6 +130,6 @@ def export_to_sql(
     # by keeping the first occurrence of each column. Skip when a mock DataFrame
     # is supplied during unit tests.
     if isinstance(df, pd.DataFrame):
-        df = df.loc[:, ~df.columns.duplicated()]
+        df = df.loc[:, ~df.columns.str.lower().duplicated()]
     engine = create_engine(conn_str)
     df.to_sql(table, engine, if_exists=if_exists, index=False, **kwargs)  # type: ignore[arg-type]

--- a/tests/unit/test_integrations_export.py
+++ b/tests/unit/test_integrations_export.py
@@ -98,3 +98,18 @@ def test_export_functions_handle_duplicate_columns(tmp_path, monkeypatch):
     out_db = tmp_path / "d.db"
     export_mod.export_to_sql(sdk, "S", "t", f"sqlite:///{out_db}")
     assert out_db.exists()
+
+
+def test_export_functions_handle_duplicate_columns_case_insensitive(tmp_path, monkeypatch):
+    df = pd.DataFrame([[1, 2]], columns=["A", "a"])
+    mapper_cls = MagicMock(return_value=MagicMock(dataframe=MagicMock(return_value=df)))
+    monkeypatch.setattr(export_mod, "RecordMapper", mapper_cls)
+    sdk = MagicMock()
+
+    out_json = tmp_path / "d.json"
+    export_mod.export_to_json(sdk, "S", str(out_json))
+    assert out_json.exists()
+
+    out_db = tmp_path / "d.db"
+    export_mod.export_to_sql(sdk, "S", "t", f"sqlite:///{out_db}")
+    assert out_db.exists()


### PR DESCRIPTION
## Summary
- remove case-insensitive duplicates when exporting
- test case-insensitive duplicate handling in export

## Testing
- `./scripts/setup.sh`
- `poetry run ruff check --fix .`
- `poetry run black --check .`
- `poetry run mypy imednet`
- `poetry run pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684ce724c260832cbc0ba1d8f839329a