### PR TITLE
Add REST API reference docs

### DIFF
--- a/docs/endpoints/codings.rst
+++ b/docs/endpoints/codings.rst
@@ -1,0 +1,184 @@
+Codings Endpoint
+================
+
+The codings endpoint exposes medical coding activity for a study. Entries are
+created when values collected in iMednet are standardized to a dictionary term
+such as MedDRA.
+
+Accessing the index
+-------------------
+
+A ``GET`` request returns the coding history for a study::
+
+   GET /api/v1/edc/studies/PHARMADEMO/codings?page=0&size=25 \
+       &sort=recordId%2CASC&filter=dictionaryName%3DMedDRA HTTP/1.1
+   Content-Type: application/json
+   Host: localhost:8080
+
+Path parameters
+---------------
+
+``studyKey``
+   The study identifier used to retrieve codings.
+
+Request parameters
+------------------
+
+``page``
+   Index page to return. Defaults to ``0``.
+
+``size``
+   Items per page. Defaults to ``25`` with a maximum of ``500``.
+
+``sort``
+   Property used to sort results. Append ``asc`` or ``desc`` to specify the
+   direction. Multiple ``sort`` parameters may be supplied. The default is
+   ``formId,asc``.
+
+``filter``
+   Optional search criteria. See :doc:`../rest_api_reference` for syntax.
+
+Response body
+-------------
+
+Example response::
+
+   {
+     "metadata": {
+       "status": "OK",
+       "method": "GET",
+       "path": "/api/v1/edc/studies/PHARMADEMO/codings",
+       "timestamp": "2025-06-05 21:12:10",
+       "error": {}
+     },
+     "pagination": {
+       "currentPage": 0,
+       "size": 25,
+       "totalPages": 1,
+       "totalElements": 1,
+       "sort": [
+         {
+           "property": "recordId",
+           "direction": "ASC"
+         }
+       ]
+     },
+     "data": [
+       {
+         "studyKey": "PHARMADEMO",
+         "siteName": "Chicago Hope Hospital",
+         "siteId": 128,
+         "subjectId": 247,
+         "subjectKey": "111-005",
+         "formId": 1,
+         "formName": "Adverse Event",
+         "formKey": "AE",
+         "revision": 2,
+         "recordId": 1,
+         "variable": "AETERM",
+         "value": "Angina",
+         "codingId": 1,
+         "code": "Angina agranulocytic",
+         "codedBy": "John Smith",
+         "reason": "Typo fix",
+         "dictionaryName": "MedDRA",
+         "dictionaryVersion": "24.0",
+         "dateCoded": "2025-06-05 21:12:10"
+       }
+     ]
+   }
+
+Response fields
+---------------
+
+``metadata.status``
+   HTTP status.
+
+``metadata.method``
+   HTTP method.
+
+``metadata.path``
+   Requested URI path.
+
+``metadata.timestamp``
+   Timestamp when the response was generated.
+
+``metadata.error``
+   Detail error message if the request failed.
+
+``pagination.currentPage``
+   Current index page.
+
+``pagination.size``
+   Page size.
+
+``pagination.totalPages``
+   Total pages returned.
+
+``pagination.totalElements``
+   Total elements returned.
+
+``pagination.sort[].property``
+   Sort property.
+
+``pagination.sort[].direction``
+   Sort direction.
+
+``data[].studyKey``
+   Unique study key for a given study.
+
+``data[].siteName``
+   Site name.
+
+``data[].siteId``
+   Unique site identifier.
+
+``data[].subjectId``
+   Mednet subject ID.
+
+``data[].subjectKey``
+   Protocol assigned subject identifier.
+
+``data[].formId``
+   Mednet form ID.
+
+``data[].formName``
+   Name of the eCRF.
+
+``data[].formKey``
+   Form key.
+
+``data[].revision``
+   Number of modifications of the coding metadata.
+
+``data[].recordId``
+   Unique record identifier.
+
+``data[].variable``
+   Name of the variable on the eCRF.
+
+``data[].value``
+   Value that was coded.
+
+``data[].codingId``
+   Mednet coding ID.
+
+``data[].code``
+   Assigned code.
+
+``data[].codedBy``
+   User who recorded the code.
+
+``data[].reason``
+   Reason the code was added.
+
+``data[].dictionaryName``
+   Dictionary name.
+
+``data[].dictionaryVersion``
+   Dictionary version.
+
+``data[].dateCoded``
+   Date the code was recorded.
+
+`Portal docs <https://portal.prod.imednetapi.com/docs/codings>`_

--- a/docs/endpoints/forms.rst
+++ b/docs/endpoints/forms.rst
@@ -1,0 +1,103 @@
+Forms Endpoint
+==============
+
+The Forms endpoint returns the design specification for electronic
+case report forms (eCRFs) within a study. Each form describes the
+questions presented to a subject when a record is created.
+
+Request
+-------
+
+``GET /api/v1/edc/studies/{studyKey}/forms``
+
+Query Parameters
+----------------
+
+``page``
+  Index page to fetch (default ``0``).
+
+``size``
+  Items per page (default ``25``, maximum ``500``).
+
+``sort``
+  Field to sort by optionally followed by ``asc`` or ``desc``.
+  The default is ``formId,asc``.
+
+``filter``
+  Optional filter criteria using the syntax described in
+  :doc:`../rest_api_reference`.
+
+Example request::
+
+  GET /api/v1/edc/studies/PHARMADEMO/forms?page=0&size=25&sort=formId%2CASC&filter=formId%3D%3D10265
+
+Response
+--------
+
+The response contains ``metadata`` and ``pagination`` objects along with a
+``data`` array of form records. Each item can be parsed into
+:class:`~imednet.models.forms.Form`.
+
+.. code-block:: json
+
+   {
+     "metadata": { "status": "OK", ... },
+     "pagination": { "currentPage": 0, "size": 25, "totalPages": 1 },
+     "data": [
+       {
+         "studyKey": "PHARMADEMO",
+         "formId": 1,
+         "formKey": "FORM_1",
+         "formName": "Mock Form 1",
+         "formType": "Subject",
+         "revision": 1,
+         "embeddedLog": false,
+         "enforceOwnership": false,
+         "userAgreement": false,
+         "subjectRecordReport": false,
+         "unscheduledVisit": false,
+         "otherForms": false,
+         "eproForm": false,
+         "allowCopy": true,
+         "disabled": false,
+         "dateCreated": "2025-06-05 21:12:09",
+         "dateModified": "2025-06-05 21:12:10"
+       }
+     ]
+   }
+
+Common fields
+~~~~~~~~~~~~~
+
+``studyKey``
+  Unique study identifier.
+
+``formId``
+  Mednet form ID.
+
+``formKey``
+  Key used when referencing the form in records.
+
+``formName``
+  Human readable name.
+
+``formType``
+  eCRF type such as ``Subject`` or ``Site``.
+
+``revision``
+  Number of metadata revisions.
+
+``dateCreated``
+  Creation timestamp.
+
+``dateModified``
+  Last modification timestamp.
+
+Methods
+-------
+
+Use :meth:`~imednet.endpoints.forms.FormsEndpoint.list` to
+retrieve all forms in a study or :meth:`~imednet.endpoints.forms.FormsEndpoint.get`
+to fetch a single form.
+
+`Portal docs <https://portal.prod.imednetapi.com/docs/forms>`_

--- a/docs/endpoints/index.rst
+++ b/docs/endpoints/index.rst
@@ -1,0 +1,19 @@
+Endpoints
+=========
+
+.. toctree::
+   :maxdepth: 1
+
+   codings
+   forms
+   intervals
+   jobs
+   queries
+   record_revisions
+   records
+   sites
+   studies
+   subjects
+   users
+   variables
+   visits

