### PR TITLE
Add CDISC business-rules helpers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `examples/workflows/queries_by_site.py`.
 - Added optional CDISC validation helpers for loading rules caches.
 - Added helpers for preparing datasets and running CDISC business rules.
+- Added helpers for loading XPT metadata and executing rules via ``RulesEngine``.
 - Updated imports in all example scripts to use the package root for `ImednetSDK`.
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   environment variable validation.
 - Added workflow examples `examples/workflows/extract_audit_trail.py` and
   `examples/workflows/queries_by_site.py`.
+- Added optional CDISC validation helpers for loading rules caches.
+- Added helpers for preparing datasets and running CDISC business rules.
 - Updated imports in all example scripts to use the package root for `ImednetSDK`.
 
 ### Fixed

--- a/imednet/validation/__init__.py
+++ b/imednet/validation/__init__.py
@@ -1,4 +1,11 @@
 from .async_schema import AsyncSchemaCache, AsyncSchemaValidator
+from .cdisc import (
+    dataset_variable_from_dataframe,
+    get_rules,
+    load_rules_cache,
+    rule_from_metadata,
+    run_business_rules,
+)
 from .schema import SchemaCache, SchemaValidator, validate_record_data
 
 __all__ = [
@@ -7,4 +14,9 @@ __all__ = [
     "validate_record_data",
     "AsyncSchemaCache",
     "AsyncSchemaValidator",
+    "load_rules_cache",
+    "get_rules",
+    "rule_from_metadata",
+    "dataset_variable_from_dataframe",
+    "run_business_rules",
 ]

--- a/imednet/validation/__init__.py
+++ b/imednet/validation/__init__.py
@@ -1,10 +1,14 @@
 from .async_schema import AsyncSchemaCache, AsyncSchemaValidator
 from .cdisc import (
+    dataset_metadata_from_xpt,
     dataset_variable_from_dataframe,
+    get_datasets_metadata,
     get_rules,
     load_rules_cache,
     rule_from_metadata,
     run_business_rules,
+    run_rules_engine,
+    write_validation_report,
 )
 from .schema import SchemaCache, SchemaValidator, validate_record_data
 
@@ -18,5 +22,9 @@ __all__ = [
     "get_rules",
     "rule_from_metadata",
     "dataset_variable_from_dataframe",
+    "dataset_metadata_from_xpt",
+    "get_datasets_metadata",
     "run_business_rules",
+    "run_rules_engine",
+    "write_validation_report",
 ]

--- a/imednet/validation/cdisc.py
+++ b/imednet/validation/cdisc.py
@@ -1,0 +1,138 @@
+"""Utilities for working with the CDISC Rules Engine."""
+
+from __future__ import annotations
+
+import os
+import pathlib
+import pickle
+from multiprocessing.managers import SyncManager
+from typing import TYPE_CHECKING, Any, List
+
+if TYPE_CHECKING:  # pragma: no cover - imported for type checking only
+    import pandas as pd
+
+
+def load_rules_cache(path_to_rules_cache: str) -> Any:
+    """Load CDISC rule definitions from ``path_to_rules_cache``.
+
+    Parameters
+    ----------
+    path_to_rules_cache:
+        Directory containing pickled rule files as distributed with the
+        ``cdisc-rules-engine`` package.
+    """
+    from cdisc_rules_engine.services.cache import InMemoryCacheService
+
+    class CacheManager(SyncManager):
+        pass
+
+    CacheManager.register("InMemoryCacheService", InMemoryCacheService)
+
+    cache_path = pathlib.Path(path_to_rules_cache)
+    manager = CacheManager()
+    manager.start()
+    cache: Any = manager.InMemoryCacheService()  # type: ignore[attr-defined]
+
+    files = next(os.walk(cache_path), (None, None, []))[2]
+    for fname in files:
+        with open(cache_path / fname, "rb") as f:
+            cache.add_all(pickle.load(f))
+
+    return cache
+
+
+def get_rules(cache: Any, standard: str, version: str) -> List[dict]:
+    """Return rules for the given standard and version from ``cache``."""
+    from cdisc_rules_engine.utilities.utils import get_rules_cache_key
+
+    cache_key_prefix = get_rules_cache_key(standard, version.replace(".", "-"))
+    return cache.get_all_by_prefix(cache_key_prefix)
+
+
+def rule_from_metadata(rule_metadata: dict) -> Any:
+    """Construct a ``Rule`` object from CDISC rule metadata."""
+    from cdisc_rules_engine.models.rule import Rule
+
+    rule_dict = Rule.from_cdisc_metadata(rule_metadata)
+    return Rule(rule_dict)
+
+
+def dataset_variable_from_dataframe(
+    data: "pd.DataFrame", domain: str, label: str | None = None
+) -> tuple[Any, Any]:
+    """Return a dataset variable and metadata for ``data``.
+
+    Parameters
+    ----------
+    data:
+        Dataframe containing the dataset to validate.
+    domain:
+        Dataset domain name (e.g. "AE").
+    label:
+        Optional human readable label for the dataset.
+    """
+    import pandas as pd
+    from cdisc_rules_engine.models.dataset.pandas_dataset import PandasDataset
+    from cdisc_rules_engine.models.dataset_variable import DatasetVariable
+    from cdisc_rules_engine.models.sdtm_dataset_metadata import SDTMDatasetMetadata
+
+    if not isinstance(data, pd.DataFrame):
+        raise TypeError("data must be a pandas DataFrame")
+
+    pandas_dataset = PandasDataset(data=data)
+    metadata = SDTMDatasetMetadata(
+        name=domain,
+        label=label or domain,
+        first_record=data.iloc[0].to_dict() if not data.empty else None,
+    )
+    dataset_variable = DatasetVariable(
+        pandas_dataset,
+        column_prefix_map={"--": metadata.domain},
+    )
+    return dataset_variable, metadata
+
+
+def run_business_rules(
+    rules: List[dict],
+    dataset_variable: Any,
+    dataset_metadata: Any,
+    *,
+    value_level_metadata: Any | None = None,
+) -> List[Any]:
+    """Execute business rules against ``dataset_variable``.
+
+    Returns a list of results from triggered rules.
+    """
+    from business_rules.engine import run
+    from cdisc_rules_engine.models.actions import COREActions
+
+    all_results: List[Any] = []
+    for rule in rules:
+        results: list[Any] = []
+        actions = COREActions(
+            output_container=results,
+            variable=dataset_variable,
+            dataset_metadata=dataset_metadata,
+            rule=rule,
+            value_level_metadata=value_level_metadata,
+        )
+        try:
+            triggered = run(
+                rule=rule,
+                defined_variables=dataset_variable,
+                defined_actions=actions,
+            )
+        except Exception:
+            continue
+        if triggered and results:
+            all_results.extend(results)
+    return all_results
+
+
+__all__ = [
+    "load_rules_cache",
+    "get_rules",
+    "rule_from_metadata",
+    "dataset_variable_from_dataframe",
+    "run_business_rules",
+]

--- a/tests/unit/test_cdisc_rules.py
+++ b/tests/unit/test_cdisc_rules.py
@@ -17,6 +17,13 @@ def _setup_cdisc(monkeypatch):
     dataset_var_mod = ModuleType("cdisc_rules_engine.models.dataset_variable")
     meta_mod = ModuleType("cdisc_rules_engine.models.sdtm_dataset_metadata")
     actions_mod = ModuleType("cdisc_rules_engine.models.actions")
+    lib_meta_mod = ModuleType("cdisc_rules_engine.models.library_metadata_container")
+    data_services_mod = ModuleType("cdisc_rules_engine.services.data_services")
+    rules_engine_mod = ModuleType("cdisc_rules_engine.rules_engine")
+    cond_mod = ModuleType("cdisc_rules_engine.models.rule_conditions")
+    result_mod = ModuleType("cdisc_rules_engine.models.rule_validation_result")
+    config_mod = ModuleType("cdisc_rules_engine.config")
+    pyreadstat_mod = ModuleType("pyreadstat")
 
     class FakeInMemoryCacheService:
         def __init__(self):
@@ -28,8 +35,26 @@ def _setup_cdisc(monkeypatch):
         def get_all_by_prefix(self, prefix):
             return [r for r in self.data if r.get("key", "").startswith(prefix)]
 
+        def get(self, key):
+            for item in self.data:
+                if item.get("key") == key:
+                    return item
+            return None
+
     def get_rules_cache_key(std, ver):
         return f"{std}-{ver}"
+
+    def get_library_variables_metadata_cache_key(std, ver, sub):
+        return f"{std}-{ver}-vars"
+
+    def get_model_details_cache_key_from_ig(meta):
+        return "model-key"
+
+    def get_standard_details_cache_key(std, ver, sub):
+        return f"{std}-{ver}"
+
+    def get_variable_codelist_map_cache_key(std, ver, sub):
+        return f"{std}-{ver}-map"
 
     class FakeRule:
         def __init__(self, data):
@@ -50,21 +75,78 @@ def _setup_cdisc(monkeypatch):
             self.kwargs = kwargs
 
     class FakeMetadata:
-        def __init__(self, name, label, first_record=None):
+        def __init__(
+            self,
+            name,
+            label,
+            first_record=None,
+            filename="",
+            full_path="",
+            file_size=0,
+            record_count=0,
+        ):
             self.name = name
             self.label = label
             self.first_record = first_record
             self.domain = name
+            self.filename = filename
+            self.full_path = full_path
+            self.file_size = file_size
+            self.record_count = record_count
 
     class FakeCOREActions:
         def __init__(self, output_container=None, **kwargs):
             self.output_container = output_container if output_container is not None else []
+
+    class FakeLibraryMetadataContainer:
+        def __init__(self, **kwargs):
+            self.kwargs = kwargs
+
+    class FakeDataService:
+        def __init__(self, paths):
+            self.paths = paths
+
+    class FakeDataServiceFactory:
+        def __init__(self, **kwargs):
+            self.kwargs = kwargs
+
+        def get_data_service(self, dataset_paths):
+            return FakeDataService(dataset_paths)
+
+    class FakeRulesEngine:
+        def __init__(self, **kwargs):
+            self.kwargs = kwargs
+
+        def validate_single_rule(self, rule, datasets):
+            return {ds.name: [rule] for ds in datasets}
+
+    class FakeConditionCompositeFactory:
+        @staticmethod
+        def get_condition_composite(condition):
+            return {"converted": condition}
+
+    class FakeRuleValidationResult:
+        def __init__(self, rule, violations):
+            self.rule = rule
+            self.violations = violations
+
+    import pandas as pd
+
+    def read_xport(path):
+        meta = type("Meta", (), {"file_label": "label"})()
+        return pd.DataFrame({"A": [1]}), meta
+
+    pyreadstat_mod.read_xport = read_xport
 
     cache_mod.InMemoryCacheService = FakeInMemoryCacheService
     services.cache = cache_mod
     cre.services = services
 
     utils_mod.get_rules_cache_key = get_rules_cache_key
+    utils_mod.get_library_variables_metadata_cache_key = get_library_variables_metadata_cache_key
+    utils_mod.get_model_details_cache_key_from_ig = get_model_details_cache_key_from_ig
+    utils_mod.get_standard_details_cache_key = get_standard_details_cache_key
+    utils_mod.get_variable_codelist_map_cache_key = get_variable_codelist_map_cache_key
     utilities.utils = utils_mod
     cre.utilities = utilities
 
@@ -75,6 +157,12 @@ def _setup_cdisc(monkeypatch):
     dataset_var_mod.DatasetVariable = FakeDatasetVariable
     meta_mod.SDTMDatasetMetadata = FakeMetadata
     actions_mod.COREActions = FakeCOREActions
+    lib_meta_mod.LibraryMetadataContainer = FakeLibraryMetadataContainer
+    data_services_mod.DataServiceFactory = FakeDataServiceFactory
+    rules_engine_mod.RulesEngine = FakeRulesEngine
+    cond_mod.ConditionCompositeFactory = FakeConditionCompositeFactory
+    result_mod.RuleValidationResult = FakeRuleValidationResult
+    config_mod.config = {}
 
     # stub business_rules.engine.run
     engine_mod = ModuleType("business_rules.engine")
@@ -126,6 +214,29 @@ def _setup_cdisc(monkeypatch):
         meta_mod,
     )
     monkeypatch.setitem(sys.modules, "cdisc_rules_engine.models.actions", actions_mod)
