### PR TITLE
feat: document all record POST scenarios

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Documented caching thread-safety and added a quick start guide.
 - Added `examples/quick_start.py` demonstrating minimal SDK usage with
   environment variable validation.
+- Expanded `RecordUpdateWorkflow` documentation and examples to cover all
+  record POST scenarios.
 - Added workflow examples `examples/workflows/extract_audit_trail.py` and
   `examples/workflows/queries_by_site.py`.
 

--- a/examples/workflows/update_record.py
+++ b/examples/workflows/update_record.py
@@ -1,28 +1,71 @@
 from imednet.sdk import ImednetSDK
 from imednet.workflows import JobPoller, RecordUpdateWorkflow
 
-"""Example script for creating a new record and waiting for job completion.
+"""Examples for all ``RecordUpdateWorkflow`` POST scenarios.
 
-This script demonstrates how to use :class:`RecordUpdateWorkflow` to create an
-unscheduled record for an existing subject. After submitting the record the
-returned batch ID is polled using :class:`JobPoller` until the job finishes.
+The script demonstrates how to:
 
-Replace the placeholder values below with valid credentials and identifiers
-before running the script.
+1. Register a new subject.
+2. Update a scheduled record.
+3. Create an unscheduled record for an existing subject.
+
+Each step submits the record and then waits for the asynchronous job to finish
+using :class:`JobPoller`. Replace the placeholder values below with real
+credentials and identifiers before running the script.
 """
 
 api_key = "XXXXXXXXXX"
 security_key = "XXXXXXXXXX"
 base_url = None  # Or set to your custom base URL if needed
 study_key = "XXXXXXXXXX"
-form_key = "XXXXXXXXXX"
-subject_key = "XXXXXXXXXX"
+form_key = "XXXXXXXXXX"  # Registration or visit form key
+site_name = "XXXXXXXXXX"  # Site for new subject registration
+interval_name = "XXXXXXXXXX"  # Interval for updating a scheduled record
+subject_key = "XXXXXXXXXX"  # Existing subject key
 
 sdk = ImednetSDK(api_key=api_key, security_key=security_key, base_url=base_url)
 workflow = RecordUpdateWorkflow(sdk)
 
 record_data = {"VARIABLE_NAME": "value"}
 
+# 1. Register a new subject
+try:
+    job = workflow.register_subject(
+        study_key=study_key,
+        form_identifier=form_key,
+        site_identifier=site_name,
+        data=record_data,
+        wait_for_completion=False,
+    )
+
+    if not job.batch_id:
+        raise RuntimeError("Registration succeeded but no batch ID returned")
+
+    status = JobPoller(sdk, study_key, job.batch_id).wait()
+    print(f"Registration job {status.batch_id} finished with state: {status.state}")
+except Exception as e:
+    print(f"Error registering subject: {e}")
+
+# 2. Update a scheduled record
+try:
+    job = workflow.update_scheduled_record(
+        study_key=study_key,
+        form_identifier=form_key,
+        subject_identifier=subject_key,
+        interval_identifier=interval_name,
+        data=record_data,
+        wait_for_completion=False,
+    )
+
+    if not job.batch_id:
+        raise RuntimeError("Update succeeded but no batch ID returned")
+
+    status = JobPoller(sdk, study_key, job.batch_id).wait()
+    print(f"Update job {status.batch_id} finished with state: {status.state}")
+except Exception as e:
+    print(f"Error updating scheduled record: {e}")
+
+# 3. Create an unscheduled record
 try:
     job = workflow.create_new_record(
         study_key=study_key,
@@ -33,9 +76,9 @@ try:
     )
 
     if not job.batch_id:
-        raise RuntimeError("Submission succeeded but no batch ID returned")
+        raise RuntimeError("Creation succeeded but no batch ID returned")
 
     status = JobPoller(sdk, study_key, job.batch_id).wait()
-    print(f"Job {status.batch_id} finished with state: {status.state}")
+    print(f"Creation job {status.batch_id} finished with state: {status.state}")
 except Exception as e:
     print(f"Error creating record: {e}")

--- a/imednet/workflows/record_update.py
+++ b/imednet/workflows/record_update.py
@@ -1,4 +1,15 @@
-"""Placeholder for Record Creation/Update workflows."""
+"""High level helpers for posting records to the iMedNet API.
+
+This module exposes convenience methods covering all POST scenarios for the
+``records`` endpoint:
+
+- ``register_subject`` – create a registration record for a new subject.
+- ``update_scheduled_record`` – modify a record that already exists on a scheduled visit.
+- ``create_new_record`` – add an unscheduled record for an existing subject.
+
+All helpers ultimately call ``create_or_update_records`` which performs optional
+schema validation and can poll job status until completion.
+"""
 
 import warnings
 from typing import TYPE_CHECKING, Any, Dict, List, Literal, Union


### PR DESCRIPTION
## Summary
- detail RecordUpdateWorkflow module
- extend workflow example to cover all record POST cases
- add unit tests for each RecordUpdateWorkflow helper
- note update in CHANGELOG

## Testing
- `poetry run ruff check --fix .`
- `poetry run black --check .`
- `poetry run mypy imednet`
- `poetry run pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685178af4f70832ca6d3f72522208c57