--- a/docs/endpoints/intervals.rst
+++ b/docs/endpoints/intervals.rst
@@ -1,0 +1,201 @@
+Intervals Endpoint
+==================
+
+The ``intervals`` resource lists the scheduled intervals (or visits) for a
+study. Each interval defines a set of forms that must be completed for a
+subject. A visit is a single instance of an interval for a given subject.
+
+Accessing the index
+-------------------
+
+Use ``GET`` to retrieve intervals for a study. The request supports paging,
+sorting and filtering.
+
+Example request::
+
+   GET /api/v1/edc/studies/PHARMADEMO/intervals?page=0&size=25&sort=intervalId%2CASC&filter=intervalId%3D%3D161 HTTP/1.1
+   Content-Type: application/json
+   Host: localhost:8080
+
+Path parameters
+~~~~~~~~~~~~~~~
+
+``studyKey``
+  Study key used to retrieve intervals.
+
+Request parameters
+~~~~~~~~~~~~~~~~~~
+
+``page``
+  Index page to return. Defaults to ``0``.
+
+``size``
+  Items per page. Defaults to ``25``. Maximum ``500``.
+
+``sort``
+  Property used to sort the result set. Add ``asc`` or ``desc`` after the
+  property name to specify direction. Multiple ``sort`` parameters are allowed.
+  Default ``intervalId,asc``.
+
+``filter``
+  Optional filter criteria. See :doc:`../rest_api_reference` for syntax.
+
+Response body
+-------------
+
+Example payload::
+
+   {
+     "metadata" : {
+       "status" : "OK",
+       "method" : "GET",
+       "path" : "/api/v1/edc/studies/PHARMADEMO/intervals",
+       "timestamp" : "2025-06-05 21:12:08",
+       "error" : { }
+     },
+     "pagination" : {
+       "currentPage" : 0,
+       "size" : 25,
+       "totalPages" : 1,
+       "totalElements" : 1,
+       "sort" : [ {
+         "property" : "intervalId",
+         "direction" : "ASC"
+       } ]
+     },
+     "data" : [ {
+       "studyKey" : "PHARMADEMO",
+       "intervalId" : 1,
+       "intervalName" : "Day 1",
+       "intervalDescription" : "Day 1",
+       "intervalSequence" : 110,
+       "intervalGroupId" : 10,
+       "intervalGroupName" : "ePRO",
+       "disabled" : true,
+       "dateCreated" : "2025-06-05 21:12:08",
+       "dateModified" : "2025-06-05 21:12:09",
+       "timeline" : "Start Date End Date",
+       "definedUsingInterval" : "Baseline",
+       "windowCalculationForm" : "Procedure",
+       "windowCalculationDate" : "PROCDT",
+       "actualDateForm" : "Follow Up",
+       "actualDate" : "FUDT",
+       "dueDateWillBeIn" : 30,
+       "negativeSlack" : 7,
+       "positiveSlack" : 7,
+       "eproGracePeriod" : 2,
+       "forms" : [ {
+         "formId" : 123,
+         "formKey" : "MY-FORM-KEY",
+         "formName" : "myFormName"
+       } ]
+     } ]
+   }
+
+Response fields
+---------------
+
+``metadata.status``
+  HTTP status.
+
+``metadata.method``
+  HTTP method.
+
+``metadata.path``
+  Request URI path.
+
+``metadata.timestamp``
+  Timestamp when the response was generated.
+
+``metadata.error``
+  Error details when a request fails.
+
+``pagination.currentPage``
+  Current index page.
+
+``pagination.size``
+  Page size.
+
+``pagination.totalPages``
+  Total pages returned.
+
+``pagination.totalElements``
+  Total elements returned.
+
+``pagination.sort[].property``
+  Sort property.
+
+``pagination.sort[].direction``
+  Sort direction.
+
+``data[].studyKey``
+  Study key.
+
+``data[].intervalId``
+  Unique interval identifier.
+
+``data[].intervalName``
+  Interval or visit name.
+
+``data[].intervalDescription``
+  Interval description.
+
+``data[].intervalSequence``
+  Sequence number.
+
+``data[].intervalGroupId``
+  Interval group ID.
+
+``data[].intervalGroupName``
+  Interval group name.
+
+``data[].timeline``
+  Type of interval visit window.
+
+``data[].definedUsingInterval``
+  Baseline interval where the calculate-from date is collected.
+
+``data[].windowCalculationForm``
+  Baseline form where the calculate-from date is collected.
+
+``data[].windowCalculationDate``
+  Baseline field used to calculate dates.
+
+``data[].actualDateForm``
+  Actual date form for the interval.
+
+``data[].actualDate``
+  Actual date field for the interval.
+
+``data[].dueDateWillBeIn``
+  Number of days the actual date is due from the calculate-from date.
+
+``data[].negativeSlack``
+  Allowed negative days from the due date.
+
+``data[].positiveSlack``
+  Allowed positive days from the due date.
+
+``data[].eproGracePeriod``
+  Allowed positive days for ePRO from the due date.
+
+``data[].forms[].formId``
+  Form ID.
+
+``data[].forms[].formKey``
+  Form key.
+
+``data[].forms[].formName``
+  Form name.
+
+``data[].disabled``
+  Interval soft-delete status.
+
+``data[].dateCreated``
+  Date when the interval was created.
+
+``data[].dateModified``
+  Date when the interval was last modified.
+
+`Portal docs <https://portal.prod.imednetapi.com/docs/intervals>`_
+

--- a/docs/endpoints/jobs.rst
+++ b/docs/endpoints/jobs.rst
@@ -1,0 +1,76 @@
+Jobs Endpoint
+=============
+
+Given a batch ID, fetch the job information created by a background operation.
+Jobs are typically generated when you submit records via ``POST`` and the server
+processes them asynchronously.
+
+Accessing the job
+-----------------
+
+A ``GET`` request retrieves the job status.
+
+.. code-block:: http
+
+    GET /api/v1/edc/studies/MOCK-STUDY/jobs/f89ceda2-f7c8-4939-859e-d3e967f315a1 HTTP/1.1
+    Content-Type: application/json
+    Host: localhost:8080
+
+Path parameters
+---------------
+
+All parameters in the path are required.
+
+.. list-table:: /api/v1/edc/studies/{studyKey}/jobs/{batchId}
+   :header-rows: 1
+
+   * - Parameter
+     - Description
+   * - ``studyKey``
+     - Study key used to look up the job state.
+   * - ``batchId``
+     - Batch ID returned from the ``POST /records`` request.
+
+Example response
+----------------
+
+.. code-block:: json
+
+    {
+      "jobId": "930720e7-4f3b-4452-be2b-f4233e5f433b",
+      "batchId": "9e9e8584-0c71-40f2-86ee-7d414766f7f2",
+      "state": "completed",
+      "dateCreated": "2020-12-01 21:47:36",
+      "dateStarted": "2020-12-01 21:47:42",
+      "dateFinished": "2020-12-01 21:47:45"
+    }
+
+Response fields
+---------------
+
+.. list-table::
+   :header-rows: 1
+
+   * - Field
+     - Type
+     - Description
+   * - ``jobId``
+     - string
+     - Job identifier
+   * - ``batchId``
+     - string
+     - Associated batch ID
+   * - ``state``
+     - string
+     - Current job state
+   * - ``dateCreated``
+     - string
+     - Timestamp when the job was created
+   * - ``dateStarted``
+     - string
+     - Timestamp when processing started
+   * - ``dateFinished``
+     - string
+     - Timestamp when processing completed
+
+`Portal docs <https://portal.prod.imednetapi.com/docs/jobs>`_

--- a/docs/endpoints/queries.rst
+++ b/docs/endpoints/queries.rst
@@ -1,0 +1,189 @@
+Queries Endpoint
+================
+
+Given a ``studyKey`` fetch the set of queries. A query is a conduct resource that
+encapsulates dialogue pertaining to specific eCRF responses or other matters
+relevant to the conduct of the study. Queries may be user‑initiated, or
+automatically applied according to study protocol criteria.
+
+Accessing the index
+-------------------
+
+A ``GET`` request is used to access the index.
+
+Request structure
+-----------------
+
+.. code-block:: http
+
+   GET /api/v1/edc/studies/batchId/queries?page=0&size=25&sort=annotationId%2CASC&filter=variable%3D%3Daeterm HTTP/1.1
+   Content-Type: application/json
+   Host: localhost:8080
+
+Path parameters
+~~~~~~~~~~~~~~~
+
+``studyKey``
+    StudyKey to retrieve list of query.
+
+Request parameters
+~~~~~~~~~~~~~~~~~~
+
+``page``
+    Which index page to be returned. Default value is ``0``.
+
+``size``
+    Items per page to be returned. Default value is ``25``. Maximum items allowed
+    per page is ``500``.
+
+``sort``
+    Name of the property by which to sort the result set. To sort in a particular
+    direction add a comma to the property name and either ``asc`` or ``desc``.
+    To sort by multiple properties add additional ``sort`` parameters. Default
+    value is ``annotationId,asc``.
+
+``filter``
+    Optional filter search criteria. Must follow correct syntax. Refer to
+    :doc:`rest_api_reference` for details.
+
+Response body
+-------------
+
+Below is an example response payload.
+
+.. code-block:: json
+
+   {
+     "metadata" : {
+       "status" : "OK",
+       "method" : "GET",
+       "path" : "/api/v1/edc/studies/batchId/queries",
+       "timestamp" : "2025-06-05 21:12:09",
+       "error" : { }
+     },
+     "pagination" : {
+       "currentPage" : 0,
+       "size" : 25,
+       "totalPages" : 1,
+       "totalElements" : 1,
+       "sort" : [ {
+         "property" : "annotationId",
+         "direction" : "ASC"
+       } ]
+     },
+     "data" : [ {
+       "studyKey" : "PHARMADEMO",
+       "subjectId" : 1,
+       "subjectOid" : "OID-1",
+       "annotationType" : "subject",
+       "annotationId" : 1,
+       "type" : null,
+       "description" : "Monitor Query",
+       "recordId" : 123,
+       "variable" : "aeterm",
+       "subjectKey" : "123-005",
+       "dateCreated" : "2025-06-05 21:12:09",
+       "dateModified" : "2025-06-05 21:12:10",
+       "queryComments" : [ {
+         "sequence" : 1,
+         "annotationStatus" : "Monitor Query Open",
+         "user" : "john",
+         "comment" : "Added comment to study",
+         "closed" : false,
+         "date" : "2025-06-05 21:12:09"
+       } ]
+     } ]
+   }
+
+Response fields
+---------------
+
+``metadata.status``
+    Http status
+
+``metadata.method``
+    Http method
+
+``metadata.path``
+    Requested URI path
+
+``metadata.timestamp``
+    Timestamp when response was generated
+
+``metadata.error``
+    Detail error message from request if error occur
+
+``pagination.currentPage``
+    Current index page
+
+``pagination.size``
+    Size per page
+
+``pagination.totalPages``
+    Total pages return from search
+
+``pagination.totalElements``
+    Total elements return from search
+
+``pagination.sort[].property``
+    Sort property
+
+``pagination.sort[].direction``
+    Sort direction
+
+``data[].studyKey``
+    Unique study key for a given study
+
+``data[].subjectId``
+    Mednet Subject ID
+
+``data[].subjectOid``
+    Client-assigned subject OID
+
+``data[].annotationType``
+    User defined identifier for Query Type
+
+``data[].annotationId``
+    Unique system identifier for Query Instance
+
+``data[].type``
+    System text identifier for query type/location. Valid responses are
+    ``subject`` | ``record`` | ``question``
+
+``data[].description``
+    Query description
+
+``data[].subjectKey``
+    Protocol-assigned subject identifier
+
+``data[].recordId``
+    Unique system identifier for Record
+
+``data[].variable``
+    User defined field identifier
+
+``data[].queryComments[].sequence``
+    Query sequence
+
+``data[].queryComments[].user``
+    User performing Query action
+
+``data[].queryComments[].annotationStatus``
+    User defined Query status
+
+``data[].queryComments[].comment``
+    User comments applied at time of Query action
+
+``data[].queryComments[].closed``
+    Query moved to closed status
+
+``data[].queryComments[].date``
+    Date of Query Comment
+
+``data[].dateCreated``
+    Date when the query was created
+
+``data[].dateModified``
+    Date when the query was modified
+
+`Portal docs <https://portal.prod.imednetapi.com/docs/queries>`_

