### PR TITLE
Add fake data generators for additional models

### DIFF
--- a/docs/caching.rst
+++ b/docs/caching.rst
@@ -33,6 +33,10 @@ The cache maps each form key to a dictionary of variables and also tracks form
 IDs. ``SchemaValidator`` looks up the form key for a record and fetches metadata
 on demand if it has not been cached yet.
 
+For offline tests, ``imednet.testing.fake_data`` includes helpers to generate
+forms, variables and records. These objects can be used with
+``SchemaCache.refresh`` to validate payloads without hitting the API.
+
 Limitations
 -----------
 

--- a/docs/live_tests.md
+++ b/docs/live_tests.md
@@ -97,6 +97,13 @@ The `imednet.testing.fake_data` module offers helper functions for generating
 realistic payloads using `Faker`. These payloads match the REST API examples and
 can be parsed directly by the SDK models for offline testing.
 
+`fake_forms_for_cache` and `fake_variables_for_cache` create
+`Form` and `Variable` objects that can populate a
+`SchemaCache`. Patch `FormsEndpoint.list` and
+`VariablesEndpoint.list` in your tests to return these lists
+before calling `schema.refresh()`. Use `fake_record` with that
+cache to produce typed record payloads for validation.
+
 ## Expected Results
 
 All live tests should pass when run against a properly configured iMedNet environment. Each test

--- a/docs/schema_validation.rst
+++ b/docs/schema_validation.rst
@@ -36,3 +36,28 @@ submitting records::
         validator = AsyncSchemaValidator(sdk)
         await validator.validate_batch(study_key, records)
         await sdk.records.async_create(study_key, records, schema=validator.schema)
+
+Offline Example
+---------------
+
+``imednet.testing.fake_data`` provides helpers for generating form
+metadata and sample records without an API connection. Combine these
+functions with ``SchemaCache`` to validate payloads locally::
+
+    from types import SimpleNamespace
+    from imednet.testing import fake_data
+    from imednet.validation.schema import SchemaCache
+
+    forms = fake_data.fake_forms_for_cache(1, study_key="S")
+    variables = fake_data.fake_variables_for_cache(forms, vars_per_form=2,
+                                                   study_key="S")
+
+    forms_ep = SimpleNamespace(list=lambda **_: forms)
+    vars_ep = SimpleNamespace(list=lambda form_id=None, **__: [
+        v for v in variables if form_id is None or v.form_id == form_id
+    ])
+
+    schema = SchemaCache()
+    schema.refresh(forms_ep, vars_ep, study_key="S")
+
+    record = fake_data.fake_record(schema)

--- a/imednet/testing/fake_data.py
+++ b/imednet/testing/fake_data.py
@@ -156,10 +156,192 @@ def fake_record() -> Dict[str, Any]:
     }
 
 
