### PR TITLE
Improve documentation accessibility

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,42 @@
+name: Build and Deploy Documentation
+
+permissions:
+  contents: write
+  pages: write
+  id-token: write
+
+on:
+  push:
+    branches: [ main ]
+
+jobs:
+  docs:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v3
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+
+      - name: Install Poetry
+        uses: abatilo/actions-poetry@v2
+        with:
+          poetry-version: '1.8.0'
+
+      - name: Install dependencies
+        run: |
+          poetry install --with dev
+
+      - name: Build HTML documentation
+        run: |
+          poetry run sphinx-build -b html docs docs/_build/html
+
+      - name: Deploy to GitHub Pages
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: docs/_build/html
+          publish_branch: gh-pages

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added a comprehensive test suite ensuring over 90% coverage.
 - Exposed `BaseClient` from the package root and updated import examples.
 - Added unit test for `BaseClient` initialization using environment variables.
+- Reintroduced automatic documentation deployment to GitHub Pages.
+- Documented caching thread-safety and added a quick start guide.
 
 ### Fixed
 
@@ -21,8 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 
-- Removed GitHub Actions workflow for documentation generation and deployment (docs.yml). Documentation must now be built and viewed locally.
-- Removed obsolete TEST_PLAN.md file.
+ - Removed obsolete TEST_PLAN.md file.
 
 ## [0.1.0] - 2025-04-28
 

--- a/README.md
+++ b/README.md
@@ -16,6 +16,9 @@ A Python SDK for interacting with the iMedNet REST API. Provides client, endpoin
 
 See the [Changelog](CHANGELOG.md) for release history.
 
+Full API documentation is published at
+https://bright-research.github.io/imednet-python-sdk/.
+
 ## Features
 
 - Simple, consistent interface for API calls
@@ -24,6 +27,9 @@ See the [Changelog](CHANGELOG.md) for release history.
 - Workflow utilities for data extraction and mapping
 - Pandas helpers for DataFrame conversion and CSV export
 - Optional in-memory caching for study, form, interval, and variable listings
+  (not thread-safe; refresh or recreate the SDK in long running processes)
+- Structured JSON logging with optional OpenTelemetry tracing
+- Async client and CLI for common tasks
 
 Calls to `sdk.studies.list()`, `sdk.forms.list()`, `sdk.intervals.list()` and
 `sdk.variables.list()` cache results in memory. Pass `refresh=True` to bypass
@@ -41,6 +47,19 @@ Or install from source:
 git clone https://github.com/Bright-Research/imednet-python-sdk.git
 cd imednet-python-sdk
 ./scripts/setup.sh
+```
+
+## Quick Start
+
+Enable structured logging, create an SDK instance and list studies:
+
+```python
+from imednet import ImednetSDK
+from imednet.utils import configure_json_logging
+
+configure_json_logging()
+sdk = ImednetSDK()
+print(sdk.studies.list())
 ```
 
 ## Usage

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -6,6 +6,7 @@ Welcome to imednet-sdk's documentation!
    :caption: Contents:
 
    logging_and_tracing
+   quick_start
    api_overview
    rest_api_reference
    endpoints/index

--- a/docs/quick_start.rst
+++ b/docs/quick_start.rst
@@ -1,0 +1,31 @@
+Quick Start
+===========
+
+This page walks through a minimal example of using the SDK.
+
+Install the package from PyPI:
+
+.. code-block:: console
+
+   pip install imednet-sdk
+
+Set your credentials as environment variables:
+
+.. code-block:: bash
+
+   export IMEDNET_API_KEY="your_api_key"
+   export IMEDNET_SECURITY_KEY="your_security_key"
+
+Enable structured logging and list studies:
+
+.. code-block:: python
+
+   from imednet import ImednetSDK
+   from imednet.utils import configure_json_logging
+
+   configure_json_logging()
+   sdk = ImednetSDK()
+   studies = sdk.studies.list()
+   print(studies)
+
+Cached endpoints can be refreshed with ``refresh=True``. The caches are not thread safe so long running applications should recreate the SDK when needed.


### PR DESCRIPTION
## Summary
- restore GitHub Pages workflow for automatic docs deployment
- link to hosted docs and document caching thread-safety
- add Quick Start section with logging example
- add Quick Start page to Sphinx docs

## Testing
- `./scripts/setup.sh`
- `poetry run ruff check --fix .`
- `poetry run black --check .`
- `poetry run mypy imednet`
- `poetry run pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6850d44c3fd4832cafbb1d5c7d79ff7a