### PR TITLE
docs: remove Bright Research references

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -26,7 +26,7 @@ Project maintainers are responsible for clarifying standards of acceptable behav
 
 ## Reporting Guidelines
 
-If you are subject to or witness unacceptable behavior, please report it by contacting the project maintainers at [open an issue](https://github.com/Bright-Research/imednet-python-sdk/issues) or emailing <frederick.deruiter@brightresearch.com>.
+If you are subject to or witness unacceptable behavior, please report it by contacting the project maintainers at [open an issue](https://github.com/Bright-Research/imednet-python-sdk/issues) or emailing <fpderuiter@gmail.com>.
 
 ## License & Attribution
 

--- a/README.md
+++ b/README.md
@@ -352,7 +352,6 @@ To publish a new release:
 
 ## Governance and Roadmap
 
-This project is currently maintained by Bright Research.
 
 ## License
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ classifiers = [
     "Typing :: Typed",
 ]
 authors = ["Frederick de Ruiter <127706008+fderuiter@users.noreply.github.com>"]
-maintainers = ["Frederick de Ruiter <frederick.deruiter@brightresearch.com>"]
+maintainers = ["Frederick de Ruiter <fpderuiter@gmail.com>"]
 packages = [{ include = "imednet" }]
 include = [
     "README.md",


### PR DESCRIPTION
## Summary
- remove statement naming Bright Research as the maintainer
- update contact emails to fpderuiter@gmail.com

## Testing
- `poetry run ruff check --fix .`
- `poetry run black --check .`
- `poetry run mypy imednet`
- `poetry run pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68504cd676fc832c98f06318f44b2c64