+def fake_form() -> Dict[str, Any]:
+    """Return a fake form payload."""
+
+    return {
+        "studyKey": faker.bothify(text="??????"),
+        "formId": faker.random_int(min=1, max=10000),
+        "formKey": faker.lexify(text="????"),
+        "formName": faker.word().title(),
+        "formType": faker.random_element(["CRF", "Diary"]),
+        "revision": faker.random_int(min=1, max=10),
+        "embeddedLog": faker.boolean(),
+        "enforceOwnership": faker.boolean(),
+        "userAgreement": faker.boolean(),
+        "subjectRecordReport": faker.boolean(),
+        "unscheduledVisit": faker.boolean(),
+        "otherForms": faker.boolean(),
+        "eproForm": faker.boolean(),
+        "allowCopy": faker.boolean(),
+        "disabled": faker.boolean(),
+        "dateCreated": _timestamp(),
+        "dateModified": _timestamp(),
+    }
+
+
+def fake_variable() -> Dict[str, Any]:
+    """Return a fake variable payload."""
+
+    return {
+        "studyKey": faker.bothify(text="??????"),
+        "variableId": faker.random_int(min=1, max=10000),
+        "variableType": faker.random_element(["text", "integer", "date"]),
+        "variableName": faker.lexify(text="????"),
+        "sequence": faker.random_int(min=1, max=100),
+        "revision": faker.random_int(min=1, max=10),
+        "disabled": faker.boolean(),
+        "dateCreated": _timestamp(),
+        "dateModified": _timestamp(),
+        "formId": faker.random_int(min=1, max=10000),
+        "variableOid": faker.uuid4(),
+        "deleted": faker.boolean(),
+        "formKey": faker.lexify(text="????"),
+        "formName": faker.word().title(),
+        "label": faker.word().title(),
+        "blinded": faker.boolean(),
+    }
+
+
+def fake_visit() -> Dict[str, Any]:
+    """Return a fake visit payload."""
+
+    return {
+        "visitId": faker.random_int(min=1, max=10000),
+        "studyKey": faker.bothify(text="??????"),
+        "intervalId": faker.random_int(min=1, max=10000),
+        "intervalName": faker.word().title(),
+        "subjectId": faker.random_int(min=1, max=10000),
+        "subjectKey": f"{faker.random_int(100, 999)}-{faker.random_int(100, 999)}",
+        "startDate": _timestamp(),
+        "endDate": _timestamp(),
+        "dueDate": _timestamp(),
+        "visitDate": _timestamp(),
+        "visitDateForm": faker.word().title(),
+        "visitDateQuestion": faker.word(),
+        "deleted": False,
+        "dateCreated": _timestamp(),
+        "dateModified": _timestamp(),
+    }
+
+
+def fake_coding() -> Dict[str, Any]:
+    """Return a fake coding payload."""
+
+    return {
+        "studyKey": faker.bothify(text="??????"),
+        "siteName": faker.company(),
+        "siteId": faker.random_int(min=1, max=10000),
+        "subjectId": faker.random_int(min=1, max=10000),
+        "subjectKey": f"{faker.random_int(100, 999)}-{faker.random_int(100, 999)}",
+        "formId": faker.random_int(min=1, max=10000),
+        "formName": faker.word().title(),
+        "formKey": faker.lexify(text="????"),
+        "revision": faker.random_int(min=1, max=5),
+        "recordId": faker.random_int(min=1, max=10000),
+        "variable": faker.lexify(text="????"),
+        "value": faker.word(),
+        "codingId": faker.random_int(min=1, max=10000),
+        "code": faker.lexify(text="???"),
+        "codedBy": faker.user_name(),
+        "reason": faker.sentence(nb_words=3),
+        "dictionaryName": faker.word().title(),
+        "dictionaryVersion": str(faker.random_int(min=1, max=5)),
+        "dateCoded": _timestamp(),
+    }
+
+
+def fake_record_revision() -> Dict[str, Any]:
+    """Return a fake record revision payload."""
+
+    return {
+        "studyKey": faker.bothify(text="??????"),
+        "recordRevisionId": faker.random_int(min=1, max=10000),
+        "recordId": faker.random_int(min=1, max=10000),
+        "recordOid": faker.uuid4(),
+        "recordRevision": faker.random_int(min=1, max=10),
+        "dataRevision": faker.random_int(min=1, max=10),
+        "recordStatus": faker.random_element(["Record Incomplete", "Record Complete"]),
+        "subjectId": faker.random_int(min=1, max=10000),
+        "subjectOid": faker.uuid4(),
+        "subjectKey": f"{faker.random_int(100, 999)}-{faker.random_int(100, 999)}",
+        "siteId": faker.random_int(min=1, max=10000),
+        "formKey": faker.lexify(text="????"),
+        "intervalId": faker.random_int(min=1, max=10000),
+        "role": faker.word(),
+        "user": faker.user_name(),
+        "reasonForChange": faker.sentence(nb_words=3),
+        "deleted": False,
+        "dateCreated": _timestamp(),
+    }
+
+
+def fake_study() -> Dict[str, Any]:
+    """Return a fake study payload."""
+
+    return {
+        "sponsorKey": faker.lexify(text="????????"),
+        "studyKey": faker.bothify(text="??????"),
+        "studyId": faker.random_int(min=1, max=10000),
+        "studyName": faker.word().title(),
+        "studyDescription": faker.sentence(nb_words=3),
+        "studyType": faker.random_element(["Clinical", "Observational", "Registry"]),
+        "dateCreated": _timestamp(),
+        "dateModified": _timestamp(),
+    }
+
+
+def fake_job() -> Dict[str, Any]:
+    """Return a fake job payload."""
+
+    return {
+        "jobId": faker.uuid4(),
+        "batchId": faker.lexify(text="????????"),
+        "state": faker.random_element(["OPEN", "RUNNING", "COMPLETE"]),
+        "dateCreated": _timestamp(),
+        "dateStarted": _timestamp(),
+        "dateFinished": _timestamp(),
+    }
+
+
+def fake_user() -> Dict[str, Any]:
+    """Return a fake user payload."""
+
+    return {
+        "userId": faker.uuid4(),
+        "login": faker.user_name(),
+        "firstName": faker.first_name(),
+        "lastName": faker.last_name(),
+        "email": faker.email(),
+        "userActiveInStudy": faker.boolean(),
+        "roles": [
+            {
+                "dateCreated": _timestamp(),
+                "dateModified": _timestamp(),
+                "roleId": faker.lexify(text="????"),
+                "communityId": faker.random_int(min=1, max=10000),
+                "name": faker.word().title(),
+                "description": faker.sentence(nb_words=3),
+                "level": faker.random_int(min=1, max=5),
+                "type": faker.word(),
+                "inactive": faker.boolean(),
+            }
+        ],
+    }
+
+
 __all__ = [
     "fake_subject",
     "fake_site",
     "fake_interval",
     "fake_query",
     "fake_record",
+    "fake_form",
+    "fake_variable",
+    "fake_visit",
+    "fake_coding",
+    "fake_record_revision",
+    "fake_study",
+    "fake_job",
+    "fake_user",
 ]

