### PR TITLE
Update README about SQLite column limit

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,6 +170,11 @@ Parquet and SQL exports require the optional `pyarrow` and `SQLAlchemy` dependen
 pip install "imednet-sdk[pyarrow,sqlalchemy]"
 ```
 
+SQLite imposes a limit of roughly 2000 columns per table. The
+`export_to_sql` helper and `imednet export sql` command will raise an error
+if this limit is exceeded. When exporting studies with many variables, use a
+different database backend or include only the required fields.
+
 Then run commands such as:
 
 ```powershell


### PR DESCRIPTION
## Summary
- document SQLite's 2000-column limit for CLI SQL export

## Testing
- `poetry run ruff check --fix .`
- `poetry run black --check .`
- `poetry run mypy imednet`
- `poetry run pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684dfd5737dc832c9554454e37a73008