--- a/docs/endpoints/record_revisions.rst
+++ b/docs/endpoints/record_revisions.rst
@@ -1,0 +1,153 @@
+Record Revisions Endpoint
+=========================
+
+Given a ``StudyKey``, fetch the set of record revisions. Each revision represents a distinct state
+in the lifecycle of a record. Every time data is modified on a record or it progresses to a new
+status, a new record revision is captured.
+
+Accessing the index
+-------------------
+
+A ``GET`` request is used to access the index.
+
+.. code-block:: http
+
+   GET /api/v1/edc/studies/PHARMADEMO/recordRevisions?page=0&size=25&sort=recordRevisionId%2CASC&filter=subjectKey%3D%3D270 HTTP/1.1
+   Content-Type: application/json
+   Host: localhost:8080
+
+Path Parameters
+---------------
+
+``studyKey``
+    Study key to retrieve list of record revisions.
+
+Request Parameters
+------------------
+
+``page``
+    Index page to return. Default is ``0``.
+``size``
+    Items per page. Default is ``25``. Maximum is ``500``.
+``sort``
+    Sort property. Append ``asc`` or ``desc`` for direction. Default is ``recordRevisionId,asc``.
+``filter``
+    Optional filter criteria. See :ref:`filter` for syntax details.
+
+Response
+--------
+
+Example response payload:
+
+.. code-block:: json
+
+   {
+     "metadata": {
+       "status": "OK",
+       "method": "GET",
+       "path": "/api/v1/edc/studies/PHARMADEMO/recordRevisions",
+       "timestamp": "2025-06-05 21:12:09",
+       "error": {}
+     },
+     "pagination": {
+       "currentPage": 0,
+       "size": 25,
+       "totalPages": 1,
+       "totalElements": 1,
+       "sort": [
+         {
+           "property": "recordRevisionId",
+           "direction": "ASC"
+         }
+       ]
+     },
+     "data": [
+       {
+         "studyKey": "PHARMADEMO",
+         "recordRevisionId": 1,
+         "recordId": 1,
+         "recordOid": "REC-1",
+         "recordRevision": 1,
+         "dataRevision": 1,
+         "recordStatus": "Record Complete",
+         "subjectId": 247,
+         "subjectOid": "OID-1",
+         "subjectKey": "001-003",
+         "siteId": 2,
+         "formKey": "AE",
+         "intervalId": 15,
+         "role": "Research Coordinator",
+         "user": "jdoe",
+         "reasonForChange": "Data entry error",
+         "deleted": true,
+         "dateCreated": "2025-06-05 21:12:09"
+       }
+     ]
+   }
+
+Response Fields
+---------------
+
+``metadata.status`` (String)
+    HTTP status.
+``metadata.method`` (String)
+    HTTP method.
+``metadata.path`` (String)
+    Requested URI path.
+``metadata.timestamp`` (String)
+    Timestamp when response was generated.
+``metadata.error`` (Object)
+    Detailed error message if an error occurred.
+``pagination.currentPage`` (Number)
+    Current index page.
+``pagination.size`` (Number)
+    Size per page.
+``pagination.totalPages`` (Number)
+    Total pages returned from search.
+``pagination.totalElements`` (Number)
+    Total elements returned from search.
+``pagination.sort[].property`` (String)
+    Sort property.
+``pagination.sort[].direction`` (String)
+    Sort direction.
+``data[].studyKey`` (String)
+    Unique study key.
+``data[].recordRevisionId`` (Number)
+    Unique system identifier for the record revision.
+``data[].recordId`` (Number)
+    Unique system identifier for the related record.
+``data[].recordOid`` (String)
+    Client-assigned record OID.
+``data[].recordRevision`` (Number)
+    Record revision number.
+``data[].dataRevision`` (Number)
+    Data revision number.
+``data[].recordStatus`` (String)
+    User defined record status.
+``data[].subjectId`` (Number)
+    Mednet Subject ID.
+``data[].subjectOid`` (String)
+    Client-assigned subject OID.
+``data[].subjectKey`` (String)
+    Protocol-assigned subject identifier.
+``data[].siteId`` (Number)
+    Unique system identifier for the related site.
+``data[].formKey`` (String)
+    Form key.
+``data[].intervalId`` (Number)
+    Unique system identifier for the interval.
+``data[].role`` (String)
+    Role name of the user who saved the record revision.
+``data[].user`` (String)
+    Username of the user who saved the record revision.
+``data[].reasonForChange`` (String)
+    Record revision's Reason For Change data.
+``data[].deleted`` (Boolean)
+    Record deleted flag.
+``data[].dateCreated`` (String)
+    Date when this record revision was created.
+
+Reference
+---------
+
+`Portal docs <https://portal.prod.imednetapi.com/docs/Record%20Revisions>`_