--- a/tests/utils/test_fake_data.py
+++ b/tests/utils/test_fake_data.py
@@ -1,5 +1,19 @@
 import imednet.testing.fake_data as fake_data
-from imednet.models import Interval, Query, Record, Site, Subject
+from imednet.models import (
+    Coding,
+    Form,
+    Interval,
+    Job,
+    Query,
+    Record,
+    RecordRevision,
+    Site,
+    Study,
+    Subject,
+    User,
+    Variable,
+    Visit,
+)
 
 
 def test_fake_subject_parses() -> None:
@@ -30,3 +44,51 @@ def test_fake_record_parses() -> None:
     data = fake_data.fake_record()
     obj = Record.from_json(data)
     assert isinstance(obj, Record)
+
+
+def test_fake_form_parses() -> None:
+    data = fake_data.fake_form()
+    obj = Form.from_json(data)
+    assert isinstance(obj, Form)
+
+
+def test_fake_variable_parses() -> None:
+    data = fake_data.fake_variable()
+    obj = Variable.from_json(data)
+    assert isinstance(obj, Variable)
+
+
+def test_fake_visit_parses() -> None:
+    data = fake_data.fake_visit()
+    obj = Visit.from_json(data)
+    assert isinstance(obj, Visit)
+
+
+def test_fake_coding_parses() -> None:
+    data = fake_data.fake_coding()
+    obj = Coding.from_json(data)
+    assert isinstance(obj, Coding)
+
+
+def test_fake_record_revision_parses() -> None:
+    data = fake_data.fake_record_revision()
+    obj = RecordRevision.from_json(data)
+    assert isinstance(obj, RecordRevision)
+
+
+def test_fake_study_parses() -> None:
+    data = fake_data.fake_study()
+    obj = Study.model_validate(data)
+    assert isinstance(obj, Study)
+
+
+def test_fake_job_parses() -> None:
+    data = fake_data.fake_job()
+    obj = Job.from_json(data)
+    assert isinstance(obj, Job)
+
+
+def test_fake_user_parses() -> None:
+    data = fake_data.fake_user()
+    obj = User.from_json(data)
+    assert isinstance(obj, User)

