### PR TITLE
fix(export): deduplicate parquet columns

### DIFF
--- a/imednet/integrations/export.py
+++ b/imednet/integrations/export.py
@@ -29,6 +29,8 @@ def export_to_parquet(
     df: pd.DataFrame = RecordMapper(sdk).dataframe(
         study_key, use_labels_as_columns=use_labels_as_columns
     )
+    if isinstance(df, pd.DataFrame):
+        df = df.loc[:, ~df.columns.str.lower().duplicated()]
     df.to_parquet(path, index=False, **kwargs)
 
 


### PR DESCRIPTION
## Summary
- remove case-insensitive duplicate columns in `export_to_parquet`
- test parquet export with duplicate column names

## Testing
- `poetry run ruff check --fix .`
- `poetry run black --check .`
- `poetry run mypy imednet`
- `poetry run pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684ce87b0dc8832c9bf4a3ae13bdfc26