### PR TITLE
Add quick start example

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added unit test for `BaseClient` initialization using environment variables.
 - Reintroduced automatic documentation deployment to GitHub Pages.
 - Documented caching thread-safety and added a quick start guide.
+- Added `examples/quick_start.py` demonstrating minimal SDK usage with
+  environment variable validation.
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -61,6 +61,8 @@ configure_json_logging()
 sdk = ImednetSDK()
 print(sdk.studies.list())
 ```
+Run `python examples/quick_start.py` for a runnable version that checks your
+environment variables.
 
 ## Usage
 

--- a/docs/quick_start.rst
+++ b/docs/quick_start.rst
@@ -28,4 +28,7 @@ Enable structured logging and list studies:
    studies = sdk.studies.list()
    print(studies)
 
+The example script :mod:`examples.quick_start` provides a runnable version that
+validates required environment variables.
+
 Cached endpoints can be refreshed with ``refresh=True``. The caches are not thread safe so long running applications should recreate the SDK when needed.

--- a/examples/quick_start.py
+++ b/examples/quick_start.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+import os
+import sys
+
+from imednet import ImednetSDK
+from imednet.utils import configure_json_logging
+
+"""Quick start example using environment variables for authentication.
+
+Set ``IMEDNET_API_KEY`` and ``IMEDNET_SECURITY_KEY`` before running this
+script. Optionally set ``IMEDNET_BASE_URL`` for non-default instances.
+
+Example:
+
+    export IMEDNET_API_KEY="your_api_key"
+    export IMEDNET_SECURITY_KEY="your_security_key"
+    python examples/quick_start.py
+"""
+
+
+def main() -> None:
+    """Run a minimal SDK example using environment variables."""
+
+    configure_json_logging()
+
+    missing = [var for var in ("IMEDNET_API_KEY", "IMEDNET_SECURITY_KEY") if not os.getenv(var)]
+    if missing:
+        vars_ = ", ".join(missing)
+        print(f"Missing required environment variable(s): {vars_}", file=sys.stderr)
+        sys.exit(1)
+
+    sdk = ImednetSDK()
+    print(sdk.studies.list())
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- document a runnable quick-start example
- add `examples/quick_start.py` using environment variables
- mention the new script in docs

## Testing
- `poetry run ruff check --fix .`
- `poetry run black --check .`
- `poetry run mypy imednet`
- `poetry run pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6850e2cf3e80832c942af6fc772c4e47