--- a/docs/endpoints/records.rst
+++ b/docs/endpoints/records.rst
@@ -1,0 +1,372 @@
+Records Endpoint
+================
+
+Given a ``studyKey``, fetch the set of records. A record is a conduct resource that
+represents a single instance of an electronic case report form (eCRF). Each record
+contains the responses to each question on the eCRF.
+
+Accessing the index
+-------------------
+
+A ``GET`` request retrieves records while ``POST`` adds records to the iMednet
+database.
+
+Path parameters
+---------------
+
+``{studyKey}``
+  StudyKey to retrieve list of records.
+
+GET Requests
+------------
+
+**GET Request structure**
+
+.. code-block:: http
+
+   GET /api/v1/edc/studies/PHARMADEMO/records?page=0&size=25&sort=recordId%2CASC&filter=recordId%3D%3D5510&recordDataFilter=aeterm%3D%3DBronchitis HTTP/1.1
+   Content-Type: application/json
+   Host: localhost:8080
+
+**GET Request parameters**
+
+Request parameters are optional. Default values are used unless specified.
+
++-------------------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+| Parameter         | Description                                                                                                                                                                                                |
++===================+============================================================================================================================================================================================================+
+| ``page``          | Which index page to be returned. Default value is ``0``.                                                                                                                                                    |
++-------------------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+| ``size``          | Items per page to be returned. Default value is ``25``. Maximum items allowed per page is ``500``.                                                                                                          |
++-------------------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+| ``sort``          | Name of the property by which to sort the result set. To sort in a particular direction add a comma to the property name and ``asc`` or ``desc``. To sort by multiple properties add additional sort parameters. Default value is ``recordId,asc``. |
++-------------------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+| ``filter``        | Optional filter search criteria. Must follow correct syntax. Refer to :doc:`../rest_api_reference` for details.                                                                                              |
++-------------------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+| ``recordDataFilter`` | Optional record data filter search criteria. Must follow correct syntax. Refer to :doc:`../rest_api_reference` for details.                                                                                |
++-------------------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+
+**GET Response body**
+
+.. code-block:: json
+
+   {
+     "metadata" : {
+       "status" : "OK",
+       "method" : "GET",
+       "path" : "/api/v1/edc/studies/PHARMADEMO/records",
+       "timestamp" : "2025-06-05 21:12:09",
+       "error" : { }
+     },
+     "pagination" : {
+       "currentPage" : 0,
+       "size" : 25,
+       "totalPages" : 1,
+       "totalElements" : 1,
+       "sort" : [ {
+         "property" : "recordId",
+         "direction" : "ASC"
+       } ]
+     },
+     "data" : [ {
+       "studyKey" : "PHARMADEMO",
+       "intervalId" : 99,
+       "formId" : 10202,
+       "formKey" : "AE",
+       "siteId" : 128,
+       "recordId" : 1,
+       "recordOid" : "REC-1",
+       "recordType" : "SUBJECT",
+       "recordStatus" : "Record Incomplete",
+       "deleted" : false,
+       "dateCreated" : "2025-06-05 21:12:09",
+       "dateModified" : "2025-06-05 21:12:10",
+       "subjectId" : 326,
+       "subjectOid" : "OID-1",
+       "subjectKey" : "123-456",
+       "visitId" : 1,
+       "parentRecordId" : 34,
+       "keywords" : [ {
+         "keywordName" : "Data Entry Error",
+         "keywordKey" : "DEE",
+         "keywordId" : 15362,
+         "dateAdded" : "2025-06-05 21:12:09"
+       } ],
+       "recordData" : {
+         "dateCreated" : "2018-10-18 06:21:46",
+         "unvnum" : "1",
+         "dateModified" : "2018-11-18 07:11:16",
+         "aeser" : "",
+         "aeterm" : "Bronchitis"
+       }
+     } ]
+   }
+
+**GET Response fields**
+
++----------------------------+---------+-------------------------------------------------------------+
+| Path                       | Type    | Description                                                 |
++============================+=========+=============================================================+
+| ``metadata.status``        | String  | HTTP status                                                |
++----------------------------+---------+-------------------------------------------------------------+
+| ``metadata.method``        | String  | HTTP method                                                |
++----------------------------+---------+-------------------------------------------------------------+
+| ``metadata.path``          | String  | Requested URI path                                         |
++----------------------------+---------+-------------------------------------------------------------+
+| ``metadata.timestamp``     | String  | Timestamp when response was generated                      |
++----------------------------+---------+-------------------------------------------------------------+
+| ``metadata.error``         | Object  | Detail error message from request if error occur           |
++----------------------------+---------+-------------------------------------------------------------+
+| ``pagination.currentPage`` | Number  | Current index page                                         |
++----------------------------+---------+-------------------------------------------------------------+
+| ``pagination.size``        | Number  | Size per page                                              |
++----------------------------+---------+-------------------------------------------------------------+
+| ``pagination.totalPages``  | Number  | Total pages return from search                             |
++----------------------------+---------+-------------------------------------------------------------+
+| ``pagination.totalElements`` | Number | Total elements return from search                           |
++----------------------------+---------+-------------------------------------------------------------+
+| ``pagination.sort[].property`` | String | Sort property                                              |
++----------------------------+---------+-------------------------------------------------------------+
+| ``pagination.sort[].direction`` | String | Sort direction                                             |
++----------------------------+---------+-------------------------------------------------------------+
+| ``data[].studyKey``        | String  | Unique study key for a given study                         |
++----------------------------+---------+-------------------------------------------------------------+
+| ``data[].intervalId``      | Number  | Unique system identifier for Interval                      |
++----------------------------+---------+-------------------------------------------------------------+
+| ``data[].formId``          | Number  | Form ID                                                    |
++----------------------------+---------+-------------------------------------------------------------+
+| ``data[].formKey``         | String  | Form Key                                                   |
++----------------------------+---------+-------------------------------------------------------------+
+| ``data[].siteId``          | Number  | Unique system identifier for site                          |
++----------------------------+---------+-------------------------------------------------------------+
+| ``data[].recordId``        | Number  | Unique system identifier for record                        |
++----------------------------+---------+-------------------------------------------------------------+
+| ``data[].recordOid``       | String  | Client-assigned record OID                                 |
++----------------------------+---------+-------------------------------------------------------------+
+| ``data[].recordType``      | String  | Type of record                                             |
++----------------------------+---------+-------------------------------------------------------------+
+| ``data[].recordStatus``    | String  | User defined record status                                 |
++----------------------------+---------+-------------------------------------------------------------+
+| ``data[].subjectId``       | Number  | Mednet Subject ID                                          |
++----------------------------+---------+-------------------------------------------------------------+
+| ``data[].subjectOid``      | String  | Client-assigned subject OID                                |
++----------------------------+---------+-------------------------------------------------------------+
+| ``data[].subjectKey``      | String  | Protocol-assigned subject identifier                       |
++----------------------------+---------+-------------------------------------------------------------+
+| ``data[].visitId``         | Number  | Unique system identifier for the subject visit instance    |
++----------------------------+---------+-------------------------------------------------------------+
+| ``data[].keywords``        | Array   | All keywords currently associated with the record          |
++----------------------------+---------+-------------------------------------------------------------+
+| ``data[].recordData``      | Object  | Record data detail                                         |
++----------------------------+---------+-------------------------------------------------------------+
+| ``data[].deleted``         | Boolean | Record deleted flag                                        |
++----------------------------+---------+-------------------------------------------------------------+
+| ``data[].parentRecordId``  | Number  | Parent Record Id                                           |
++----------------------------+---------+-------------------------------------------------------------+
+| ``data[].dateCreated``     | String  | Date when this record was created                          |
++----------------------------+---------+-------------------------------------------------------------+
+| ``data[].dateModified``    | String  | Last date modified of this record                          |
++----------------------------+---------+-------------------------------------------------------------+
+
+POST Requests
+-------------
+
+Providing a ``studyKey`` and a request body adds a record to the iMednet database.
+The request body is an array. The contents of the body determine if the request
+will register a subject, update a scheduled record, or create a new record.
+
+**Request structure**
+
+.. code-block:: http
+
+   POST /api/v1/edc/studies/PHARMADEMO/records HTTP/1.1
+   x-email-notify: user@domain.com
+   Accept: application/json
+   Content-Type: application/json
+   Host: localhost:8080
+
+   [ ]
+
+**POST Request Identifiers**
+
++---------------------+--------------------------------------+-------------------------------------------+
+| Identifier          | Name                                 | Description                               |
++=====================+======================================+===========================================+
+| ``formKey``         | User defined form key                |                                          |
++---------------------+--------------------------------------+-------------------------------------------+
+| ``formId``          | System generated form identifier     |                                          |
++---------------------+--------------------------------------+-------------------------------------------+
+| ``siteName``        | User defined site name               |                                          |
++---------------------+--------------------------------------+-------------------------------------------+
+| ``siteId``          | System generated site identifier     |                                          |
++---------------------+--------------------------------------+-------------------------------------------+
+| ``subjectKey``      | Patient Display ID Full              |                                          |
++---------------------+--------------------------------------+-------------------------------------------+
+| ``subjectId``       | System generated subject identifier  |                                          |
++---------------------+--------------------------------------+-------------------------------------------+
+| ``subjectOid``      | User assigned subject OID            |                                          |
++---------------------+--------------------------------------+-------------------------------------------+
+| ``intervalName``    | User defined interval name           |                                          |
++---------------------+--------------------------------------+-------------------------------------------+
+| ``intervalId``      | System generated interval identifier |                                          |
++---------------------+--------------------------------------+-------------------------------------------+
+| ``recordId``        | System generated record identifier   |                                          |
++---------------------+--------------------------------------+-------------------------------------------+
+| ``recordOid``       | User defined record OID              |                                          |
++---------------------+--------------------------------------+-------------------------------------------+
+
+**Field Types**
+
+When making a POST request, use the correct type for any fields included in the
+``data`` object.
+
+Sample request body containing all valid field types:
+
+.. code-block:: json
+
+   [ {
+     "formKey" : "REG",
+     "siteName" : "Minneapolis",
+     "data" : {
+       "textField" : "Text data",
+       "dateField" : "2020-01-20",
+       "numberField" : 11,
+       "radioField" : "Yes",
+       "dropdownField" : "Always",
+       "memoField" : "Memo data",
+       "checkboxField" : true
+     }
+   } ]
+
+Valid field types:
+
++---------------------------+---------+-------------------------------+
+| Path                      | Type    | Description                   |
++===========================+=========+===============================+
+| ``[].formKey``            | String  | Form Key                      |
++---------------------------+---------+-------------------------------+
+| ``[].siteName``           | String  | Site Name                     |
++---------------------------+---------+-------------------------------+
+| ``[].data``               | Object  | Data for specific record      |
++---------------------------+---------+-------------------------------+
+| ``[].data.textField``     | String  | Text field                    |
++---------------------------+---------+-------------------------------+
+| ``[].data.dateField``     | String  | Date field                    |
++---------------------------+---------+-------------------------------+
+| ``[].data.numberField``   | Number  | Number field                  |
++---------------------------+---------+-------------------------------+
+| ``[].data.radioField``    | String  | Radio field                   |
++---------------------------+---------+-------------------------------+
+| ``[].data.dropdownField`` | String  | Dropdown field                |
++---------------------------+---------+-------------------------------+
+| ``[].data.memoField``     | String  | Memo field                    |
++---------------------------+---------+-------------------------------+
+| ``[].data.checkboxField`` | Boolean | Checkbox field                |
++---------------------------+---------+-------------------------------+
+
+Register Subject
+----------------
+
+Request body for registering a subject:
+
+.. code-block:: json
+
+   [ {
+     "formKey" : "REG",
+     "siteName" : "Minneapolis",
+     "data" : {
+       "textField" : "Text value"
+     }
+   } ]
+
+Request fields:
+
++-----------------------+---------+-------------------------------+
+| Path                  | Type    | Description                   |
++=======================+=========+===============================+
+| ``[].formKey``        | String  | Form Key                      |
++-----------------------+---------+-------------------------------+
+| ``[].siteName``       | String  | Site Name                     |
++-----------------------+---------+-------------------------------+
+| ``[].data``           | Object  | Data for specific record      |
++-----------------------+---------+-------------------------------+
+| ``[].data.textField`` | String  | Text field                    |
++-----------------------+---------+-------------------------------+
+
+Update a Scheduled Record
+-------------------------
+
+Request body for updating a scheduled record:
+
+.. code-block:: json
+
+   [ {
+     "formKey" : "REG",
+     "subjectKey" : "651-042",
+     "intervalName" : "Registration",
+     "data" : {
+       "textField" : "Text value"
+     }
+   } ]
+
+Request fields:
+
++-----------------------+---------+-------------------------------+
+| Path                  | Type    | Description                   |
++=======================+=========+===============================+
+| ``[].formKey``        | String  | Form Key                      |
++-----------------------+---------+-------------------------------+
+| ``[].subjectKey``     | String  | Subject Key                   |
++-----------------------+---------+-------------------------------+
+| ``[].intervalName``   | String  | Interval Name                 |
++-----------------------+---------+-------------------------------+
+| ``[].data``           | Object  | Data for specific record      |
++-----------------------+---------+-------------------------------+
+| ``[].data.textField`` | String  | Text field                    |
++-----------------------+---------+-------------------------------+
+
+Create a New Record
+-------------------
+
+Request body for creating a new record:
+
+.. code-block:: json
+
+   [ {
+     "formKey" : "REG",
+     "subjectKey" : "123-876",
+     "data" : {
+       "textField" : "Text value"
+     }
+   } ]
+
+Request fields:
+
++-----------------------+---------+-------------------------------+
+| Path                  | Type    | Description                   |
++=======================+=========+===============================+
+| ``[].formKey``        | String  | Form Key                      |
++-----------------------+---------+-------------------------------+
+| ``[].subjectKey``     | String  | Subject Key                   |
++-----------------------+---------+-------------------------------+
+| ``[].data``           | Object  | Data for specific record      |
++-----------------------+---------+-------------------------------+
+| ``[].data.textField`` | String  | Text field                    |
++-----------------------+---------+-------------------------------+
+
+Response body
+-------------
+
+The POST request returns a ``batchId`` and a ``state`` which can be used to check
+on the status of the record being added via ``GET`` requests to the jobs
+endpoint.
+
+.. code-block:: json
+
+   {
+     "jobId": "9663fe34-eec7-460a-a820-097f1eb2875e",
+     "batchId" : "c3q191e4-f894-72cd-a753-b37283eh0866",
+     "state": "created"
+   }
+
+`Portal docs <https://portal.prod.imednetapi.com/docs/records>`_

