### PR TITLE
Expose BaseClient at package root

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added PyPI, code style (Black), linter (Ruff), and typing (Mypy) badges to `README.md`.
 - Added `pandas` to development dependencies for workflow features.
 - Added a comprehensive test suite ensuring over 90% coverage.
+- Exposed `BaseClient` from the package root and updated import examples.
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ Then, you can use the SDK like this:
 ```python
 import os
 import json
-from imednet.sdk import ImednetSDK
+from imednet import ImednetSDK
 from imednet.workflows.study_structure import get_study_structure
 
 # Credentials are automatically read from the IMEDNET_API_KEY and
@@ -105,7 +105,7 @@ Use `AsyncImednetSDK` when working with asyncio:
 
 ```python
 import os
-from imednet.sdk import AsyncImednetSDK
+from imednet import AsyncImednetSDK
 
 async def main():
     study_key = os.getenv("IMEDNET_STUDY_KEY", "your_study_key_here")
@@ -138,7 +138,7 @@ payloads can be validated before submission with
 ``AsyncSchemaValidator.validate_batch``:
 
 ```python
-from imednet.sdk import AsyncImednetSDK
+from imednet import AsyncImednetSDK
 from imednet.validation.async_schema import AsyncSchemaValidator
 
 async def submit_records_async(records):

--- a/docs/airflow.rst
+++ b/docs/airflow.rst
@@ -62,7 +62,7 @@ Operators and Sensors
 ``ImednetExportOperator`` saves records to a local file using helpers from
 ``imednet.integrations.export``. ``ImednetToS3Operator`` sends JSON data to S3
 and ``ImednetJobSensor`` waits for an export job to complete. All operators use
-``ImednetHook`` to obtain an :class:`~imednet.sdk.ImednetSDK` instance from an
+``ImednetHook`` to obtain an :class:`~imednet.ImednetSDK` instance from an
 Airflow connection.
 
 Testing with Airflow

--- a/imednet/__init__.py
+++ b/imednet/__init__.py
@@ -1,11 +1,18 @@
 from importlib import metadata as _metadata
 
+from .core.base_client import BaseClient
 from .sdk import AsyncImednetSDK, ImednetSDK
 
 # Provide a backward-compatible alias
 ImednetClient = ImednetSDK
 
-__all__ = ["ImednetSDK", "AsyncImednetSDK", "ImednetClient", "__version__"]
+__all__ = [
+    "ImednetSDK",
+    "AsyncImednetSDK",
+    "ImednetClient",
+    "BaseClient",
+    "__version__",
+]
 
 try:
     __version__: str = _metadata.version("imednet-sdk")


### PR DESCRIPTION
## Summary
- export `BaseClient` in `imednet.__init__`
- document root import path for SDK clients
- mention BaseClient export in CHANGELOG

## Testing
- `poetry run ruff check --fix .`
- `poetry run black --check .`
- `poetry run mypy imednet`
- `poetry run pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6850af4c604c832c8c33ffca9e36d790