### PR TITLE
Add workflow tests with fake data

### DIFF
--- a/tests/workflows/conftest.py
+++ b/tests/workflows/conftest.py
@@ -1,0 +1,23 @@
+import types
+
+import pytest
+from imednet.testing import fake_data
+from imednet.validation.schema import SchemaCache
+
+
+@pytest.fixture
+def schema() -> SchemaCache:
+    forms = fake_data.fake_forms_for_cache(1, study_key="S")
+    variables = fake_data.fake_variables_for_cache(forms, vars_per_form=1, study_key="S")
+    forms_ep = types.SimpleNamespace(list=lambda **_: forms)
+
+    def list_vars(*_, form_id=None, **__):
+        return [v for v in variables if form_id is None or v.form_id == form_id]
+
+    vars_ep = types.SimpleNamespace(list=list_vars)
+
+    cache = SchemaCache()
+    from typing import Any, cast
+
+    cache.refresh(cast(Any, forms_ep), cast(Any, vars_ep), study_key="S")
+    return cache

--- a/tests/workflows/test_data_extraction.py
+++ b/tests/workflows/test_data_extraction.py
@@ -1,0 +1,79 @@
+from unittest.mock import MagicMock
+
+from imednet.models.record_revisions import RecordRevision
+from imednet.models.records import Record
+from imednet.models.subjects import Subject
+from imednet.models.visits import Visit
+from imednet.testing import fake_data
+from imednet.workflows.data_extraction import DataExtractionWorkflow
+
+
+def test_extract_records_by_criteria_filters_subject_and_visit(schema) -> None:
+    sdk = MagicMock()
+    s1 = Subject.from_json(fake_data.fake_subject())
+    s2 = Subject.from_json(fake_data.fake_subject())
+    s1.subject_key = "S1"
+    s2.subject_key = "S2"
+    sdk.subjects.list.return_value = [s1, s2]
+
+    v1 = Visit.from_json(fake_data.fake_visit())
+    v2 = Visit.from_json(fake_data.fake_visit())
+    v1.subject_key = "S1"
+    v1.visit_id = 1
+    v2.subject_key = "S2"
+    v2.visit_id = 2
+    sdk.visits.list.return_value = [v1, v2]
+
+    r1 = Record.from_json(fake_data.fake_record(schema))
+    r2 = Record.from_json(fake_data.fake_record(schema))
+    r3 = Record.from_json(fake_data.fake_record(schema))
+    r1.subject_key = "S1"
+    r1.visit_id = 1
+    r1.record_id = 1
+    r2.subject_key = "S2"
+    r2.visit_id = 2
+    r2.record_id = 2
+    r3.subject_key = "S1"
+    r3.visit_id = 99
+    r3.record_id = 3
+    sdk.records.list.return_value = [r1, r2, r3]
+
+    wf = DataExtractionWorkflow(sdk)
+    result = wf.extract_records_by_criteria(
+        "STUDY",
+        subject_filter={"status": "active"},
+        visit_filter={"visit_id": 1},
+    )
+
+    sdk.subjects.list.assert_called_once_with("STUDY", status="active")
+    assert sdk.subjects.list.call_args.kwargs == {"status": "active"}
+    sdk.visits.list.assert_called_once_with("STUDY", visit_id=1)
+    assert sdk.visits.list.call_args.kwargs == {"visit_id": 1}
+    sdk.records.list.assert_called_once_with(study_key="STUDY", record_data_filter=None)
+    assert sdk.records.list.call_args.kwargs == {"study_key": "STUDY", "record_data_filter": None}
+
+    assert [r.record_id for r in result] == [1, 2]
+
+
+def test_extract_audit_trail_builds_filters_and_dates() -> None:
+    sdk = MagicMock()
+    revision = RecordRevision.from_json(fake_data.fake_record_revision())
+    sdk.record_revisions.list.return_value = [revision]
+
+    wf = DataExtractionWorkflow(sdk)
+    result = wf.extract_audit_trail(
+        "STUDY",
+        start_date="2021-01-01",
+        end_date="2021-01-02",
+        user_filter={"role": "data"},
+        status="open",
+    )
+
+    sdk.record_revisions.list.assert_called_once_with(
+        "STUDY",
+        role="data",
+        status="open",
+        start_date="2021-01-01",
+        end_date="2021-01-02",
+    )
+    assert result == [revision]

