### PR TITLE
Complete pending tasks

### DIFF
--- a/imednet/utils/json_logging.py
+++ b/imednet/utils/json_logging.py
@@ -1,11 +1,14 @@
 import logging
 
-from pythonjsonlogger import jsonlogger
+try:  # python-json-logger >= 3.0
+    from pythonjsonlogger.json import JsonFormatter
+except ModuleNotFoundError:  # pragma: no cover - fallback for older versions
+    from pythonjsonlogger.jsonlogger import JsonFormatter
 
 
 def configure_json_logging(level: int = logging.INFO) -> None:
     """Configure root logger to emit JSON formatted logs."""
     handler = logging.StreamHandler()
-    formatter = jsonlogger.JsonFormatter()
+    formatter = JsonFormatter()
     handler.setFormatter(formatter)
     logging.basicConfig(level=level, handlers=[handler], force=True)

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+asyncio_default_fixture_loop_scope = module


### PR DESCRIPTION
## Summary
- support new and old python-json-logger import path
- configure pytest-asyncio loop scope

## Testing
- `poetry run ruff check --fix .`
- `poetry run black --check .`
- `poetry run mypy imednet`
- `poetry run pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684cecc89878832ca4ca1b99d50c70a7