### PR TITLE
Update HTTPX instrumentation docs

### DIFF
--- a/docs/imednet.core.rst
+++ b/docs/imednet.core.rst
@@ -34,14 +34,15 @@ request when you configure logging:
 
 If ``opentelemetry`` is installed, pass a tracer instance or rely on the global
 tracer provider. Each request is executed within a span and works with
-``opentelemetry-instrumentation-requests`` for automatic context propagation:
+``opentelemetry-instrumentation-httpx`` for automatic context propagation of the
+HTTPX requests used by the SDK:
 
 .. code-block:: python
 
     from opentelemetry import trace
-    from opentelemetry.instrumentation.requests import RequestsInstrumentor
+    from opentelemetry.instrumentation.httpx import HTTPXClientInstrumentor
 
-    RequestsInstrumentor().instrument()
+    HTTPXClientInstrumentor().instrument()
     tracer = trace.get_tracer("my-app")
     client = Client(api_key="...", security_key="...", tracer=tracer)
 .. automodule:: imednet.core.context

--- a/docs/logging_and_tracing.rst
+++ b/docs/logging_and_tracing.rst
@@ -7,17 +7,17 @@ call :func:`imednet.utils.configure_json_logging` in your application to apply t
 same format globally.
 
 If `opentelemetry` is installed, the client can record spans around each HTTP
-request. Installing ``opentelemetry-instrumentation-requests`` will automatically
-instrument the underlying HTTPX calls. You may also pass your own tracer to the
-client.
+request. Installing ``opentelemetry-instrumentation-httpx`` will automatically
+instrument the HTTPX requests used by the SDK. You may also pass your own
+tracer to the client.
 
 Example configuration::
 
    from opentelemetry import trace
-   from opentelemetry.instrumentation.requests import RequestsInstrumentor
+   from opentelemetry.instrumentation.httpx import HTTPXClientInstrumentor
    from imednet.core.client import Client
 
-   RequestsInstrumentor().instrument()
+   HTTPXClientInstrumentor().instrument()
    tracer = trace.get_tracer(__name__)
    client = Client(api_key="A", security_key="B", tracer=tracer)
 


### PR DESCRIPTION
## Summary
- document that the SDK should use `opentelemetry-instrumentation-httpx`
- use `HTTPXClientInstrumentor` in examples

## Testing
- `poetry run ruff check --fix .`
- `poetry run black --check .`
- `poetry run mypy imednet`
- `poetry run pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68506fd6eb78832cb72676c8c3ef5cc0