### PR TITLE
Add base paginator with shared logic

### DIFF
--- a/imednet/core/paginator.py
+++ b/imednet/core/paginator.py
@@ -1,22 +1,12 @@
-"""
-Pagination helper for iterating through paginated API responses.
-"""
+"""Pagination helpers for iterating through API responses."""
 
 from typing import Any, AsyncIterator, Dict, Iterator, Optional
 
 import httpx
 
 
-class Paginator:
-    """
-    Iterate over pages of results from the iMednet API.
-
-    Example::
-
-        paginator = Paginator(client, "/api/v1/edc/studies/{study_key}/sites")
-        for item in paginator:
-            # process each item
-    """
+class BasePaginator:
+    """Shared paginator implementation."""
 
     def __init__(
         self,
@@ -28,7 +18,7 @@ class Paginator:
         size_param: str = "size",
         data_key: str = "data",
         metadata_key: str = "metadata",
-    ):
+    ) -> None:
         self.client = client
         self.path = path
         self.params = params.copy() if params else {}
@@ -38,41 +28,59 @@ class Paginator:
         self.data_key = data_key
         self.metadata_key = metadata_key
 
-    def __iter__(self) -> Iterator[Any]:
+    def _build_params(self, page: int) -> Dict[str, Any]:
+        query = dict(self.params)
+        query[self.page_param] = page
+        query[self.size_param] = self.page_size
+        return query
+
+    def _extract_items(self, payload: Dict[str, Any]) -> list[Any]:
+        return payload.get(self.data_key, []) or []
+
+    def _next_page(self, payload: Dict[str, Any], page: int) -> Optional[int]:
+        pagination = payload.get("pagination", {})
+        total_pages = pagination.get("totalPages")
+        if total_pages is None or page >= total_pages - 1:
+            return None
+        return page + 1
+
+    def _iter_sync(self) -> Iterator[Any]:
         page = 0
         while True:
-            query = dict(self.params)
-            query[self.page_param] = page
-            query[self.size_param] = self.page_size
-            response: httpx.Response = self.client.get(self.path, params=query)
+            params = self._build_params(page)
+            response: httpx.Response = self.client.get(self.path, params=params)
             payload = response.json()
-            items = payload.get(self.data_key, []) or []
-            for item in items:
+            for item in self._extract_items(payload):
                 yield item
-            # Use 'pagination' key instead of 'metadata' for pagination info
-            pagination = payload.get("pagination", {})
-            total_pages = pagination.get("totalPages")
-            if total_pages is None or page >= total_pages - 1:
+            next_page = self._next_page(payload, page)
+            if next_page is None:
                 break
-            page += 1
+            page = next_page
+
+    async def _iter_async(self) -> AsyncIterator[Any]:
+        page = 0
+        while True:
+            params = self._build_params(page)
+            response: httpx.Response = await self.client.get(self.path, params=params)
+            payload = response.json()
+            for item in self._extract_items(payload):
+                yield item
+            next_page = self._next_page(payload, page)
+            if next_page is None:
+                break
+            page = next_page
 
 
-class AsyncPaginator(Paginator):
+class Paginator(BasePaginator):
+    """Iterate synchronously over paginated API results."""
+
+    def __iter__(self) -> Iterator[Any]:
+        yield from self._iter_sync()
+
+
+class AsyncPaginator(BasePaginator):
     """Asynchronous variant of :class:`Paginator`."""
 
     async def __aiter__(self) -> AsyncIterator[Any]:
-        page = 0
-        while True:
-            query = dict(self.params)
-            query[self.page_param] = page
-            query[self.size_param] = self.page_size
-            response: httpx.Response = await self.client.get(self.path, params=query)
-            payload = response.json()
-            items = payload.get(self.data_key, []) or []
-            for item in items:
-                yield item
-            pagination = payload.get("pagination", {})
-            total_pages = pagination.get("totalPages")
-            if total_pages is None or page >= total_pages - 1:
-                break
-            page += 1
+        async for item in self._iter_async():
+            yield item


### PR DESCRIPTION
## Summary
- introduce `BasePaginator` with shared pagination helpers
- derive `Paginator` and `AsyncPaginator` from the base class

## Testing
- `poetry run ruff check --fix .`
- `poetry run black --check .`
- `poetry run mypy imednet`
- `poetry run pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6850af1a7138832c92962002bae24843