### PR TITLE
Add async records example

### DIFF
--- a/examples/async/get_records_async.py
+++ b/examples/async/get_records_async.py
@@ -1,0 +1,43 @@
+import asyncio
+
+from imednet.sdk import AsyncImednetSDK
+
+"""Example script demonstrating basic usage of the AsyncImednetSDK.
+
+This script initializes the asynchronous client with API credentials, retrieves a list of
+studies, selects the first study, and then fetches and prints a few records associated with
+that study.
+
+Replace the "XXXXXXXXXX" placeholders with your API key, security key and optionally a
+specific study key. ``base_url`` can be left ``None`` to use the default iMednet endpoint or
+set to a custom URL if needed.
+"""
+
+api_key = "XXXXXXXXXX"
+security_key = "XXXXXXXXXX"
+base_url = None  # Or set to your custom base URL if needed
+study_key = "XXXXXXXXXX"
+
+
+async def main() -> None:
+    try:
+        async with AsyncImednetSDK(
+            api_key=api_key,
+            security_key=security_key,
+            base_url=base_url,
+        ) as sdk:
+            studies = await sdk.studies.async_list()
+            if not studies:
+                print("No studies returned from API.")
+            for study in studies[:1]:
+                study_key = study.study_key
+                records = await sdk.records.async_list(study_key=study_key)
+                print(f"Records for study '{study_key}': {len(records)}")
+                for record in records[:5]:
+                    print(f"- Record ID: {record.record_id}, " f"Subject Key: {record.subject_key}")
+    except Exception as e:
+        print(f"Error: {e}")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())


### PR DESCRIPTION
## Summary
- add an async example showing how to call `async_list` on records

## Testing
- `poetry run ruff check --fix .`
- `poetry run black --check .`
- `poetry run mypy imednet`
- `poetry run pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6850a132ad70832c9d5dad55dee69033