### PR TITLE
Add BaseClient unit test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `pandas` to development dependencies for workflow features.
 - Added a comprehensive test suite ensuring over 90% coverage.
 - Exposed `BaseClient` from the package root and updated import examples.
+- Added unit test for `BaseClient` initialization using environment variables.
 
 ### Fixed
 

--- a/tests/unit/test_base_client.py
+++ b/tests/unit/test_base_client.py
@@ -1,0 +1,26 @@
+from unittest.mock import MagicMock
+
+import httpx
+import imednet.core.base_client as base_client
+from imednet.core.base_client import BaseClient
+
+
+class DummyClient(BaseClient):
+    def _create_client(self, api_key: str, security_key: str) -> httpx.Client:
+        return httpx.Client(headers={"x-api-key": api_key, "x-imn-security-key": security_key})
+
+
+def test_initialization_from_env(monkeypatch) -> None:
+    monkeypatch.setenv("IMEDNET_API_KEY", "env_key")
+    monkeypatch.setenv("IMEDNET_SECURITY_KEY", "env_secret")
+    monkeypatch.setenv("IMEDNET_BASE_URL", "https://env.example.com")
+
+    tracer = MagicMock()
+    monkeypatch.setattr(base_client, "trace", MagicMock(get_tracer=lambda _: tracer))
+
+    client = DummyClient()
+
+    assert client.base_url == "https://env.example.com"
+    assert client._client.headers["x-api-key"] == "env_key"
+    assert client._client.headers["x-imn-security-key"] == "env_secret"
+    assert client._tracer is tracer


### PR DESCRIPTION
## Summary
- add BaseClient environment variable initialization test
- document test addition in CHANGELOG

## Testing
- `poetry run ruff check --fix .`
- `poetry run black --check .`
- `poetry run mypy imednet`
- `poetry run pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6850b5def2a4832c850188fdafb5ff3f