--- a/tests/utils/test_fake_data.py
+++ b/tests/utils/test_fake_data.py
@@ -1,3 +1,6 @@
+from types import SimpleNamespace
+from typing import Any, cast
+
 import imednet.testing.fake_data as fake_data
 from imednet.models import (
     Coding,
@@ -14,6 +17,7 @@ from imednet.models import (
     Variable,
     Visit,
 )
+from imednet.validation.schema import SchemaCache, validate_record_data
 
 
 def test_fake_subject_parses() -> None:
@@ -44,6 +48,19 @@ def test_fake_record_parses() -> None:
     data = fake_data.fake_record()
     obj = Record.from_json(data)
     assert isinstance(obj, Record)
+
+
+def test_fake_record_with_schema() -> None:
+    cache = SchemaCache()
+    var = Variable(variable_name="age", variable_type="integer", form_id=1, form_key="F1")
+    object.__setattr__(var, "required", True)
+    cache._form_variables = {"F1": {"age": var}}
+    cache._form_id_to_key = {1: "F1"}
+
+    data = fake_data.fake_record(cache)
+    obj = Record.from_json(data)
+    assert obj.form_key == "F1"
+    assert isinstance(obj.record_data.get("age"), int)
 
 
 def test_fake_form_parses() -> None:
@@ -92,3 +109,66 @@ def test_fake_user_parses() -> None:
     data = fake_data.fake_user()
     obj = User.from_json(data)
     assert isinstance(obj, User)
+
+
+def test_fake_forms_for_cache_returns_forms() -> None:
+    forms = fake_data.fake_forms_for_cache(2, study_key="S")
+    assert len(forms) == 2
+    assert all(isinstance(f, Form) for f in forms)
+    assert {f.study_key for f in forms} == {"S"}
+
+
+def test_fake_variables_for_cache_and_schema_refresh() -> None:
+    forms = fake_data.fake_forms_for_cache(1)
+    variables = fake_data.fake_variables_for_cache(forms, vars_per_form=1)
+
+    forms_ep = SimpleNamespace(list=lambda **_: forms)
+
+    def list_vars(*_, form_id=None, **__):
+        return [v for v in variables if form_id is None or v.form_id == form_id]
+
+    vars_ep = SimpleNamespace(list=list_vars)
+
+    cache = SchemaCache()
+    cache.refresh(cast(Any, forms_ep), cast(Any, vars_ep), study_key="X")
+
+    form = forms[0]
+    var = variables[0]
+
+    assert cache.form_key_from_id(form.form_id) == form.form_key
+    assert cache.variables_for_form(form.form_key)[var.variable_name] is var
+
+
+def test_fake_forms_for_cache_from_json() -> None:
+    forms = fake_data.fake_forms_for_cache(2)
+    for form in forms:
+        parsed = Form.from_json(form.model_dump(by_alias=True))
+        assert isinstance(parsed, Form)
+
+
+def test_fake_variables_for_cache_from_json() -> None:
+    forms = fake_data.fake_forms_for_cache(1)
+    variables = fake_data.fake_variables_for_cache(forms, vars_per_form=2)
+    for var in variables:
+        parsed = Variable.from_json(var.model_dump(by_alias=True))
+        assert isinstance(parsed, Variable)
+
+
+def test_validate_record_data_with_cached_schema() -> None:
+    forms = fake_data.fake_forms_for_cache(1)
+    variables = fake_data.fake_variables_for_cache(forms, vars_per_form=1)
+    variables[0].variable_type = "integer"
+
+    forms_ep = SimpleNamespace(list=lambda **_: forms)
+
+    def list_vars(*_, form_id=None, **__):
+        return [v for v in variables if form_id is None or v.form_id == form_id]
+
+    vars_ep = SimpleNamespace(list=list_vars)
+
+    cache = SchemaCache()
+    cache.refresh(cast(Any, forms_ep), cast(Any, vars_ep), study_key="X")
+
+    record_data = fake_data.fake_record(cache)
+
+    validate_record_data(cache, record_data["formKey"], record_data["recordData"])  # type: ignore[arg-type]

--- a/tests/workflows/conftest.py
+++ b/tests/workflows/conftest.py
@@ -1,0 +1,23 @@
+import types
+
+import pytest
+from imednet.testing import fake_data
+from imednet.validation.schema import SchemaCache
+
+
+@pytest.fixture
+def schema() -> SchemaCache:
+    forms = fake_data.fake_forms_for_cache(1, study_key="S")
+    variables = fake_data.fake_variables_for_cache(forms, vars_per_form=1, study_key="S")
+    forms_ep = types.SimpleNamespace(list=lambda **_: forms)
+
+    def list_vars(*_, form_id=None, **__):
+        return [v for v in variables if form_id is None or v.form_id == form_id]
+
+    vars_ep = types.SimpleNamespace(list=list_vars)
+
+    cache = SchemaCache()
+    from typing import Any, cast
+
+    cache.refresh(cast(Any, forms_ep), cast(Any, vars_ep), study_key="S")
+    return cache

--- a/tests/workflows/test_data_extraction.py
+++ b/tests/workflows/test_data_extraction.py
@@ -1,0 +1,79 @@
+from unittest.mock import MagicMock
+
+from imednet.models.record_revisions import RecordRevision
+from imednet.models.records import Record
+from imednet.models.subjects import Subject
+from imednet.models.visits import Visit
+from imednet.testing import fake_data
+from imednet.workflows.data_extraction import DataExtractionWorkflow
+
+
+def test_extract_records_by_criteria_filters_subject_and_visit(schema) -> None:
+    sdk = MagicMock()
+    s1 = Subject.from_json(fake_data.fake_subject())
+    s2 = Subject.from_json(fake_data.fake_subject())
+    s1.subject_key = "S1"
+    s2.subject_key = "S2"
+    sdk.subjects.list.return_value = [s1, s2]
+
+    v1 = Visit.from_json(fake_data.fake_visit())
+    v2 = Visit.from_json(fake_data.fake_visit())
+    v1.subject_key = "S1"
+    v1.visit_id = 1
+    v2.subject_key = "S2"
+    v2.visit_id = 2
+    sdk.visits.list.return_value = [v1, v2]
+
+    r1 = Record.from_json(fake_data.fake_record(schema))
+    r2 = Record.from_json(fake_data.fake_record(schema))
+    r3 = Record.from_json(fake_data.fake_record(schema))
+    r1.subject_key = "S1"
+    r1.visit_id = 1
+    r1.record_id = 1
+    r2.subject_key = "S2"
+    r2.visit_id = 2
+    r2.record_id = 2
+    r3.subject_key = "S1"
+    r3.visit_id = 99
+    r3.record_id = 3
+    sdk.records.list.return_value = [r1, r2, r3]
+
+    wf = DataExtractionWorkflow(sdk)
+    result = wf.extract_records_by_criteria(
+        "STUDY",
+        subject_filter={"status": "active"},
+        visit_filter={"visit_id": 1},
+    )
+
+    sdk.subjects.list.assert_called_once_with("STUDY", status="active")
+    assert sdk.subjects.list.call_args.kwargs == {"status": "active"}
+    sdk.visits.list.assert_called_once_with("STUDY", visit_id=1)
+    assert sdk.visits.list.call_args.kwargs == {"visit_id": 1}
+    sdk.records.list.assert_called_once_with(study_key="STUDY", record_data_filter=None)
+    assert sdk.records.list.call_args.kwargs == {"study_key": "STUDY", "record_data_filter": None}
+
+    assert [r.record_id for r in result] == [1, 2]
+
+
+def test_extract_audit_trail_builds_filters_and_dates() -> None:
+    sdk = MagicMock()
+    revision = RecordRevision.from_json(fake_data.fake_record_revision())
+    sdk.record_revisions.list.return_value = [revision]
+
+    wf = DataExtractionWorkflow(sdk)
+    result = wf.extract_audit_trail(
+        "STUDY",
+        start_date="2021-01-01",
+        end_date="2021-01-02",
+        user_filter={"role": "data"},
+        status="open",
+    )
+
+    sdk.record_revisions.list.assert_called_once_with(
+        "STUDY",
+        role="data",
+        status="open",
+        start_date="2021-01-01",
+        end_date="2021-01-02",
+    )
+    assert result == [revision]

--- a/tests/workflows/test_query_management.py
+++ b/tests/workflows/test_query_management.py
@@ -1,0 +1,92 @@
+from unittest.mock import MagicMock
+
+from imednet.models.queries import Query, QueryComment
+from imednet.models.subjects import Subject
+from imednet.testing import fake_data
+from imednet.workflows.query_management import QueryManagementWorkflow
+
+
+def make_query(sequence_closed: list[tuple[int, bool]]) -> Query:
+    comments = [QueryComment(sequence=seq, closed=closed) for seq, closed in sequence_closed]
+    return Query(query_comments=comments)
+
+
+def test_get_open_queries_filters_latest_comment() -> None:
+    sdk = MagicMock()
+    query_closed = make_query([(1, False), (2, True)])
+    query_open = make_query([(1, False)])
+    query_unknown = make_query([])
+    sdk.queries.list.return_value = [query_closed, query_open, query_unknown]
+
+    wf = QueryManagementWorkflow(sdk)
+    result = wf.get_open_queries("STUDY", additional_filter={"state": "new"})
+
+    sdk.queries.list.assert_called_once_with("STUDY", state="new")
+    assert sdk.queries.list.call_args.kwargs == {"state": "new"}
+    assert result == [query_open]
+
+
+def test_get_queries_for_subject_builds_combined_filter() -> None:
+    sdk = MagicMock()
+    wf = QueryManagementWorkflow(sdk)
+    wf.get_queries_for_subject("STUDY", "SUBJ1", additional_filter={"type": "x"})
+
+    sdk.queries.list.assert_called_once_with("STUDY", subject_key="SUBJ1", type="x")
+    assert sdk.queries.list.call_args.kwargs == {"subject_key": "SUBJ1", "type": "x"}
+
+
+def test_get_query_state_counts_aggregates_states() -> None:
+    sdk = MagicMock()
+    open_query = make_query([(1, False)])
+    closed_query = make_query([(1, True)])
+    unknown_query = make_query([])
+    sdk.queries.list.return_value = [open_query, closed_query, unknown_query]
+
+    wf = QueryManagementWorkflow(sdk)
+    counts = wf.get_query_state_counts("STUDY")
+
+    sdk.queries.list.assert_called_once_with("STUDY")
+    assert sdk.queries.list.call_args.kwargs == {}
+    assert counts == {"open": 1, "closed": 1, "unknown": 1}
+
+
+def test_get_queries_by_site_filters_using_subjects() -> None:
+    sdk = MagicMock()
+    s1 = Subject.from_json(fake_data.fake_subject())
+    s2 = Subject.from_json(fake_data.fake_subject())
+    s1.subject_key = "S1"
+    s2.subject_key = "S2"
+    sdk.subjects.list.return_value = [s1, s2]
+    wf = QueryManagementWorkflow(sdk)
+
+    wf.get_queries_by_site("STUDY", "SITE", additional_filter={"state": "open"})
+
+    sdk.subjects.list.assert_called_once_with("STUDY", site_name="SITE")
+    sdk.queries.list.assert_called_once_with("STUDY", subject_key=["S1", "S2"], state="open")
+    assert sdk.queries.list.call_args.kwargs == {"subject_key": ["S1", "S2"], "state": "open"}
+
+
+def test_get_queries_by_site_returns_empty_if_no_subjects() -> None:
+    sdk = MagicMock()
+    sdk.subjects.list.return_value = []
+    wf = QueryManagementWorkflow(sdk)
+
+    result = wf.get_queries_by_site("STUDY", "SITE")
+
+    sdk.subjects.list.assert_called_once_with("STUDY", site_name="SITE")
+    sdk.queries.list.assert_not_called()
+    assert result == []
+
+
+def test_get_queries_by_site_with_space_in_name() -> None:
+    sdk = MagicMock()
+    s = Subject.from_json(fake_data.fake_subject())
+    s.subject_key = "S1"
+    sdk.subjects.list.return_value = [s]
+    wf = QueryManagementWorkflow(sdk)
+
+    wf.get_queries_by_site("STUDY", "Mock Site")
+
+    sdk.subjects.list.assert_called_once_with("STUDY", site_name="Mock Site")
+    sdk.queries.list.assert_called_once_with("STUDY", subject_key=["S1"])
+    assert sdk.queries.list.call_args.kwargs == {"subject_key": ["S1"]}

--- a/tests/workflows/test_record_update.py
+++ b/tests/workflows/test_record_update.py
@@ -1,0 +1,64 @@
+import types
+from unittest.mock import MagicMock
+
+import pytest
+from imednet.core.exceptions import ValidationError
+from imednet.models.jobs import Job
+from imednet.models.variables import Variable
+from imednet.testing import fake_data
+from imednet.validation.schema import SchemaCache
+from imednet.workflows.record_update import RecordUpdateWorkflow
+
+
+def _build_schema() -> tuple[SchemaCache, Variable]:
+    forms = fake_data.fake_forms_for_cache(1, study_key="S")
+    variables = fake_data.fake_variables_for_cache(forms, vars_per_form=1, study_key="S")
+    var = variables[0]
+    object.__setattr__(var, "required", True)
+    var.variable_type = "integer"
+    forms_ep = types.SimpleNamespace(list=lambda **_: forms)
+
+    def list_vars(*_, form_id=None, **__):
+        return [v for v in variables if form_id is None or v.form_id == form_id]
+
+    vars_ep = types.SimpleNamespace(list=list_vars)
+    from typing import Any, cast
+
+    cache = SchemaCache()
+    cache.refresh(cast(Any, forms_ep), cast(Any, vars_ep), study_key="S")
+    return cache, var
+
+
+def test_create_or_update_records_no_wait(schema: SchemaCache) -> None:
+    sdk = MagicMock()
+    job = Job(batch_id="1", state="PROCESSING")
+    sdk.records.create.return_value = job
+
+    wf = RecordUpdateWorkflow(sdk)
+    wf._validator.schema = schema
+    wf._schema = schema
+    record = fake_data.fake_record(schema)
+    result = wf.create_or_update_records("S", [record])
+
+    sdk.records.create.assert_called_once_with("S", [record], schema=schema)
+    assert result == job
+
+
+def test_create_or_update_records_validation() -> None:
+    schema, var = _build_schema()
+    sdk = MagicMock()
+    wf = RecordUpdateWorkflow(sdk)
+    wf._validator.schema = schema
+    wf._schema = schema
+
+    with pytest.raises(ValidationError):
+        wf.create_or_update_records("S", [{"formKey": var.form_key, "data": {}}])
+    sdk.records.create.assert_not_called()
+
+    sdk.records.create.return_value = Job(batch_id="1", state="PROCESSING")
+    wf.create_or_update_records("S", [{"formKey": var.form_key, "data": {var.variable_name: 5}}])
+    sdk.records.create.assert_called_once_with(
+        "S",
+        [{"formKey": var.form_key, "data": {var.variable_name: 5}}],
+        schema=schema,
+    )

--- a/tests/workflows/test_register_subjects.py
+++ b/tests/workflows/test_register_subjects.py
@@ -1,0 +1,24 @@
+from unittest.mock import MagicMock
+
+from imednet.models.jobs import Job
+from imednet.models.records import RegisterSubjectRequest
+from imednet.testing import fake_data
+from imednet.workflows.register_subjects import RegisterSubjectsWorkflow
+
+
+def test_register_subjects_passes_records_correctly(schema) -> None:
+    sdk = MagicMock()
+    job = Job(batch_id="1", state="PROCESSING")
+    sdk.records.create.return_value = job
+    wf = RegisterSubjectsWorkflow(sdk)
+    rec = fake_data.fake_record(schema)
+    req = RegisterSubjectRequest(form_key=rec["formKey"], site_name="SITE", data=rec["recordData"])
+
+    result = wf.register_subjects("STUDY", [req], email_notify="test@example.com")
+
+    sdk.records.create.assert_called_once_with(
+        study_key="STUDY",
+        records_data=[req.model_dump(by_alias=True)],
+        email_notify="test@example.com",
+    )
+    assert result == job

--- a/tests/workflows/test_subject_data.py
+++ b/tests/workflows/test_subject_data.py
@@ -1,0 +1,45 @@
+from unittest.mock import MagicMock
+
+from imednet.models.queries import Query
+from imednet.models.records import Record
+from imednet.models.subjects import Subject
+from imednet.models.visits import Visit
+from imednet.testing import fake_data
+from imednet.workflows.subject_data import SubjectDataWorkflow
+
+
+def test_get_all_subject_data_aggregates_across_endpoints(schema) -> None:
+    sdk = MagicMock()
+    subject = Subject.from_json(fake_data.fake_subject())
+    visit = Visit.from_json(fake_data.fake_visit())
+    record_dict = fake_data.fake_record(schema)
+    record = Record.from_json(record_dict)
+    query = Query.from_json(fake_data.fake_query())
+
+    subject.subject_key = "S1"
+    visit.subject_key = "S1"
+    visit.visit_id = 1
+    record.subject_key = "S1"
+    record.visit_id = 1
+
+    sdk.subjects.list.return_value = [subject]
+    sdk.visits.list.return_value = [visit]
+    sdk.records.list.return_value = [record]
+    sdk.queries.list.return_value = [query]
+
+    wf = SubjectDataWorkflow(sdk)
+    result = wf.get_all_subject_data("STUDY", "S1")
+
+    sdk.subjects.list.assert_called_once_with("STUDY", subject_key="S1")
+    assert sdk.subjects.list.call_args.kwargs == {"subject_key": "S1"}
+    sdk.visits.list.assert_called_once_with("STUDY", subject_key="S1")
+    assert sdk.visits.list.call_args.kwargs == {"subject_key": "S1"}
+    sdk.records.list.assert_called_once_with("STUDY", subject_key="S1")
+    assert sdk.records.list.call_args.kwargs == {"subject_key": "S1"}
+    sdk.queries.list.assert_called_once_with("STUDY", subject_key="S1")
+    assert sdk.queries.list.call_args.kwargs == {"subject_key": "S1"}
+
+    assert result.subject_details == subject
+    assert result.visits == [visit]
+    assert result.records == [record]
+    assert result.queries == [query]


### PR DESCRIPTION
## Summary
- expand fake data helpers with more model payloads
- test that each helper can instantiate its corresponding model

## Testing
- `poetry run ruff check --fix .`
- `poetry run black --check .`
- `poetry run mypy imednet`
- `poetry run pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68507e2546d8832cab674173214bab6e