### PR TITLE
Update pytest asyncio config

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,2 +1,2 @@
 [pytest]
-asyncio_default_fixture_loop_scope = module
+asyncio_mode = auto


### PR DESCRIPTION
## Summary
- remove deprecated `asyncio_default_fixture_loop_scope` option
- set `asyncio_mode = auto` in `pytest.ini`

## Testing
- `poetry run ruff check --fix .`
- `poetry run black --check .`
- `poetry run mypy imednet`
- `poetry run pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684f305323d4832ca2c3fab2677c1e24