--- a/docs/endpoints/sites.rst
+++ b/docs/endpoints/sites.rst
@@ -1,0 +1,144 @@
+Sites Endpoint
+==============
+
+Given a ``studyKey``, fetch the set of sites. A site is a conduct resource that
+represents a single hospital, clinic, or other type of geographic entity which
+will contain subjects that participate in the study.
+
+Sites are related to subjects in that any site has one-to-many subjects.
+
+Accessing the index
+-------------------
+
+A ``GET`` request is used to access the index.
+
+.. code-block:: http
+
+   GET /api/v1/edc/studies/PHARMADEMO/sites?page=0&size=25&sort=siteId%2CASC \
+     &filter=siteId%3D%3D48 HTTP/1.1
+   Content-Type: application/json
+   Host: localhost:8080
+
+Path parameters
+---------------
+
+Path parameters are required.
+
+``/api/v1/edc/studies/{studyKey}/sites``
+
+:studyKey: StudyKey to retrieve list of sites that belong to particular study.
+
+Request parameters
+------------------
+
+Request parameters are optional. Default values are used unless specified.
+
+:page: Which index page to be returned. Default value is 0.
+:size: Items per page to be returned. Default value is 25. Maximum items
+       allowed per page is 500.
+:sort: Name of the property by which to sort the result set. To sort in a
+       particular direction add a comma to the property name and either
+       ``asc`` or ``desc``. To sort by multiple properties add additional sort
+       parameters. Default value is ``siteId,asc``.
+:filter: Optional filter search criteria. Must follow correct syntax. Refer to
+         :doc:`rest_api_reference` for details.
+
+Response body
+-------------
+
+Below is an example response payload.
+
+.. code-block:: json
+
+   {
+     "metadata" : {
+       "status" : "OK",
+       "method" : "GET",
+       "path" : "/api/v1/edc/studies/PHARMADEMO/sites",
+       "timestamp" : "2025-06-05 21:12:09",
+       "error" : { }
+     },
+     "pagination" : {
+       "currentPage" : 0,
+       "size" : 25,
+       "totalPages" : 1,
+       "totalElements" : 1,
+       "sort" : [ {
+         "property" : "siteId",
+         "direction" : "ASC"
+       } ]
+     },
+     "data" : [ {
+       "studyKey" : "PHARMADEMO",
+       "siteId" : 1,
+       "siteName" : "Mock Site 1",
+       "siteEnrollmentStatus" : "Enrollment Open",
+       "dateCreated" : "2025-06-05 21:12:09",
+       "dateModified" : "2025-06-05 21:12:10"
+     } ]
+   }
+
+Response fields
+---------------
+
+The table below describes each field in the response.
+
+.. list-table::
+   :header-rows: 1
+
+   * - Path
+     - Type
+     - Description
+   * - ``metadata.status``
+     - String
+     - HTTP status
+   * - ``metadata.method``
+     - String
+     - HTTP method
+   * - ``metadata.path``
+     - String
+     - Requested URI path
+   * - ``metadata.timestamp``
+     - String
+     - Timestamp when response was generated
+   * - ``metadata.error``
+     - Object
+     - Detail error message from request if error occur
+   * - ``pagination.currentPage``
+     - Number
+     - Current index page
+   * - ``pagination.size``
+     - Number
+     - Size per page
+   * - ``pagination.totalPages``
+     - Number
+     - Total pages return from search
+   * - ``pagination.totalElements``
+     - Number
+     - Total elements return from search
+   * - ``pagination.sort[].property``
+     - String
+     - Sort property
+   * - ``pagination.sort[].direction``
+     - String
+     - Sort direction
+   * - ``data[].studyKey``
+     - String
+     - Unique study key for a given study
+   * - ``data[].siteId``
+     - Number
+     - Unique site Id
+   * - ``data[].siteName``
+     - String
+     - Site name
+   * - ``data[].siteEnrollmentStatus``
+     - String
+     - Status of site enrollment
+   * - ``data[].dateCreated``
+     - String
+     - Date when this record was created
+   * - ``data[].dateModified``
+     - String
+     - Last date modified of this record
+
+`Portal docs <https://portal.prod.imednetapi.com/docs/sites>`_