+    monkeypatch.setitem(
+        sys.modules,
+        "cdisc_rules_engine.models.library_metadata_container",
+        lib_meta_mod,
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "cdisc_rules_engine.services.data_services",
+        data_services_mod,
+    )
+    monkeypatch.setitem(sys.modules, "cdisc_rules_engine.rules_engine", rules_engine_mod)
+    monkeypatch.setitem(
+        sys.modules,
+        "cdisc_rules_engine.models.rule_conditions",
+        cond_mod,
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "cdisc_rules_engine.models.rule_validation_result",
+        result_mod,
+    )
+    monkeypatch.setitem(sys.modules, "cdisc_rules_engine.config", config_mod)
+    monkeypatch.setitem(sys.modules, "pyreadstat", pyreadstat_mod)
     monkeypatch.setattr(cdisc, "SyncManager", DummyManager)
 
 
@@ -175,3 +286,51 @@ def test_run_business_rules(monkeypatch):
     rules = [{"core_id": "R1", "domains": {"Include": ["AE"]}}]
     results = cdisc.run_business_rules(rules, dv, meta)
     assert results  # results should not be empty
+
+
+def test_dataset_metadata_from_xpt(tmp_path, monkeypatch):
+    _setup_cdisc(monkeypatch)
+    xpt_file = tmp_path / "ae.xpt"
+    xpt_file.write_bytes(b"data")
+    meta = cdisc.dataset_metadata_from_xpt(str(xpt_file))
+    assert meta.filename == "ae.xpt"
+
+
+def test_get_datasets_metadata(tmp_path, monkeypatch):
+    _setup_cdisc(monkeypatch)
+    (tmp_path / "ae.xpt").write_bytes(b"ae")
+    (tmp_path / "dm.XPT").write_bytes(b"dm")
+    datasets = cdisc.get_datasets_metadata(str(tmp_path))
+    names = {d.name for d in datasets}
+    assert names == {"AE", "DM"}
+
+
+def test_run_rules_engine(tmp_path, monkeypatch):
+    _setup_cdisc(monkeypatch)
+    file_path = tmp_path / "ae.xpt"
+    file_path.write_bytes(b"ae")
+    rules_dir = tmp_path / "rules"
+    rules_dir.mkdir()
+    with open(rules_dir / "rules.pkl", "wb") as f:
+        pickle.dump([{"core_id": "R1"}], f)
+    datasets = [cdisc.dataset_metadata_from_xpt(str(file_path))]
+    cache = cdisc.load_rules_cache(str(rules_dir))
+    rules = [{"core_id": "R1", "conditions": {}}]
+    results, elapsed = cdisc.run_rules_engine(
+        rules,
+        datasets,
+        cache,
+        standard="sdtmig",
+        standard_version="3-4",
+        dataset_paths=[str(file_path)],
+        ct_packages=[],
+    )
+    assert results and elapsed >= 0
+
+
+def test_write_validation_report(tmp_path, monkeypatch):
+    _setup_cdisc(monkeypatch)
+    output = tmp_path / "out.txt"
+    results = [type("Res", (), {"rule": {"core_id": "C1"}, "violations": [1]})()]
+    cdisc.write_validation_report(results, str(output))
+    assert output.read_text()

