### PR TITLE
Add per-form SQLite export

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,10 +171,11 @@ Parquet and SQL exports require the optional `pyarrow` and `SQLAlchemy` dependen
 pip install "imednet-sdk[pyarrow,sqlalchemy]"
 ```
 
-SQLite imposes a limit of roughly 2000 columns per table. The
-`export_to_sql` helper and `imednet export sql` command will raise an error
-if this limit is exceeded. When exporting studies with many variables, use a
-different database backend or include only the required fields.
+SQLite imposes a limit of roughly 2000 columns per table. To avoid this
+restriction the `imednet export sql` command automatically writes one table
+per form when the connection string uses SQLite. Use `--single-table` to
+retain the original behaviour. The `export_to_sql_by_form` helper provides
+the same functionality for direct Python usage.
 
 Then run commands such as:
 
@@ -201,11 +202,10 @@ imednet records list STUDY_KEY
 imednet subjects list --help
 ```
 
-When exporting to SQLite using the CLI, keep in mind that the database
-cannot store more than ``2000`` columns in a table. The helper
-``export_to_sql`` enforces this via the constant
-``imednet.integrations.export.MAX_SQLITE_COLUMNS``. Use another
-database backend if your study contains more variables.
+When using SQLite the helper constant ``imednet.integrations.export.MAX_SQLITE_COLUMNS``
+still applies. If a form exceeds this limit an error is raised. Consider another
+database backend for very wide forms or specify ``--single-table`` to manually
+manage the limitation.
 
 - See the full API reference in the [HTML docs](docs/_build/html/index.html).
 - More examples can be found in the `examples/` directory.

--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -60,12 +60,10 @@ List subjects that are screened for a study and save their records as CSV:
 
 Use ``--help`` on any command to see all options.
 
-SQLite Column Limit
--------------------
+SQLite Exports
+--------------
 
-The ``export sql`` command writes records to a database using
-``export_to_sql``. When the destination is SQLite, tables are limited to
-``2000`` columns. The helper checks this against
-``imednet.integrations.export.MAX_SQLITE_COLUMNS`` and raises a friendly
-error if exceeded. Use another backend if your study contains more
-variables.
+When the connection string uses SQLite, ``export sql`` writes one table per
+form to avoid the ``2000`` column limit. Pass ``--single-table`` to disable
+this behaviour. The constant ``imednet.integrations.export.MAX_SQLITE_COLUMNS``
+still enforces the maximum columns per table.

--- a/imednet/cli/__init__.py
+++ b/imednet/cli/__init__.py
@@ -11,6 +11,7 @@ from ..integrations.export import (  # noqa: F401
     export_to_excel,  # noqa: F401
     export_to_json,  # noqa: F401
     export_to_parquet,  # noqa: F401
+    export_to_sql_by_form,  # noqa: F401
     export_to_sql,  # noqa: F401
 )  # noqa: F401
 from ..workflows.data_extraction import DataExtractionWorkflow  # noqa: F401

--- a/imednet/integrations/__init__.py
+++ b/imednet/integrations/__init__.py
@@ -6,6 +6,7 @@ from .export import (
     export_to_json,
     export_to_parquet,
     export_to_sql,
+    export_to_sql_by_form,
 )
 
 __all__ = [
@@ -13,5 +14,6 @@ __all__ = [
     "export_to_excel",
     "export_to_json",
     "export_to_parquet",
+    "export_to_sql_by_form",
     "export_to_sql",
 ]


### PR DESCRIPTION
## Summary
- implement `export_to_sql_by_form` to split exports by form
- automatically use new behaviour in CLI when connection string is SQLite
- document SQLite splitting and new `--single-table` option
- test export helper and CLI changes

## Testing
- `poetry run ruff check --fix .`
- `poetry run black --check .`
- `poetry run mypy imednet`
- `poetry run pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68504c5a6d3c832c980292babe6931ee