--- a/docs/endpoints/studies.rst
+++ b/docs/endpoints/studies.rst
@@ -1,0 +1,137 @@
+Studies Endpoint
+================
+
+The ``/api/v1/edc/studies`` endpoint returns metadata for studies that the API
+key is authorized to access.
+
+Accessing the index
+-------------------
+
+Send a ``GET`` request to ``/api/v1/edc/studies``. Optional query parameters
+control pagination, sorting and filtering.
+
+Example::
+
+    GET /api/v1/edc/studies?page=0&size=25&sort=studyKey%2CASC \
+        &filter=studyKey%3D%3DPHARMADEMO HTTP/1.1
+    x-imn-security-key: my-security-key
+    x-api-key: my-api-token
+    Content-Type: application/json
+    Host: localhost:8080
+
+Request parameters
+------------------
+
+``page``
+    Index page to return. Defaults to ``0``.
+
+``size``
+    Items per page. Defaults to ``25`` with a maximum of ``500``.
+
+``sort``
+    Sort property and optional direction. Defaults to ``studyKey,asc``. Provide
+    multiple ``sort`` parameters to sort by several properties.
+
+``filter``
+    Optional filter expression. See :ref:`rest_api_reference` for syntax.
+
+Response body
+-------------
+
+.. code-block:: json
+
+    {
+      "metadata": {
+        "status": "OK",
+        "method": "GET",
+        "path": "/api/v1/edc/studies",
+        "timestamp": "2025-06-05 21:12:08",
+        "error": {}
+      },
+      "pagination": {
+        "currentPage": 0,
+        "size": 25,
+        "totalPages": 1,
+        "totalElements": 1,
+        "sort": [
+          {
+            "property": "studyKey",
+            "direction": "ASC"
+          }
+        ]
+      },
+      "data": [
+        {
+          "sponsorKey": "100",
+          "studyKey": "PHARMADEMO",
+          "studyId": 100,
+          "studyName": "iMednet Pharma Demonstration Study",
+          "studyDescription": "iMednet Demonstration Study v2 Created 05April2018 After A5 Release",
+          "studyType": "STUDY",
+          "dateCreated": "2025-06-05 21:12:08",
+          "dateModified": "2025-06-05 21:12:09"
+        }
+      ]
+    }
+
+Response fields
+---------------
+
+``metadata.status``
+    HTTP status.
+
+``metadata.method``
+    HTTP method.
+
+``metadata.path``
+    Requested URI path.
+
+``metadata.timestamp``
+    Timestamp when the response was generated.
+
+``metadata.error``
+    Error details if the request failed.
+
+``pagination.currentPage``
+    Current result page.
+
+``pagination.size``
+    Size per page.
+
+``pagination.totalPages``
+    Total pages returned.
+
+``pagination.totalElements``
+    Total elements returned.
+
+``pagination.sort[].property``
+    Sort property.
+
+``pagination.sort[].direction``
+    Sort direction.
+
+``data[].sponsorKey``
+    Sponsor key the study belongs to.
+
+``data[].studyKey``
+    Unique study key.
+
+``data[].studyId``
+    Mednet study ID.
+
+``data[].studyName``
+    Study name.
+
+``data[].studyDescription``
+    Study description.
+
+``data[].studyType``
+    Study type.
+
+``data[].dateCreated``
+    Record creation timestamp.
+
+``data[].dateModified``
+    Last modified timestamp.
+
+`Portal docs <https://portal.prod.imednetapi.com/docs/studies>`_

--- a/docs/endpoints/subjects.rst
+++ b/docs/endpoints/subjects.rst
@@ -1,0 +1,161 @@
+Subjects Endpoint
+=================
+
+Given a ``studyKey`` this endpoint returns all subjects for the study. A subject represents
+one participant and belongs to exactly one site. Each subject may have multiple records.
+
+Accessing the index
+-------------------
+
+Send a ``GET`` request to ``/api/v1/edc/studies/{studyKey}/subjects``.
+
+Example::
+
+   GET /api/v1/edc/studies/PHARMADEMO/subjects?page=0&size=25&sort=subjectId%2CASC&filter=subjectId%3D%3D370 HTTP/1.1
+   Content-Type: application/json
+   Host: localhost:8080
+
+Path parameters
+---------------
+
+``studyKey``
+  Study key to retrieve subjects for.
+
+Request parameters
+------------------
+
+``page``
+  Index page to return. Defaults to ``0``.
+
+``size``
+  Items per page. Defaults to ``25`` with a maximum of ``500``.
+
+``sort``
+  Sort property and direction separated by a comma. Defaults to ``subjectId,asc``.
+
+``filter``
+  Optional filter expression. See the :doc:`rest_api_reference` for syntax.
+
+Response body
+-------------
+
+Example payload::
+
+   {
+     "metadata": {
+       "status": "OK",
+       "method": "GET",
+       "path": "/api/v1/edc/studies/PHARMADEMO/subjects",
+       "timestamp": "2025-06-05 21:12:09",
+       "error": {}
+     },
+     "pagination": {
+       "currentPage": 0,
+       "size": 25,
+       "totalPages": 1,
+       "totalElements": 1,
+       "sort": [
+         {
+           "property": "subjectId",
+           "direction": "ASC"
+         }
+       ]
+     },
+     "data": [
+       {
+         "studyKey": "PHARMADEMO",
+         "subjectId": 1,
+         "subjectOid": "OID-1",
+         "subjectKey": "01-001",
+         "subjectStatus": "Enrolled",
+         "siteId": 128,
+         "siteName": "Chicago Hope Hospital",
+         "deleted": false,
+         "enrollmentStartDate": "2025-06-05 21:12:09",
+         "dateCreated": "2025-06-05 21:12:09",
+         "dateModified": "2025-06-05 21:12:10",
+         "keywords": [
+           {
+             "keywordName": "Data Entry Error",
+             "keywordKey": "DEE",
+             "keywordId": 15362,
+             "dateAdded": "2025-06-05 21:12:09"
+           }
+         ]
+       }
+     ]
+   }
+
+Response fields
+---------------
+
+``metadata.status`` (String)
+  HTTP status.
+
+``metadata.method`` (String)
+  HTTP method.
+
+``metadata.path`` (String)
+  Request path.
+
+``metadata.timestamp`` (String)
+  Timestamp when the response was generated.
+
+``metadata.error`` (Object)
+  Detailed error information when a request fails.
+
+``pagination.currentPage`` (Number)
+  Current index page.
+
+``pagination.size`` (Number)
+  Page size returned.
+
+``pagination.totalPages`` (Number)
+  Total pages in the result set.
+
+``pagination.totalElements`` (Number)
+  Total elements found.
+
+``pagination.sort[].property`` (String)
+  Sort property.
+
+``pagination.sort[].direction`` (String)
+  Sort direction.
+
+``data[].studyKey`` (String)
+  Unique study key for a given study.
+
+``data[].subjectId`` (Number)
+  Mednet subject ID.
+
+``data[].subjectOid`` (String)
+  Client assigned subject OID.
+
+``data[].subjectKey`` (String)
+  Protocol assigned subject identifier.
+
+``data[].subjectStatus`` (String)
+  Subject status.
+
+``data[].siteId`` (Number)
+  Mednet site ID.
+
+``data[].siteName`` (String)
+  Site name.
+
+``data[].enrollmentStartDate`` (String)
+  Enrollment start date.
+
+``data[].deleted`` (Boolean)
+  Subject deleted flag.
+
+``data[].dateCreated`` (String)
+  Date the subject was created.
+
+``data[].dateModified`` (String)
+  Last modification date.
+
+``data[].keywords`` (Array)
+  Keywords associated with the subject.
+
+`Portal docs <https://portal.prod.imednetapi.com/docs/subjects>`_