--- a/tests/unit/test_cdisc_rules.py
+++ b/tests/unit/test_cdisc_rules.py
@@ -1,0 +1,177 @@
+import pickle
+import sys
+from types import ModuleType
+
+import imednet.validation.cdisc as cdisc
+
+
+def _setup_cdisc(monkeypatch):
+    cre = ModuleType("cdisc_rules_engine")
+    services = ModuleType("cdisc_rules_engine.services")
+    cache_mod = ModuleType("cdisc_rules_engine.services.cache")
+    utilities = ModuleType("cdisc_rules_engine.utilities")
+    utils_mod = ModuleType("cdisc_rules_engine.utilities.utils")
+    models = ModuleType("cdisc_rules_engine.models")
+    rule_mod = ModuleType("cdisc_rules_engine.models.rule")
+    pandas_mod = ModuleType("cdisc_rules_engine.models.dataset.pandas_dataset")
+    dataset_var_mod = ModuleType("cdisc_rules_engine.models.dataset_variable")
+    meta_mod = ModuleType("cdisc_rules_engine.models.sdtm_dataset_metadata")
+    actions_mod = ModuleType("cdisc_rules_engine.models.actions")
+
+    class FakeInMemoryCacheService:
+        def __init__(self):
+            self.data = []
+
+        def add_all(self, data):
+            self.data.extend(data)
+
+        def get_all_by_prefix(self, prefix):
+            return [r for r in self.data if r.get("key", "").startswith(prefix)]
+
+    def get_rules_cache_key(std, ver):
+        return f"{std}-{ver}"
+
+    class FakeRule:
+        def __init__(self, data):
+            self.data = data
+
+        @classmethod
+        def from_cdisc_metadata(cls, meta):
+            return {"core_id": meta["Core"]["Id"]}
+
+    class FakePandasDataset:
+        def __init__(self, data):
+            self.data = data
+
+    class FakeDatasetVariable:
+        def __init__(self, dataset, column_prefix_map=None, **kwargs):
+            self.dataset = dataset
+            self.column_prefix_map = column_prefix_map or {}
+            self.kwargs = kwargs
+
+    class FakeMetadata:
+        def __init__(self, name, label, first_record=None):
+            self.name = name
+            self.label = label
+            self.first_record = first_record
+            self.domain = name
+
+    class FakeCOREActions:
+        def __init__(self, output_container=None, **kwargs):
+            self.output_container = output_container if output_container is not None else []
+
+    cache_mod.InMemoryCacheService = FakeInMemoryCacheService
+    services.cache = cache_mod
+    cre.services = services
+
+    utils_mod.get_rules_cache_key = get_rules_cache_key
+    utilities.utils = utils_mod
+    cre.utilities = utilities
+
+    rule_mod.Rule = FakeRule
+    models.rule = rule_mod
+
+    pandas_mod.PandasDataset = FakePandasDataset
+    dataset_var_mod.DatasetVariable = FakeDatasetVariable
+    meta_mod.SDTMDatasetMetadata = FakeMetadata
+    actions_mod.COREActions = FakeCOREActions
+
+    # stub business_rules.engine.run
+    engine_mod = ModuleType("business_rules.engine")
+
+    def fake_run(*, rule, defined_variables, defined_actions):
+        defined_actions.output_container.append(rule)
+        return True
+
+    engine_mod.run = fake_run
+    monkeypatch.setitem(sys.modules, "business_rules", ModuleType("business_rules"))
+    monkeypatch.setitem(sys.modules, "business_rules.engine", engine_mod)
+
+    cre.models = models
+
+    class DummyManager:
+        _factory = None
+
+        @classmethod
+        def register(cls, name, factory):  # noqa: D401
+            cls._factory = factory
+
+        def start(self):
+            pass
+
+        def InMemoryCacheService(self):  # noqa: N802 - mimic actual name
+            assert self._factory is not None
+            return self._factory()
+
+    monkeypatch.setitem(sys.modules, "cdisc_rules_engine", cre)
+    monkeypatch.setitem(sys.modules, "cdisc_rules_engine.services", services)
+    monkeypatch.setitem(sys.modules, "cdisc_rules_engine.services.cache", cache_mod)
+    monkeypatch.setitem(sys.modules, "cdisc_rules_engine.utilities", utilities)
+    monkeypatch.setitem(sys.modules, "cdisc_rules_engine.utilities.utils", utils_mod)
+    monkeypatch.setitem(sys.modules, "cdisc_rules_engine.models", models)
+    monkeypatch.setitem(sys.modules, "cdisc_rules_engine.models.rule", rule_mod)
+    monkeypatch.setitem(
+        sys.modules,
+        "cdisc_rules_engine.models.dataset.pandas_dataset",
+        pandas_mod,
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "cdisc_rules_engine.models.dataset_variable",
+        dataset_var_mod,
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "cdisc_rules_engine.models.sdtm_dataset_metadata",
+        meta_mod,
+    )
+    monkeypatch.setitem(sys.modules, "cdisc_rules_engine.models.actions", actions_mod)
+    monkeypatch.setattr(cdisc, "SyncManager", DummyManager)
+
+
+def test_load_rules_cache(tmp_path, monkeypatch):
+    _setup_cdisc(monkeypatch)
+    rules = [{"key": "sdtmig-3-4-1"}]
+    with open(tmp_path / "rules.pkl", "wb") as f:
+        pickle.dump(rules, f)
+
+    cache = cdisc.load_rules_cache(str(tmp_path))
+    assert cache.get_all_by_prefix("sdtmig") == rules
+
+
+def test_get_rules(monkeypatch):
+    _setup_cdisc(monkeypatch)
+    from cdisc_rules_engine.services.cache import InMemoryCacheService
+
+    cache = InMemoryCacheService()
+    cache.add_all([{"key": "sdtmig-3-4-1"}, {"key": "adam-2-1"}])
+
+    rules = cdisc.get_rules(cache, "sdtmig", "3.4")
+    assert rules == [{"key": "sdtmig-3-4-1"}]
+
+
+def test_rule_from_metadata(monkeypatch):
+    _setup_cdisc(monkeypatch)
+    rule = cdisc.rule_from_metadata({"Core": {"Id": "CORE-1"}})
+    assert rule.data == {"core_id": "CORE-1"}
+
+
+def test_dataset_variable_from_dataframe(monkeypatch):
+    _setup_cdisc(monkeypatch)
+    import pandas as pd
+
+    df = pd.DataFrame({"AESEQ": [1]})
+    dv, meta = cdisc.dataset_variable_from_dataframe(df, "AE")
+    assert meta.name == "AE"
+    assert dv.dataset.data.equals(df)
+
+
+def test_run_business_rules(monkeypatch):
+    _setup_cdisc(monkeypatch)
+    import pandas as pd
+
+    df = pd.DataFrame({"AESEQ": [1]})
+    dv, meta = cdisc.dataset_variable_from_dataframe(df, "AE")
+    rules = [{"core_id": "R1", "domains": {"Include": ["AE"]}}]
+    results = cdisc.run_business_rules(rules, dv, meta)
+    assert results  # results should not be empty


### PR DESCRIPTION
## Summary
- add dataset helpers to run CDISC business rules
- export new helpers in `imednet.validation`
- extend tests for cdisc helpers
- document new functionality

## Testing
- `poetry run ruff check --fix .`
- `poetry run black --check .`
- `poetry run mypy imednet`
- `poetry run pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6851d4de4948832c850b6f50b5872252