### PR TITLE
Implement async job polling

### DIFF
--- a/docs/job_polling.rst
+++ b/docs/job_polling.rst
@@ -15,3 +15,23 @@ a timeout occurs.
        E -- Yes --> F[raise JobTimeoutError]
        E -- No --> G[sleep interval]
        G --> B
+
+Using the SDK
+-------------
+
+``ImednetSDK`` provides a convenience method ``poll_job`` that blocks until the
+job finishes. ``AsyncImednetSDK`` exposes ``async_poll_job`` for the same
+behavior in asynchronous code.
+
+.. code-block:: python
+
+   from imednet.sdk import ImednetSDK, AsyncImednetSDK
+
+   # synchronous
+   sdk = ImednetSDK()
+   status = sdk.poll_job("STUDY", "BATCH", interval=2, timeout=60)
+
+   # asynchronous
+   async def wait_async():
+       async with AsyncImednetSDK() as sdk:
+           status = await sdk.async_poll_job("STUDY", "BATCH", interval=2, timeout=60)

--- a/tests/unit/async/test_async_poll_job.py
+++ b/tests/unit/async/test_async_poll_job.py
@@ -1,0 +1,58 @@
+import asyncio
+from unittest.mock import AsyncMock
+
+import pytest
+from imednet.models.jobs import JobStatus
+from imednet.sdk import AsyncImednetSDK
+
+
+def _create_sdk() -> AsyncImednetSDK:
+    return AsyncImednetSDK(
+        api_key="key",
+        security_key="secret",
+        base_url="https://example.com",
+    )
+
+
+@pytest.mark.asyncio
+async def test_async_poll_job_success(monkeypatch) -> None:
+    sdk = _create_sdk()
+    states = [
+        JobStatus(batch_id="1", state="PROCESSING", progress=10),
+        JobStatus(batch_id="1", state="COMPLETED", progress=100),
+    ]
+    monkeypatch.setattr(sdk.jobs, "async_get", AsyncMock(side_effect=lambda s, b: states.pop(0)))
+    monkeypatch.setattr(asyncio, "sleep", AsyncMock())
+
+    result = await sdk.async_poll_job("STUDY", "1", interval=0, timeout=5)
+    assert result.state == "COMPLETED"
+
+
+@pytest.mark.asyncio
+async def test_async_poll_job_timeout(monkeypatch) -> None:
+    sdk = _create_sdk()
+    job = JobStatus(batch_id="1", state="PROCESSING")
+    monkeypatch.setattr(sdk.jobs, "async_get", AsyncMock(return_value=job))
+    monkeypatch.setattr(asyncio, "sleep", AsyncMock())
+    tick = {"v": 0}
+
+    def monotonic() -> int:
+        tick["v"] += 1
+        return tick["v"]
+
+    monkeypatch.setattr("time.monotonic", monotonic)
+    with pytest.raises(TimeoutError):
+        await sdk.async_poll_job("S", "1", interval=0, timeout=2)
+
+
+@pytest.mark.asyncio
+async def test_async_poll_job_failed(monkeypatch) -> None:
+    sdk = _create_sdk()
+    states = [
+        JobStatus(batch_id="1", state="PROCESSING"),
+        JobStatus(batch_id="1", state="FAILED"),
+    ]
+    monkeypatch.setattr(sdk.jobs, "async_get", AsyncMock(side_effect=lambda s, b: states.pop(0)))
+    monkeypatch.setattr(asyncio, "sleep", AsyncMock())
+    with pytest.raises(RuntimeError):
+        await sdk.async_poll_job("S", "1", interval=0, timeout=5)


### PR DESCRIPTION
## Summary
- add `async_poll_job` to poll job status asynchronously
- document synchronous and asynchronous polling usage
- test async job polling logic

## Testing
- `poetry run ruff check --fix .`
- `poetry run black --check .`
- `poetry run mypy imednet`
- `poetry run pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6850b4d0acbc832cac8705c6ba3df66b