### PR TITLE
Add schema validation diagram

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -8,6 +8,7 @@ Welcome to imednet-sdk's documentation!
    logging_and_tracing
    api_overview
    architecture
+   schema_validation
    cli
    airflow
    live_test_plan

--- a/docs/schema_validation.rst
+++ b/docs/schema_validation.rst
@@ -1,0 +1,22 @@
+Schema Validation Flow
+======================
+
+The SDK uses :class:`~imednet.validation.schema.SchemaValidator` and
+:class:`~imednet.validation.schema.SchemaCache` to verify record data before
+submitting it to the API. The diagram below outlines the main steps.
+
+.. mermaid::
+
+   graph TD
+       A[Record payload] --> B[SchemaValidator.validate_record]
+       B --> C{formKey or formId}
+       C -->|Resolve formKey| D[SchemaCache]
+       D --> E{variables cached?}
+       E -- No --> F[refresh(study_key)]
+       F --> G[sdk.variables.list]
+       G --> D
+       E -- Yes --> H[validate_record_data]
+       D --> H
+       H --> I{validation passes?}
+       I -- Yes --> J[submit to RecordsEndpoint]
+       I -- No --> K[raise ValidationError]


### PR DESCRIPTION
## Summary
- document schema validation process
- add new documentation page with Mermaid diagram

## Testing
- `poetry run ruff check --fix .`
- `poetry run black --check .`
- `poetry run mypy imednet`
- `poetry run pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684e0c0cd8fc832cbd3f47418f0f9415