--- a/docs/endpoints/users.rst
+++ b/docs/endpoints/users.rst
@@ -1,0 +1,157 @@
+Users Endpoint
+==============
+
+Given a StudyKey, fetch the users.
+
+Accessing the index
+-------------------
+A ``GET`` request is used to access the index.
+
+Request structure
+-----------------
+
+.. code-block:: http
+
+   GET /api/v1/edc/studies/MOCK-STUDY/users?page=0&size=25&includeInactive=false&sort=login%2CASC HTTP/1.1
+   Content-Type: application/json
+   Host: localhost:8080
+
+Path parameters
+---------------
+Path parameters are required.
+
+``studyKey``
+  StudyKey to retrieve list of variables.
+
+Request parameters
+------------------
+Request parameters are optional. Default values are used unless specified.
+
+``page``
+  Which index page to be returned. Default value is ``0``.
+``size``
+  Items per page to be returned. Default value is ``25``. Maximum items allowed per page is ``500``.
+``sort``
+  Name of the property by which to sort the result set. To sort in a particular direction add a comma to the property name and either ``asc`` or ``desc``. To sort by multiple properties add additional sort parameters. Default value is ``login,asc``.
+``includeInactive``
+  Boolean flag whether to include inactive Users. Default value is ``false``.
+
+Response body
+-------------
+Below is an example response payload.
+
+.. code-block:: json
+
+   {
+     "metadata": {
+       "status": "OK",
+       "method": "GET",
+       "path": "/api/v1/edc/studies/MOCK-STUDY/users",
+       "timestamp": "2025-06-05 21:12:07",
+       "error": {}
+     },
+     "pagination": {
+       "currentPage": 0,
+       "size": 25,
+       "totalPages": 1,
+       "totalElements": 1,
+       "sort": [
+         {
+           "property": "login",
+           "direction": "ASC"
+         }
+       ]
+     },
+     "data": [
+       {
+         "userId": "685253e1-1a95-4352-a7b0-4c62d3807727",
+         "login": "wsmith1",
+         "firstName": "William",
+         "lastName": "Smith",
+         "email": "wsmith@mednet.com",
+         "userActiveInStudy": true,
+         "roles": [
+           {
+             "dateCreated": [2025, 6, 5, 21, 12, 7, 625000000],
+             "dateModified": [2025, 6, 5, 21, 12, 7, 625000000],
+             "roleId": "6ec2a32b-143c-43d3-b562-9d902a61f884",
+             "communityId": 1,
+             "name": "Role name 1",
+             "description": "Role description 1",
+             "level": 1,
+             "type": "Role type 1",
+             "inactive": false
+           },
+           {
+             "dateCreated": [2025, 6, 5, 21, 12, 7, 625000000],
+             "dateModified": [2025, 6, 5, 21, 12, 7, 625000000],
+             "roleId": "6ec2a32b-143c-43d3-b562-9d902a61f884",
+             "communityId": 2,
+             "name": "Role name 2",
+             "description": "Role description 2",
+             "level": 2,
+             "type": "Role type 2",
+             "inactive": false
+           }
+         ]
+       }
+     ]
+   }
+
+Response fields
+---------------
+
+``metadata.status``
+  String - HTTP status.
+``metadata.method``
+  String - HTTP method.
+``metadata.path``
+  String - Requested URI path.
+``metadata.timestamp``
+  String - Timestamp when response was generated.
+``metadata.error``
+  Object - Detail error message from request if error occur.
+``pagination.currentPage``
+  Number - Current index page.
+``pagination.size``
+  Number - Size per page.
+``pagination.totalPages``
+  Number - Total pages return from search.
+``pagination.totalElements``
+  Number - Total elements return from search.
+``pagination.sort[].property``
+  String - Sort property.
+``pagination.sort[].direction``
+  String - Sort direction.
+``data[].userId``
+  String - User ID.
+``data[].login``
+  String - Login.
+``data[].firstName``
+  String - First name.
+``data[].lastName``
+  String - Last name.
+``data[].email``
+  String - Email.
+``data[].userActiveInStudy``
+  Boolean - Boolean value for if the user is active in the study.
+``data[].roles[].dateCreated``
+  Array - Role date created.
+``data[].roles[].dateModified``
+  Array - Role date modified.
+``data[].roles[].roleId``
+  String - Role ID.
+``data[].roles[].communityId``
+  Number - Community ID associated with Role.
+``data[].roles[].name``
+  String - Role name.
+``data[].roles[].description``
+  String - Role description.
+``data[].roles[].level``
+  Number - Role level.
+``data[].roles[].type``
+  String - Role type.
+``data[].roles[].inactive``
+  Boolean - Inactive.
+
+`Portal docs <https://portal.prod.imednetapi.com/docs/users>`_

--- a/docs/endpoints/variables.rst
+++ b/docs/endpoints/variables.rst
@@ -1,0 +1,103 @@
+Variables Endpoint
+==================
+
+This endpoint retrieves the set of variables for a given study. Each variable
+represents a field on an electronic clinical case report form (eCRF). Records in
+the system contain responses for these variables within their ``recordData``
+sections.
+
+Accessing the index
+-------------------
+
+The list of variables is returned via a ``GET`` request.
+
+Request structure
+-----------------
+
+.. code-block:: http
+
+   GET /api/v1/edc/studies/PHARMADEMO/variables?page=0&size=25&sort=variableId%2CASC&
+       filter=variableId%3D%3D10299 HTTP/1.1
+   Content-Type: application/json
+   Host: localhost:8080
+
+Path parameters
+---------------
+
+``studyKey``
+    Study key used to retrieve the list of variables. This value is required.
+
+Request parameters
+------------------
+
+``page``
+    Index page to return. Defaults to ``0``.
+
+``size``
+    Number of items per page. Defaults to ``25`` and may not exceed ``500``.
+
+``sort``
+    Property name to sort by. Append ``asc`` or ``desc`` to specify direction.
+    Multiple ``sort`` parameters may be supplied. Defaults to ``formId,asc``.
+
+``filter``
+    Optional filter criteria. Must follow the API filter syntax.
+
+Example response
+----------------
+
+.. code-block:: json
+
+   {
+     "metadata": {
+       "status": "OK",
+       "method": "GET",
+       "path": "/api/v1/edc/studies/PHARMADEMO/variables",
+       "timestamp": "2025-06-05 21:12:08",
+       "error": {}
+     },
+     "pagination": {
+       "currentPage": 0,
+       "size": 25,
+       "totalPages": 1,
+       "totalElements": 1,
+       "sort": [
+         {
+           "property": "variableId",
+           "direction": "ASC"
+         }
+       ]
+     },
+     "data": [
+       {
+         "studyKey": "PHARMADEMO",
+         "variableId": 1,
+         "variableType": "RADIO",
+         "variableName": "Pain Level",
+         "sequence": 1,
+         "revision": 1,
+         "disabled": false,
+         "dateCreated": "2025-06-05 21:12:08",
+         "dateModified": "2025-06-05 21:12:09",
+         "formId": 108727,
+         "variableOid": "OID-1",
+         "deleted": false,
+         "formKey": "FORM_1",
+         "formName": "Pre-procedure screening",
+         "label": "Select patient pain level between 1 and 10",
+         "blinded": false
+       }
+     ]
+   }
+
+Response fields
+---------------
+
+``metadata``
+    Response metadata including HTTP status, method and timestamp.
+
+``pagination``
+    Information about the current page, page size, total pages and sort order.
+
+``data``
+    List of variables and their attributes for the specified study.

--- a/docs/endpoints/visits.rst
+++ b/docs/endpoints/visits.rst
@@ -1,0 +1,185 @@
+Visits Endpoint
+===============
+
+Given a ``studyKey``, fetch the set of visits for that study. A visit represents a single
+instance of an interval for a subject.
+
+Accessing the index
+-------------------
+
+A ``GET`` request is used to access the index.
+
+Request structure
+-----------------
+
+.. code-block:: http
+
+   GET /api/v1/edc/studies/PHARMADEMO/visits?page=0&size=25&sort=visitId%2CASC&filter=subjectKey%3D%3D270 HTTP/1.1
+   Content-Type: application/json
+   Host: localhost:8080
+
+Path parameters
+---------------
+
+Path parameters are required.
+
+.. list-table:: /api/v1/edc/studies/{studyKey}/visits
+   :header-rows: 1
+
+   * - Parameter
+     - Description
+   * - ``studyKey``
+     - StudyKey to retrieve list of visits
+
+Request parameters
+------------------
+
+Request parameters are optional. Default values are used unless specified.
+
+.. list-table::
+   :header-rows: 1
+
+   * - Parameter
+     - Description
+   * - ``page``
+     - Which index page to be returned. Default value is 0.
+   * - ``size``
+     - Items per page to be returned. Default value is 25. Maximum items allowed per page is 500
+   * - ``sort``
+     - Name of the property by which to sort the result set. To sort in a particular direction add a comma to the property name and either ``asc`` or ``desc``. To sort by multiple properties add additional sort parameters. Default value is ``visitId,asc``.
+   * - ``filter``
+     - Optional filter search criteria. Must follow correct syntax. Refer to filter section for details.
+
+Response body
+-------------
+
+Below is an example response payload.
+
+.. code-block:: json
+
+   {
+     "metadata" : {
+       "status" : "OK",
+       "method" : "GET",
+       "path" : "/api/v1/edc/studies/PHARMADEMO/visits",
+       "timestamp" : "2025-06-05 21:12:08",
+       "error" : { }
+     },
+     "pagination" : {
+       "currentPage" : 0,
+       "size" : 25,
+       "totalPages" : 1,
+       "totalElements" : 1,
+       "sort" : [ {
+         "property" : "visitId",
+         "direction" : "ASC"
+       } ]
+     },
+     "data" : [ {
+       "visitId" : 1,
+       "studyKey" : "PHARMADEMO",
+       "intervalId" : 13,
+       "intervalName" : "Day 15",
+       "subjectId" : 247,
+       "subjectKey" : "111-005",
+       "startDate" : "2025-06-05",
+       "endDate" : "2025-06-12",
+       "dueDate" : null,
+       "visitDate" : "2025-06-07",
+       "visitDateForm" : "Follow Up",
+       "deleted" : false,
+       "visitDateQuestion" : "AESEV",
+       "dateCreated" : "2025-06-05 21:12:08",
+       "dateModified" : "2025-06-05 21:12:08"
+     } ]
+   }
+
+Response fields
+---------------
+
+.. list-table::
+   :header-rows: 1
+
+   * - Path
+     - Type
+     - Description
+   * - ``metadata.status``
+     - String
+     - Http status
+   * - ``metadata.method``
+     - String
+     - Http method
+   * - ``metadata.path``
+     - String
+     - Requested URI path
+   * - ``metadata.timestamp``
+     - String
+     - Timestamp when response was generated
+   * - ``metadata.error``
+     - Object
+     - Detailed error message from request if an error occured
+   * - ``pagination.currentPage``
+     - Number
+     - Current index page
+   * - ``pagination.size``
+     - Number
+     - Size per page
+   * - ``pagination.totalPages``
+     - Number
+     - Total pages returned from search
+   * - ``pagination.totalElements``
+     - Number
+     - Total elements returned from search
+   * - ``pagination.sort[].property``
+     - String
+     - Sort property
+   * - ``pagination.sort[].direction``
+     - String
+     - Sort direction
+   * - ``data[].studyKey``
+     - String
+     - Unique study key for a given study
+   * - ``data[].subjectId``
+     - Number
+     - Mednet Subject ID
+   * - ``data[].subjectKey``
+     - String
+     - Protocol-assigned subject identifier
+   * - ``data[].visitId``
+     - Number
+     - Unique system identifier for the subject visit instance
+   * - ``data[].intervalId``
+     - Number
+     - Unique system indentifier for the related interval
+   * - ``data[].intervalName``
+     - String
+     - User defined identifier for the related interval
+   * - ``data[].startDate``
+     - String
+     - Subject visit Start Date defined in interval visit window
+   * - ``data[].dueDate``
+     - Null
+     - Subject visit Due Date defined in interval visit window
+   * - ``data[].endDate``
+     - String
+     - Subject visit End Date defined in interval visit window
+   * - ``data[].visitDate``
+     - String
+     - Subject visit Actual Date defined in interval visit window
+   * - ``data[].visitDateForm``
+     - String
+     - Actual Date Form defined in interval visit window
+   * - ``data[].deleted``
+     - Boolean
+     - Subject visit deleted flag
+   * - ``data[].visitDateQuestion``
+     - String
+     - User defined field identifier
+   * - ``data[].dateCreated``
+     - String
+     - Date when this visit was created
+   * - ``data[].dateModified``
+     - String
+     - Date when this visit was last modified
+
+`Portal docs <https://portal.prod.imednetapi.com/docs/visits>`_

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -8,6 +8,7 @@ Welcome to imednet-sdk's documentation!
    logging_and_tracing
    api_overview
    rest_api_reference