--- a/tests/workflows/test_query_management.py
+++ b/tests/workflows/test_query_management.py
@@ -1,0 +1,92 @@
+from unittest.mock import MagicMock
+
+from imednet.models.queries import Query, QueryComment
+from imednet.models.subjects import Subject
+from imednet.testing import fake_data
+from imednet.workflows.query_management import QueryManagementWorkflow
+
+
+def make_query(sequence_closed: list[tuple[int, bool]]) -> Query:
+    comments = [QueryComment(sequence=seq, closed=closed) for seq, closed in sequence_closed]
+    return Query(query_comments=comments)
+
+
+def test_get_open_queries_filters_latest_comment() -> None:
+    sdk = MagicMock()
+    query_closed = make_query([(1, False), (2, True)])
+    query_open = make_query([(1, False)])
+    query_unknown = make_query([])
+    sdk.queries.list.return_value = [query_closed, query_open, query_unknown]
+
+    wf = QueryManagementWorkflow(sdk)
+    result = wf.get_open_queries("STUDY", additional_filter={"state": "new"})
+
+    sdk.queries.list.assert_called_once_with("STUDY", state="new")
+    assert sdk.queries.list.call_args.kwargs == {"state": "new"}
+    assert result == [query_open]
+
+
+def test_get_queries_for_subject_builds_combined_filter() -> None:
+    sdk = MagicMock()
+    wf = QueryManagementWorkflow(sdk)
+    wf.get_queries_for_subject("STUDY", "SUBJ1", additional_filter={"type": "x"})
+
+    sdk.queries.list.assert_called_once_with("STUDY", subject_key="SUBJ1", type="x")
+    assert sdk.queries.list.call_args.kwargs == {"subject_key": "SUBJ1", "type": "x"}
+
+
+def test_get_query_state_counts_aggregates_states() -> None:
+    sdk = MagicMock()
+    open_query = make_query([(1, False)])
+    closed_query = make_query([(1, True)])
+    unknown_query = make_query([])
+    sdk.queries.list.return_value = [open_query, closed_query, unknown_query]
+
+    wf = QueryManagementWorkflow(sdk)
+    counts = wf.get_query_state_counts("STUDY")
+
+    sdk.queries.list.assert_called_once_with("STUDY")
+    assert sdk.queries.list.call_args.kwargs == {}
+    assert counts == {"open": 1, "closed": 1, "unknown": 1}
+
+
+def test_get_queries_by_site_filters_using_subjects() -> None:
+    sdk = MagicMock()
+    s1 = Subject.from_json(fake_data.fake_subject())
+    s2 = Subject.from_json(fake_data.fake_subject())
+    s1.subject_key = "S1"
+    s2.subject_key = "S2"
+    sdk.subjects.list.return_value = [s1, s2]
+    wf = QueryManagementWorkflow(sdk)
+
+    wf.get_queries_by_site("STUDY", "SITE", additional_filter={"state": "open"})
+
+    sdk.subjects.list.assert_called_once_with("STUDY", site_name="SITE")
+    sdk.queries.list.assert_called_once_with("STUDY", subject_key=["S1", "S2"], state="open")
+    assert sdk.queries.list.call_args.kwargs == {"subject_key": ["S1", "S2"], "state": "open"}
+
+
+def test_get_queries_by_site_returns_empty_if_no_subjects() -> None:
+    sdk = MagicMock()
+    sdk.subjects.list.return_value = []
+    wf = QueryManagementWorkflow(sdk)
+
+    result = wf.get_queries_by_site("STUDY", "SITE")
+
+    sdk.subjects.list.assert_called_once_with("STUDY", site_name="SITE")
+    sdk.queries.list.assert_not_called()
+    assert result == []
+
+
+def test_get_queries_by_site_with_space_in_name() -> None:
+    sdk = MagicMock()
+    s = Subject.from_json(fake_data.fake_subject())
+    s.subject_key = "S1"
+    sdk.subjects.list.return_value = [s]
+    wf = QueryManagementWorkflow(sdk)
+
+    wf.get_queries_by_site("STUDY", "Mock Site")
+
+    sdk.subjects.list.assert_called_once_with("STUDY", site_name="Mock Site")
+    sdk.queries.list.assert_called_once_with("STUDY", subject_key=["S1"])
+    assert sdk.queries.list.call_args.kwargs == {"subject_key": ["S1"]}

