### PR TITLE
Add async schema validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,21 @@ schema.refresh(sdk.forms, sdk.variables, study_key)
 sdk.records.create(study_key, record_data, schema=schema)
 ```
 
+When using ``AsyncImednetSDK`` the same logic applies asynchronously. Record
+payloads can be validated before submission with
+``AsyncSchemaValidator.validate_batch``:
+
+```python
+from imednet.sdk import AsyncImednetSDK
+from imednet.validation.async_schema import AsyncSchemaValidator
+
+async def submit_records_async(records):
+    async with AsyncImednetSDK() as sdk:
+        validator = AsyncSchemaValidator(sdk)
+        await validator.validate_batch(study_key, records)
+        await sdk.records.async_create(study_key, records, schema=validator.schema)
+```
+
 ### Exporting records to CSV
 
 Install the optional pandas dependency and call

--- a/docs/schema_validation.rst
+++ b/docs/schema_validation.rst
@@ -26,4 +26,13 @@ The diagram below outlines the main steps.
        D --> H
        H --> I{validation passes?}
        I -- Yes --> J[submit to RecordsEndpoint]
-       I -- No --> K[raise ValidationError]
+   I -- No --> K[raise ValidationError]
+
+Record payloads can also be validated asynchronously. Use
+``AsyncSchemaValidator.validate_batch`` with ``AsyncImednetSDK`` before
+submitting records::
+
+    async with AsyncImednetSDK() as sdk:
+        validator = AsyncSchemaValidator(sdk)
+        await validator.validate_batch(study_key, records)
+        await sdk.records.async_create(study_key, records, schema=validator.schema)

--- a/imednet/validation/__init__.py
+++ b/imednet/validation/__init__.py
@@ -1,11 +1,10 @@
-from .schema import (
-    SchemaCache,
-    SchemaValidator,
-    validate_record_data,
-)
+from .async_schema import AsyncSchemaCache, AsyncSchemaValidator
+from .schema import SchemaCache, SchemaValidator, validate_record_data
 
 __all__ = [
     "SchemaCache",
     "SchemaValidator",
     "validate_record_data",
+    "AsyncSchemaCache",
+    "AsyncSchemaValidator",
 ]

--- a/imednet/validation/async_schema.py
+++ b/imednet/validation/async_schema.py
@@ -1,0 +1,67 @@
+"""Asynchronous schema validation utilities."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, Dict, Optional, cast
+
+from ..endpoints.forms import FormsEndpoint
+from ..endpoints.variables import VariablesEndpoint
+from ..models.variables import Variable
+
+if TYPE_CHECKING:
+    from ..sdk import AsyncImednetSDK
+from .schema import SchemaCache, validate_record_data
+
+
+class AsyncSchemaCache:
+    """Cache of variables by form key with asynchronous refresh."""
+
+    def __init__(self) -> None:
+        self._form_variables: Dict[str, Dict[str, Variable]] = {}
+        self._form_id_to_key: Dict[int, str] = {}
+
+    async def refresh(
+        self,
+        forms: FormsEndpoint,
+        variables: VariablesEndpoint,
+        study_key: Optional[str] = None,
+    ) -> None:
+        self._form_variables.clear()
+        self._form_id_to_key.clear()
+        for form in await forms.async_list(study_key=study_key):
+            self._form_id_to_key[form.form_id] = form.form_key
+            vars_for_form = await variables.async_list(study_key=study_key, formId=form.form_id)
+            self._form_variables[form.form_key] = {v.variable_name: v for v in vars_for_form}
+
+    def variables_for_form(self, form_key: str) -> Dict[str, Variable]:
+        return self._form_variables.get(form_key, {})
+
+    def form_key_from_id(self, form_id: int) -> Optional[str]:
+        return self._form_id_to_key.get(form_id)
+
+
+class AsyncSchemaValidator:
+    """Validate records asynchronously using variable metadata."""
+
+    def __init__(self, sdk: "AsyncImednetSDK") -> None:
+        self._sdk = sdk
+        self.schema = AsyncSchemaCache()
+
+    async def refresh(self, study_key: str) -> None:
+        self.schema._form_variables.clear()
+        self.schema._form_id_to_key.clear()
+        variables = await self._sdk.variables.async_list(study_key=study_key, refresh=True)
+        for var in variables:
+            self.schema._form_id_to_key[var.form_id] = var.form_key
+            self.schema._form_variables.setdefault(var.form_key, {})[var.variable_name] = var
+
+    async def validate_record(self, study_key: str, record: Dict[str, Any]) -> None:
+        form_key = record.get("formKey") or self.schema.form_key_from_id(record.get("formId", 0))
+        if form_key and not self.schema.variables_for_form(form_key):
+            await self.refresh(study_key)
+        if form_key:
+            validate_record_data(cast(SchemaCache, self.schema), form_key, record.get("data", {}))
+
+    async def validate_batch(self, study_key: str, records: list[Dict[str, Any]]) -> None:
+        for rec in records:
+            await self.validate_record(study_key, rec)

--- a/tests/unit/async/test_async_schema_validator.py
+++ b/tests/unit/async/test_async_schema_validator.py
@@ -1,0 +1,61 @@
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from imednet.core.exceptions import ValidationError
+from imednet.models.variables import Variable
+from imednet.validation.async_schema import AsyncSchemaValidator
+
+
+def _build_sdk(variable: Variable) -> MagicMock:
+    sdk = MagicMock()
+    sdk.variables.async_list = AsyncMock(return_value=[variable])
+    return sdk
+
+
+@pytest.mark.asyncio
+async def test_validate_record_unknown_variable() -> None:
+    var = Variable(variable_name="age", variable_type="integer", form_id=1, form_key="F1")
+    sdk = _build_sdk(var)
+    validator = AsyncSchemaValidator(sdk)
+
+    with pytest.raises(ValidationError):
+        await validator.validate_record("STUDY", {"formKey": "F1", "data": {"bad": 1}})
+
+    sdk.variables.async_list.assert_awaited_once_with(study_key="STUDY", refresh=True)
+
+
+@pytest.mark.asyncio
+async def test_validate_record_wrong_type() -> None:
+    var = Variable(variable_name="age", variable_type="integer", form_id=1, form_key="F1")
+    sdk = _build_sdk(var)
+    validator = AsyncSchemaValidator(sdk)
+
+    with pytest.raises(ValidationError):
+        await validator.validate_record("STUDY", {"formKey": "F1", "data": {"age": "x"}})
+
+    sdk.variables.async_list.assert_awaited_once_with(study_key="STUDY", refresh=True)
+
+
+@pytest.mark.asyncio
+async def test_refresh_called_when_form_not_cached() -> None:
+    var = Variable(variable_name="age", variable_type="integer", form_id=1, form_key="F1")
+    sdk = _build_sdk(var)
+    validator = AsyncSchemaValidator(sdk)
+    validator.refresh = AsyncMock(wraps=validator.refresh)  # type: ignore[assignment]
+
+    await validator.validate_record("STUDY", {"formKey": "F1", "data": {"age": 1}})
+
+    validator.refresh.assert_awaited_once_with("STUDY")
+    sdk.variables.async_list.assert_awaited_once_with(study_key="STUDY", refresh=True)
+
+
+@pytest.mark.asyncio
+async def test_validate_record_cached() -> None:
+    var = Variable(variable_name="age", variable_type="integer", form_id=1, form_key="F1")
+    sdk = _build_sdk(var)
+    validator = AsyncSchemaValidator(sdk)
+    validator.schema._form_variables["F1"] = {"age": var}
+
+    await validator.validate_record("STUDY", {"formKey": "F1", "data": {"age": 1}})
+
+    sdk.variables.async_list.assert_not_awaited()


### PR DESCRIPTION
## Summary
- add `AsyncSchemaValidator` and `AsyncSchemaCache`
- document async record validation in README and docs
- expose new classes from `imednet.validation`
- test async validation logic

## Testing
- `poetry run ruff check --fix .`
- `poetry run black --check .`
- `poetry run mypy imednet`
- `poetry run pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685072d34d58832c9d6c5e1969591892