+   endpoints/index
    architecture
    schema_validation
    cli

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -7,6 +7,7 @@ Welcome to imednet-sdk's documentation!
 
    logging_and_tracing
    api_overview
+   rest_api_reference
    architecture
    schema_validation
    cli

--- a/docs/rest_api_reference.rst
+++ b/docs/rest_api_reference.rst
@@ -1,0 +1,138 @@
+Mednet EDC REST API Reference
+=============================
+
+This page summarizes the core behavior of the iMednet REST API. It expands upon
+:doc:`api_overview` and serves as a quick reference for request structure and
+filter syntax.
+
+Overview
+--------
+
+The API exposes clinical study data via JSON responses. Consumers typically use
+the API to export data to reporting tools, present it in external
+applications, or compile custom audit trails.
+
+Base URL
+--------
+
+``https://edc.prod.imednetapi.com`` is the production endpoint. Append an
+endpoint route such as ``/api/v1/edc/studies`` to access resources.
+
+Security
+--------
+
+Each request requires ``x-api-key`` and ``x-imn-security-key`` headers. Keys
+should never be shared publicly. Example using ``curl``::
+
+   curl -X GET https://edc.prod.imednetapi.com/api/v1/edc/studies/STUDYKEY/sites \
+     -H 'x-api-key: XXXXXXXX' \
+     -H 'x-imn-security-key: XXX-XXX-XX-XXXXXX' \
+     -H 'Content-Type: application/json'
+
+HTTP verbs
+----------
+
+``GET`` retrieves resources while ``POST`` is used to insert data.
+
+Status codes
+------------
+
+``200``
+  Request succeeded.
+
+``400``
+  Malformed request.
+
+``401``
+  Authentication failed.
+
+``403``
+  Authorization error such as an invalid ``studyKey``.
+
+``404``
+  Resource not found.
+
+``429``
+  Too many requests.
+
+``500``
+  Unknown server error.
+
+Filtering
+---------
+
+Endpoints accept a ``filter`` query string composed of key, operator and value
+segments. ``recordDataFilter`` targets dynamic question data within a record.
+
+Attributes
+~~~~~~~~~~
+
+Valid attributes vary per endpoint. Common examples include ``studyKey`` for
+studies, ``siteId`` and ``siteName`` for sites, ``formId`` and ``formKey`` for
+forms, and ``dateCreated`` or ``dateModified`` for most resources.
+
+Operators
+~~~~~~~~~
+
+``<``  less than
+
+``<=`` less than or equal to
+
+``>``  greater than
+
+``>=`` greater than or equal to
+
+``==`` equal
+
+``!=`` not equal
+
+``=~`` contains (for ``recordDataFilter``)
+
+Connectors
+~~~~~~~~~~
+
+``and`` or ``;``  logical AND
+
+``or``  or `,`     logical OR
+
+Dates
+~~~~~
+
+Dates are UTC timestamps. When filtering visits by ``startDate``,
+``endDate``, ``dueDate`` or ``visitDate`` use the ``YYYY-MM-DD`` format.
+
+Filter examples
+~~~~~~~~~~~~~~~
+
+``formId > 10``
+  Forms with an ID greater than 10.
+
+``formType == "SUBJECT"``
+  Subject related forms.
+
+``formId > 10;formType == "SUBJECT"``
+  Subject related forms with ID greater than 10.
+
+``dateCreated>2000-11-05T14:00:00Z``
+  Entities created after 5 November 2000 14:00 UTC.
+
+``visitDate<2019-03-19``
+  Visits occurring before 19 March 2019.
+
+recordDataFilter examples
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+``AESER==Serious``
+  Serious adverse events.
+
+``AESER==Serious;GENDER==Male``
+  Serious adverse events for male subjects.
+
+``AESER==bronch``
+  Adverse events containing ``bronch``.
+
+Notes
+~~~~~
+
+White space is not allowed between attribute, operator and value. Both ``filter``
+and ``recordDataFilter`` require unique attributes and are case sensitive.

--- a/docs/rest_api_reference.rst
+++ b/docs/rest_api_reference.rst
@@ -26,8 +26,26 @@ should never be shared publicly. Example using ``curl``::
 
    curl -X GET https://edc.prod.imednetapi.com/api/v1/edc/studies/STUDYKEY/sites \
      -H 'x-api-key: XXXXXXXX' \
-     -H 'x-imn-security-key: XXX-XXX-XX-XXXXXX' \
-     -H 'Content-Type: application/json'
+    -H 'x-imn-security-key: XXX-XXX-XX-XXXXXX' \
+    -H 'Content-Type: application/json'
+
+Headers
+-------
+
+``Accept``
+  Supported server response media type. Must be ``application/json``.
+
+``x-api-key``
+  Valid API key.
+
+``x-imn-security-key``
+  Valid security key.
+
+``Content-Type``
+  Supported request content type. Must be ``application/json``.
+
+The response includes a ``Content-Type`` header indicating the payload
+type. It will also be ``application/json``.
 
 HTTP verbs
 ----------
@@ -136,3 +154,53 @@ Notes
 
 White space is not allowed between attribute, operator and value. Both ``filter``
 and ``recordDataFilter`` require unique attributes and are case sensitive.
+
+Error responses
+---------------
+
+When a request fails, details are returned in the ``metadata`` section of the
+response body. Validation errors include the offending field and value.
+Example::
+
+   {
+     "metadata": {
+       "status": "BAD_REQUEST",
+       "path": "/api/v1/edc/studies",
+       "timestamp": "2018-10-18 05:46:29",
+       "error": {
+         "code": "1000",
+         "description": "Field raised validation errors",
+         "field": {
+           "attribute": "page",
+           "value": "XX"
+         }
+       }
+     }
+   }
+
+Error response fields
+~~~~~~~~~~~~~~~~~~~~~
+
+``code``
+  Error code
+
+``description``
+  Error description message
+
+``field.attribute``
+  Origination request attribute which caused the error
+
+``field.value``
+  The value of request attribute passed in the request
+
+Error codes
+~~~~~~~~~~~
+
+``1000``
+  Validation error. Request contain invalid value.
+
+``9000``
+  Unknown error. Please contact Mednet support for assistance.
+
+``9001``
+  Unauthorized error. Insufficient permission to retrieve data.


### PR DESCRIPTION
## Summary
- document the Mednet EDC REST API endpoints and filtering syntax
- include new page in docs index

## Testing
- `poetry run ruff check --fix .`
- `poetry run black --check .`
- `poetry run mypy imednet`
- `poetry run pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685050108980832c8622edbb06df0e42