--- a/tests/workflows/test_record_update.py
+++ b/tests/workflows/test_record_update.py
@@ -1,0 +1,64 @@
+import types
+from unittest.mock import MagicMock
+
+import pytest
+from imednet.core.exceptions import ValidationError
+from imednet.models.jobs import Job
+from imednet.models.variables import Variable
+from imednet.testing import fake_data
+from imednet.validation.schema import SchemaCache
+from imednet.workflows.record_update import RecordUpdateWorkflow
+
+
+def _build_schema() -> tuple[SchemaCache, Variable]:
+    forms = fake_data.fake_forms_for_cache(1, study_key="S")
+    variables = fake_data.fake_variables_for_cache(forms, vars_per_form=1, study_key="S")
+    var = variables[0]
+    object.__setattr__(var, "required", True)
+    var.variable_type = "integer"
+    forms_ep = types.SimpleNamespace(list=lambda **_: forms)
+
+    def list_vars(*_, form_id=None, **__):
+        return [v for v in variables if form_id is None or v.form_id == form_id]
+
+    vars_ep = types.SimpleNamespace(list=list_vars)
+    from typing import Any, cast
+
+    cache = SchemaCache()
+    cache.refresh(cast(Any, forms_ep), cast(Any, vars_ep), study_key="S")
+    return cache, var
+
+
+def test_create_or_update_records_no_wait(schema: SchemaCache) -> None:
+    sdk = MagicMock()
+    job = Job(batch_id="1", state="PROCESSING")
+    sdk.records.create.return_value = job
+
+    wf = RecordUpdateWorkflow(sdk)
+    wf._validator.schema = schema
+    wf._schema = schema
+    record = fake_data.fake_record(schema)
+    result = wf.create_or_update_records("S", [record])
+
+    sdk.records.create.assert_called_once_with("S", [record], schema=schema)
+    assert result == job
+
+
+def test_create_or_update_records_validation() -> None:
+    schema, var = _build_schema()
+    sdk = MagicMock()
+    wf = RecordUpdateWorkflow(sdk)
+    wf._validator.schema = schema
+    wf._schema = schema
+
+    with pytest.raises(ValidationError):
+        wf.create_or_update_records("S", [{"formKey": var.form_key, "data": {}}])
+    sdk.records.create.assert_not_called()
+
+    sdk.records.create.return_value = Job(batch_id="1", state="PROCESSING")
+    wf.create_or_update_records("S", [{"formKey": var.form_key, "data": {var.variable_name: 5}}])
+    sdk.records.create.assert_called_once_with(
+        "S",
+        [{"formKey": var.form_key, "data": {var.variable_name: 5}}],
+        schema=schema,
+    )

--- a/tests/workflows/test_register_subjects.py
+++ b/tests/workflows/test_register_subjects.py
@@ -1,0 +1,24 @@
+from unittest.mock import MagicMock
+
+from imednet.models.jobs import Job
+from imednet.models.records import RegisterSubjectRequest
+from imednet.testing import fake_data
+from imednet.workflows.register_subjects import RegisterSubjectsWorkflow
+
+
+def test_register_subjects_passes_records_correctly(schema) -> None:
+    sdk = MagicMock()
+    job = Job(batch_id="1", state="PROCESSING")
+    sdk.records.create.return_value = job
+    wf = RegisterSubjectsWorkflow(sdk)
+    rec = fake_data.fake_record(schema)
+    req = RegisterSubjectRequest(form_key=rec["formKey"], site_name="SITE", data=rec["recordData"])
+
+    result = wf.register_subjects("STUDY", [req], email_notify="test@example.com")
+
+    sdk.records.create.assert_called_once_with(
+        study_key="STUDY",
+        records_data=[req.model_dump(by_alias=True)],
+        email_notify="test@example.com",
+    )
+    assert result == job

--- a/tests/workflows/test_subject_data.py
+++ b/tests/workflows/test_subject_data.py
@@ -1,0 +1,45 @@
+from unittest.mock import MagicMock
+
+from imednet.models.queries import Query
+from imednet.models.records import Record
+from imednet.models.subjects import Subject
+from imednet.models.visits import Visit
+from imednet.testing import fake_data
+from imednet.workflows.subject_data import SubjectDataWorkflow
+
+
+def test_get_all_subject_data_aggregates_across_endpoints(schema) -> None:
+    sdk = MagicMock()
+    subject = Subject.from_json(fake_data.fake_subject())
+    visit = Visit.from_json(fake_data.fake_visit())
+    record_dict = fake_data.fake_record(schema)
+    record = Record.from_json(record_dict)
+    query = Query.from_json(fake_data.fake_query())
+
+    subject.subject_key = "S1"
+    visit.subject_key = "S1"
+    visit.visit_id = 1
+    record.subject_key = "S1"
+    record.visit_id = 1
+
+    sdk.subjects.list.return_value = [subject]
+    sdk.visits.list.return_value = [visit]
+    sdk.records.list.return_value = [record]
+    sdk.queries.list.return_value = [query]
+
+    wf = SubjectDataWorkflow(sdk)
+    result = wf.get_all_subject_data("STUDY", "S1")
+
+    sdk.subjects.list.assert_called_once_with("STUDY", subject_key="S1")
+    assert sdk.subjects.list.call_args.kwargs == {"subject_key": "S1"}
+    sdk.visits.list.assert_called_once_with("STUDY", subject_key="S1")
+    assert sdk.visits.list.call_args.kwargs == {"subject_key": "S1"}
+    sdk.records.list.assert_called_once_with("STUDY", subject_key="S1")
+    assert sdk.records.list.call_args.kwargs == {"subject_key": "S1"}
+    sdk.queries.list.assert_called_once_with("STUDY", subject_key="S1")
+    assert sdk.queries.list.call_args.kwargs == {"subject_key": "S1"}
+
+    assert result.subject_details == subject
+    assert result.visits == [visit]
+    assert result.records == [record]
+    assert result.queries == [query]


### PR DESCRIPTION
## Summary
- create `tests/workflows` suite using fake data helpers
- validate records via a local `SchemaCache`

## Testing
- `poetry run ruff check --fix .`
- `poetry run black --check .`
- `poetry run mypy imednet`
- `poetry run pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68508bbbb648832c8e29db3594861dea