### PR TITLE
Introduce BaseClient

### DIFF
--- a/imednet/core/__init__.py
+++ b/imednet/core/__init__.py
@@ -3,6 +3,7 @@ Re-exports core components for easier access.
 """
 
 from .async_client import AsyncClient
+from .base_client import BaseClient
 from .client import Client
 from .exceptions import (
     ApiError,
@@ -22,6 +23,7 @@ from .exceptions import (
 from .paginator import AsyncPaginator, Paginator
 
 __all__ = [
+    "BaseClient",
     "Client",
     "AsyncClient",
     "Context",

--- a/imednet/core/base_client.py
+++ b/imednet/core/base_client.py
@@ -1,0 +1,76 @@
+"""Base client shared by sync and async variants."""
+
+from __future__ import annotations
+
+import logging
+import os
+from typing import Optional, Union
+
+try:  # optional opentelemetry
+    from opentelemetry import trace
+    from opentelemetry.trace import Tracer
+except Exception:  # pragma: no cover - optional dependency
+    trace = None
+    Tracer = None
+
+import httpx
+from tenacity import RetryCallState
+
+from imednet.utils.json_logging import configure_json_logging
+
+logger = logging.getLogger(__name__)
+
+
+class BaseClient:
+    """Common initialization logic for HTTP clients."""
+
+    DEFAULT_BASE_URL = "https://edc.prod.imednetapi.com"
+
+    def __init__(
+        self,
+        api_key: Optional[str] = None,
+        security_key: Optional[str] = None,
+        base_url: Optional[str] = None,
+        timeout: Union[float, httpx.Timeout] = 30.0,
+        retries: int = 3,
+        backoff_factor: float = 1.0,
+        log_level: Union[int, str] = logging.INFO,
+        tracer: Optional[Tracer] = None,
+    ) -> None:
+        api_key = (api_key or os.getenv("IMEDNET_API_KEY") or "").strip()
+        security_key = (security_key or os.getenv("IMEDNET_SECURITY_KEY") or "").strip()
+        if not api_key or not security_key:
+            raise ValueError("API key and security key are required")
+
+        self.base_url = base_url or os.getenv("IMEDNET_BASE_URL") or self.DEFAULT_BASE_URL
+        self.base_url = self.base_url.rstrip("/")
+        if self.base_url.endswith("/api"):
+            self.base_url = self.base_url[:-4]
+
+        self.timeout = timeout if isinstance(timeout, httpx.Timeout) else httpx.Timeout(timeout)
+        self.retries = retries
+        self.backoff_factor = backoff_factor
+
+        level = logging.getLevelName(log_level.upper()) if isinstance(log_level, str) else log_level
+        configure_json_logging(level)
+        logger.setLevel(level)
+
+        self.headers = {
+            "Accept": "application/json",
+            "Content-Type": "application/json",
+            "x-api-key": api_key,
+            "x-imn-security-key": security_key,
+        }
+
+        if tracer is not None:
+            self._tracer = tracer
+        elif trace is not None:
+            self._tracer = trace.get_tracer(__name__)
+        else:
+            self._tracer = None
+
+    def _should_retry(self, retry_state: RetryCallState) -> bool:
+        if retry_state.outcome is None:
+            return False
+        exc = retry_state.outcome.exception()
+        return isinstance(exc, httpx.RequestError)

--- a/tests/unit/async/test_async_client.py
+++ b/tests/unit/async/test_async_client.py
@@ -1,6 +1,11 @@
 import httpx
 import pytest
 from imednet.core.async_client import AsyncClient
+from imednet.core.base_client import BaseClient
+
+
+def test_async_client_subclass() -> None:
+    assert issubclass(AsyncClient, BaseClient)
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_core_client.py
+++ b/tests/unit/test_core_client.py
@@ -3,6 +3,7 @@ from unittest.mock import MagicMock
 import httpx
 import pytest
 from imednet.core import exceptions
+from imednet.core.base_client import BaseClient
 from imednet.core.client import Client
 
 
@@ -22,6 +23,10 @@ class DummyResponse:
     @property
     def is_error(self):
         return self.status_code >= 400
+
+
+def test_client_subclass() -> None:
+    assert issubclass(Client, BaseClient)
 
 
 def test_initialization_sets_defaults() -> None:


### PR DESCRIPTION
## Summary
- share common initialization via new `BaseClient`
- derive `Client` and `AsyncClient` from `BaseClient`
- export `BaseClient`
- update tests to cover new hierarchy
- clarify `AsyncClient` docstring

## Testing
- `poetry run ruff check --fix .`
- `poetry run black --check .`
- `poetry run mypy imednet`
- `poetry run pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6850a4ab6514832c9d816a936337b8cc