### PR TITLE
Add CDISC business-rules helpers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   environment variable validation.
 - Added workflow examples `examples/workflows/extract_audit_trail.py` and
   `examples/workflows/queries_by_site.py`.
+- Added optional CDISC validation helpers for loading rules caches.
+- Added helpers for preparing datasets and running CDISC business rules.
+- Added convenience utilities for building datasets and running validations
+  using the CDISC ``RulesEngine`` class.
 - Updated imports in all example scripts to use the package root for `ImednetSDK`.
 
 ### Fixed

--- a/imednet/validation/__init__.py
+++ b/imednet/validation/__init__.py
@@ -1,4 +1,18 @@
 from .async_schema import AsyncSchemaCache, AsyncSchemaValidator
+from .cdisc import (
+    build_library_metadata,
+    create_dataset_metadata,
+    create_rules_engine,
+    dataset_variable_from_dataframe,
+    get_data_service,
+    get_datasets_metadata,
+    get_rules,
+    load_rules_cache,
+    rule_from_metadata,
+    run_business_rules,
+    validate_rules,
+    write_validation_report,
+)
 from .schema import SchemaCache, SchemaValidator, validate_record_data
 
 __all__ = [
@@ -7,4 +21,16 @@ __all__ = [
     "validate_record_data",
     "AsyncSchemaCache",
     "AsyncSchemaValidator",
+    "load_rules_cache",
+    "get_rules",
+    "rule_from_metadata",
+    "dataset_variable_from_dataframe",
+    "run_business_rules",
+    "create_dataset_metadata",
+    "get_datasets_metadata",
+    "build_library_metadata",
+    "get_data_service",
+    "create_rules_engine",
+    "validate_rules",
+    "write_validation_report",
 ]

--- a/imednet/validation/cdisc.py
+++ b/imednet/validation/cdisc.py
@@ -1,0 +1,325 @@
+"""Utilities for working with the CDISC Rules Engine."""
+
+from __future__ import annotations
+
+import os
+import pathlib
+import pickle
+from multiprocessing.managers import SyncManager
+from typing import TYPE_CHECKING, Any, List
+
+if TYPE_CHECKING:  # pragma: no cover - imported for type checking only
+    import pandas as pd
+
+
+def load_rules_cache(path_to_rules_cache: str) -> Any:
+    """Load CDISC rule definitions from ``path_to_rules_cache``.
+
+    Parameters
+    ----------
+    path_to_rules_cache:
+        Directory containing pickled rule files as distributed with the
+        ``cdisc-rules-engine`` package.
+    """
+    from cdisc_rules_engine.services.cache import InMemoryCacheService
+
+    class CacheManager(SyncManager):
+        pass
+
+    CacheManager.register("InMemoryCacheService", InMemoryCacheService)
+
+    cache_path = pathlib.Path(path_to_rules_cache)
+    manager = CacheManager()
+    manager.start()
+    cache: Any = manager.InMemoryCacheService()  # type: ignore[attr-defined]
+
+    files = next(os.walk(cache_path), (None, None, []))[2]
+    for fname in files:
+        with open(cache_path / fname, "rb") as f:
+            cache.add_all(pickle.load(f))
+
+    return cache
+
+
+def get_rules(cache: Any, standard: str, version: str) -> List[dict]:
+    """Return rules for the given standard and version from ``cache``."""
+    from cdisc_rules_engine.utilities.utils import get_rules_cache_key
+
+    cache_key_prefix = get_rules_cache_key(standard, version.replace(".", "-"))
+    return cache.get_all_by_prefix(cache_key_prefix)
+
+
+def rule_from_metadata(rule_metadata: dict) -> Any:
+    """Construct a ``Rule`` object from CDISC rule metadata."""
+    from cdisc_rules_engine.models.rule import Rule
+
+    rule_dict = Rule.from_cdisc_metadata(rule_metadata)
+    return Rule(rule_dict)
+
+
+def dataset_variable_from_dataframe(
+    data: "pd.DataFrame", domain: str, label: str | None = None
+) -> tuple[Any, Any]:
+    """Return a dataset variable and metadata for ``data``.
+
+    Parameters
+    ----------
+    data:
+        Dataframe containing the dataset to validate.
+    domain:
+        Dataset domain name (e.g. "AE").
+    label:
+        Optional human readable label for the dataset.
+    """
+    import pandas as pd
+    from cdisc_rules_engine.models.dataset.pandas_dataset import PandasDataset
+    from cdisc_rules_engine.models.dataset_variable import DatasetVariable
+    from cdisc_rules_engine.models.sdtm_dataset_metadata import SDTMDatasetMetadata
+
+    if not isinstance(data, pd.DataFrame):
+        raise TypeError("data must be a pandas DataFrame")
+
+    pandas_dataset = PandasDataset(data=data)
+    metadata = SDTMDatasetMetadata(
+        name=domain,
+        label=label or domain,
+        first_record=data.iloc[0].to_dict() if not data.empty else None,
+    )
+    dataset_variable = DatasetVariable(
+        pandas_dataset,
+        column_prefix_map={"--": metadata.domain},
+    )
+    return dataset_variable, metadata
+
+
+def run_business_rules(
+    rules: List[dict],
+    dataset_variable: Any,
+    dataset_metadata: Any,
+    *,
+    value_level_metadata: Any | None = None,
+) -> List[Any]:
+    """Execute business rules against ``dataset_variable``.
+
+    Returns a list of results from triggered rules.
+    """
+    from business_rules.engine import run
+    from cdisc_rules_engine.models.actions import COREActions
+
+    all_results: List[Any] = []
+    for rule in rules:
+        results: list[Any] = []
+        actions = COREActions(
+            output_container=results,
+            variable=dataset_variable,
+            dataset_metadata=dataset_metadata,
+            rule=rule,
+            value_level_metadata=value_level_metadata,
+        )
+        try:
+            triggered = run(
+                rule=rule,
+                defined_variables=dataset_variable,
+                defined_actions=actions,
+            )
+        except Exception:
+            continue
+        if triggered and results:
+            all_results.extend(results)
+    return all_results
+
+
+# Option B helpers
+
+
+def create_dataset_metadata(file_path: str) -> Any:
+    """Create dataset metadata from an XPT file."""
+    import pyreadstat
+    from cdisc_rules_engine.models.sdtm_dataset_metadata import SDTMDatasetMetadata
+
+    try:
+        data, meta = pyreadstat.read_xport(file_path)
+        first_record = data.iloc[0].to_dict() if not data.empty else None
+        return SDTMDatasetMetadata(
+            name=os.path.basename(file_path).split(".")[0].upper(),
+            label=getattr(meta, "file_label", ""),
+            filename=os.path.basename(file_path),
+            full_path=file_path,
+            file_size=os.path.getsize(file_path),
+            record_count=len(data),
+            first_record=first_record,
+        )
+    except Exception:
+        return None
+
+
+def get_datasets_metadata(directory: str) -> List[Any]:
+    """Return list of metadata objects for all XPT files in ``directory``."""
+
+    datasets: List[Any] = []
+    for file in os.listdir(directory):
+        if file.lower().endswith(".xpt"):
+            file_path = os.path.join(directory, file)
+            meta = create_dataset_metadata(file_path)
+            if meta:
+                datasets.append(meta)
+    return datasets
+
+
+def build_library_metadata(
+    cache: Any,
+    standard: str,
+    standard_version: str,
+    standard_substandard: str | None = None,
+    ct_packages: List[str] | None = None,
+) -> Any:
+    """Create a library metadata container from ``cache``."""
+    from cdisc_rules_engine.models.library_metadata_container import (
+        LibraryMetadataContainer,
+    )
+    from cdisc_rules_engine.utilities.utils import (
+        get_library_variables_metadata_cache_key,
+        get_model_details_cache_key_from_ig,
+        get_standard_details_cache_key,
+        get_variable_codelist_map_cache_key,
+    )
+
+    standard_details_cache_key = get_standard_details_cache_key(
+        standard, standard_version, standard_substandard
+    )
+    variable_details_cache_key = get_library_variables_metadata_cache_key(
+        standard, standard_version, standard_substandard
+    )
+
+    standard_metadata = cache.get(standard_details_cache_key)
+    model_metadata = {}
+    if standard_metadata:
+        model_cache_key = get_model_details_cache_key_from_ig(standard_metadata)
+        model_metadata = cache.get(model_cache_key)
+
+    variable_codelist_cache_key = get_variable_codelist_map_cache_key(
+        standard, standard_version, standard_substandard
+    )
+
+    ct_package_metadata = {pkg: cache.get(pkg) for pkg in (ct_packages or [])}
+
+    return LibraryMetadataContainer(
+        standard_metadata=standard_metadata,
+        model_metadata=model_metadata,
+        variables_metadata=cache.get(variable_details_cache_key),
+        variable_codelist_map=cache.get(variable_codelist_cache_key),
+        ct_package_metadata=ct_package_metadata,
+    )
+
+
+def get_data_service(
+    dataset_paths: List[str],
+    cache: Any,
+    standard: str,
+    standard_version: str,
+    standard_substandard: str | None,
+    library_metadata: Any,
+    max_dataset_size: int,
+) -> Any:
+    """Return a data service for the given dataset paths."""
+    from cdisc_rules_engine.config import config as default_config
+    from cdisc_rules_engine.services.data_services import DataServiceFactory
+
+    factory = DataServiceFactory(
+        config=default_config,
+        cache_service=cache,
+        standard=standard,
+        standard_version=standard_version,
+        standard_substandard=standard_substandard,
+        library_metadata=library_metadata,
+        max_dataset_size=max_dataset_size,
+    )
+    return factory.get_data_service(dataset_paths)
+
+
+def create_rules_engine(
+    cache: Any,
+    data_service: Any,
+    library_metadata: Any,
+    standard: str,
+    standard_version: str,
+    dataset_paths: List[str],
+    *,
+    ct_packages: List[str] | None = None,
+    define_xml_path: str | None = None,
+    validate_xml: bool = False,
+    standard_substandard: str | None = None,
+    max_dataset_size: int = 0,
+) -> Any:
+    """Instantiate a ``RulesEngine`` for validation."""
+    from cdisc_rules_engine.config import config as default_config
+    from cdisc_rules_engine.rules_engine import RulesEngine
+
+    return RulesEngine(
+        cache=cache,
+        data_service=data_service,
+        config_obj=default_config,
+        external_dictionaries=None,
+        standard=standard,
+        standard_version=standard_version,
+        standard_substandard=standard_substandard,
+        library_metadata=library_metadata,
+        max_dataset_size=max_dataset_size,
+        dataset_paths=dataset_paths,
+        ct_packages=ct_packages,
+        define_xml_path=define_xml_path,
+        validate_xml=validate_xml,
+    )
+
+
+def validate_rules(rules_engine: Any, rules: List[dict], datasets: List[Any]) -> List[Any]:
+    """Validate each rule against ``datasets`` using ``rules_engine``."""
+    from cdisc_rules_engine.models.rule_conditions import ConditionCompositeFactory
+    from cdisc_rules_engine.models.rule_validation_result import RuleValidationResult
+
+    results: List[Any] = []
+    for rule in rules:
+        if isinstance(rule.get("conditions"), dict):
+            rule["conditions"] = ConditionCompositeFactory.get_condition_composite(
+                rule["conditions"]
+            )
+        domain_results = rules_engine.validate_single_rule(rule, datasets)
+        flattened: List[Any] = []
+        for domain in domain_results.values():
+            flattened.extend(domain)
+        results.append(RuleValidationResult(rule, flattened))
+    return results
+
+
+def write_validation_report(validation_results: List[Any], output_file: str) -> None:
+    """Write ``validation_results`` to ``output_file``."""
+    import json
+
+    with open(output_file, "w") as f:
+        for result in validation_results:
+            rule_id = result.rule.get("core_id", "Unknown")
+            f.write(f"Rule: {rule_id}\n")
+            violations = getattr(result, "violations", None)
+            if violations:
+                f.write(f"Found {len(violations)} violations\n")
+                for v in violations:
+                    f.write(f"  - {json.dumps(v, default=str)}\n")
+            else:
+                f.write("  No violations found\n")
+            f.write("\n")
+
+
+__all__ = [
+    "load_rules_cache",
+    "get_rules",
+    "rule_from_metadata",
+    "dataset_variable_from_dataframe",
+    "run_business_rules",
+    "create_dataset_metadata",
+    "get_datasets_metadata",
+    "build_library_metadata",
+    "get_data_service",
+    "create_rules_engine",
+    "validate_rules",
+    "write_validation_report",
+]

--- a/tests/unit/test_cdisc_rules.py
+++ b/tests/unit/test_cdisc_rules.py
@@ -1,0 +1,320 @@
+import pickle
+import sys
+from types import ModuleType
+
+import imednet.validation.cdisc as cdisc
+
+
+class FakeInMemoryCacheService:
+    def __init__(self):
+        self.data = []
+
+    def add_all(self, data):
+        self.data.extend(data)
+
+    def get_all_by_prefix(self, prefix):
+        return [r for r in self.data if r.get("key", "").startswith(prefix)]
+
+    def get(self, key):
+        for item in self.data:
+            if item.get("key") == key:
+                return item
+        return None
+
+
+def get_rules_cache_key(std, ver):
+    return f"{std}-{ver}"
+
+
+class FakeRule:
+    def __init__(self, data):
+        self.data = data
+
+    @classmethod
+    def from_cdisc_metadata(cls, meta):
+        return {"core_id": meta["Core"]["Id"]}
+
+
+class FakePandasDataset:
+    def __init__(self, data):
+        self.data = data
+
+
+class FakeDatasetVariable:
+    def __init__(self, dataset, column_prefix_map=None, **kwargs):
+        self.dataset = dataset
+        self.column_prefix_map = column_prefix_map or {}
+        self.kwargs = kwargs
+
+
+class FakeMetadata:
+    def __init__(self, name, label, first_record=None):
+        self.name = name
+        self.label = label
+        self.first_record = first_record
+        self.domain = name
+
+
+class FakeCOREActions:
+    def __init__(self, output_container=None, **kwargs):
+        self.output_container = output_container if output_container is not None else []
+
+
+class FakeLibraryMetadataContainer:
+    def __init__(self, **kwargs):
+        self.kwargs = kwargs
+
+
+class FakeDataServiceFactory:
+    def __init__(self, **kwargs):
+        self.kwargs = kwargs
+
+    def get_data_service(self, paths):
+        return {"paths": paths, "kwargs": self.kwargs}
+
+
+class FakeRulesEngine:
+    def __init__(self, **kwargs):
+        self.kwargs = kwargs
+
+    def validate_single_rule(self, rule, datasets):
+        return {"AE": [{"violation": rule["core_id"]}]}
+
+
+class FakeConditionCompositeFactory:
+    @staticmethod
+    def get_condition_composite(cond):
+        return {"wrapped": cond}
+
+
+class FakeRuleValidationResult:
+    def __init__(self, rule, violations):
+        self.rule = rule
+        self.violations = violations
+
+
+def _setup_cdisc(monkeypatch):
+    _cre = ModuleType("cdisc_rules_engine")
+    _services = ModuleType("cdisc_rules_engine.services")
+    _cache_mod = ModuleType("cdisc_rules_engine.services.cache")
+    _utilities = ModuleType("cdisc_rules_engine.utilities")
+    _utils_mod = ModuleType("cdisc_rules_engine.utilities.utils")
+    _models = ModuleType("cdisc_rules_engine.models")
+    _rule_mod = ModuleType("cdisc_rules_engine.models.rule")
+    _pandas_mod = ModuleType("cdisc_rules_engine.models.dataset.pandas_dataset")
+    _dataset_var_mod = ModuleType("cdisc_rules_engine.models.dataset_variable")
+    _meta_mod = ModuleType("cdisc_rules_engine.models.sdtm_dataset_metadata")
+    _actions_mod = ModuleType("cdisc_rules_engine.models.actions")
+    _lib_meta_mod = ModuleType("cdisc_rules_engine.models.library_metadata_container")
+    _data_services_mod = ModuleType("cdisc_rules_engine.services.data_services")
+    _config_mod = ModuleType("cdisc_rules_engine.config")
+    _rules_engine_mod = ModuleType("cdisc_rules_engine.rules_engine")
+    _cond_mod = ModuleType("cdisc_rules_engine.models.rule_conditions")
+    _result_mod = ModuleType("cdisc_rules_engine.models.rule_validation_result")
+    _pyreadstat_mod = ModuleType("pyreadstat")
+
+    _cache_mod.InMemoryCacheService = FakeInMemoryCacheService
+    _services.cache = _cache_mod
+    _cre.services = _services
+
+    _utils_mod.get_rules_cache_key = get_rules_cache_key
+    _utilities.utils = _utils_mod
+    _cre.utilities = _utilities
+
+    _rule_mod.Rule = FakeRule
+    _models.rule = _rule_mod
+
+    _pandas_mod.PandasDataset = FakePandasDataset
+    _dataset_var_mod.DatasetVariable = FakeDatasetVariable
+    _meta_mod.SDTMDatasetMetadata = FakeMetadata
+    _actions_mod.COREActions = FakeCOREActions
+    _lib_meta_mod.LibraryMetadataContainer = FakeLibraryMetadataContainer
+    _data_services_mod.DataServiceFactory = FakeDataServiceFactory
+    _config_mod.config = {}
+    _rules_engine_mod.RulesEngine = FakeRulesEngine
+    _cond_mod.ConditionCompositeFactory = FakeConditionCompositeFactory
+    _result_mod.RuleValidationResult = FakeRuleValidationResult
+
+    def fake_read_xport(path):
+        import pandas as pd
+
+        return pd.DataFrame({"A": [1]}), type("Meta", (), {"file_label": "lbl"})
+
+    _pyreadstat_mod.read_xport = fake_read_xport
+
+    # stub business_rules.engine.run
+    engine_mod = ModuleType("business_rules.engine")
+
+    def fake_run(*, rule, defined_variables, defined_actions):
+        defined_actions.output_container.append(rule)
+        return True
+
+    engine_mod.run = fake_run
+    monkeypatch.setitem(sys.modules, "business_rules", ModuleType("business_rules"))
+    monkeypatch.setitem(sys.modules, "business_rules.engine", engine_mod)
+
+    _cre.models = _models
+
+    class DummyManager:
+        _factory = None
+
+        @classmethod
+        def register(cls, name, factory):  # noqa: D401
+            cls._factory = factory
+
+        def start(self):
+            pass
+
+        def InMemoryCacheService(self):  # noqa: N802 - mimic actual name
+            assert self._factory is not None
+            return self._factory()
+
+    monkeypatch.setitem(sys.modules, "cdisc_rules_engine", _cre)
+    monkeypatch.setitem(sys.modules, "cdisc_rules_engine.services", _services)
+    monkeypatch.setitem(sys.modules, "cdisc_rules_engine.services.cache", _cache_mod)
+    monkeypatch.setitem(sys.modules, "cdisc_rules_engine.utilities", _utilities)
+    monkeypatch.setitem(sys.modules, "cdisc_rules_engine.utilities.utils", _utils_mod)
+    monkeypatch.setitem(sys.modules, "cdisc_rules_engine.models", _models)
+    monkeypatch.setitem(sys.modules, "cdisc_rules_engine.models.rule", _rule_mod)
+    monkeypatch.setitem(
+        sys.modules,
+        "cdisc_rules_engine.models.dataset.pandas_dataset",
+        _pandas_mod,
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "cdisc_rules_engine.models.dataset_variable",
+        _dataset_var_mod,
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "cdisc_rules_engine.models.sdtm_dataset_metadata",
+        _meta_mod,
+    )
+    monkeypatch.setitem(sys.modules, "cdisc_rules_engine.models.actions", _actions_mod)
+    monkeypatch.setitem(
+        sys.modules,
+        "cdisc_rules_engine.models.library_metadata_container",
+        _lib_meta_mod,
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "cdisc_rules_engine.services.data_services",
+        _data_services_mod,
+    )
+    monkeypatch.setitem(sys.modules, "cdisc_rules_engine.config", _config_mod)
+    monkeypatch.setitem(sys.modules, "cdisc_rules_engine.rules_engine", _rules_engine_mod)
+    monkeypatch.setitem(
+        sys.modules,
+        "cdisc_rules_engine.models.rule_conditions",
+        _cond_mod,
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "cdisc_rules_engine.models.rule_validation_result",
+        _result_mod,
+    )
+    monkeypatch.setitem(sys.modules, "pyreadstat", _pyreadstat_mod)
+    monkeypatch.setattr(cdisc, "SyncManager", DummyManager)
+
+
+def test_load_rules_cache(tmp_path, monkeypatch):
+    _setup_cdisc(monkeypatch)
+    rules = [{"key": "sdtmig-3-4-1"}]
+    with open(tmp_path / "rules.pkl", "wb") as f:
+        pickle.dump(rules, f)
+
+    cache = cdisc.load_rules_cache(str(tmp_path))
+    assert cache.get_all_by_prefix("sdtmig") == rules
+
+
+def test_get_rules(monkeypatch):
+    _setup_cdisc(monkeypatch)
+    from cdisc_rules_engine.services.cache import InMemoryCacheService
+
+    cache = InMemoryCacheService()
+    cache.add_all([{"key": "sdtmig-3-4-1"}, {"key": "adam-2-1"}])
+
+    rules = cdisc.get_rules(cache, "sdtmig", "3.4")
+    assert rules == [{"key": "sdtmig-3-4-1"}]
+
+
+def test_rule_from_metadata(monkeypatch):
+    _setup_cdisc(monkeypatch)
+    rule = cdisc.rule_from_metadata({"Core": {"Id": "CORE-1"}})
+    assert rule.data == {"core_id": "CORE-1"}
+
+
+def test_dataset_variable_from_dataframe(monkeypatch):
+    _setup_cdisc(monkeypatch)
+    import pandas as pd
+
+    df = pd.DataFrame({"AESEQ": [1]})
+    dv, meta = cdisc.dataset_variable_from_dataframe(df, "AE")
+    assert meta.name == "AE"
+    assert dv.dataset.data.equals(df)
+
+
+def test_run_business_rules(monkeypatch):
+    _setup_cdisc(monkeypatch)
+    import pandas as pd
+
+    df = pd.DataFrame({"AESEQ": [1]})
+    dv, meta = cdisc.dataset_variable_from_dataframe(df, "AE")
+    rules = [{"core_id": "R1", "domains": {"Include": ["AE"]}}]
+    results = cdisc.run_business_rules(rules, dv, meta)
+    assert results  # results should not be empty
+
+
+def test_create_dataset_metadata(tmp_path, monkeypatch):
+    _setup_cdisc(monkeypatch)
+    xpt = tmp_path / "ae.xpt"
+    xpt.write_bytes(b"")
+    meta = cdisc.create_dataset_metadata(str(xpt))
+    assert meta.name == "AE"
+    assert meta.filename == "ae.xpt"
+    assert meta.record_count == 1
+
+
+def test_get_datasets_metadata(tmp_path, monkeypatch):
+    _setup_cdisc(monkeypatch)
+    (tmp_path / "ae.xpt").write_bytes(b"")
+    (tmp_path / "dm.xpt").write_bytes(b"")
+    metas = cdisc.get_datasets_metadata(str(tmp_path))
+    assert len(metas) == 2
+
+
+def test_validate_rules(monkeypatch):
+    _setup_cdisc(monkeypatch)
+    datasets = [object()]
+    engine = cdisc.create_rules_engine(
+        cache=None,
+        data_service=None,
+        library_metadata=None,
+        standard="sdtmig",
+        standard_version="3-4",
+        dataset_paths=[],
+    )
+    rules = [{"core_id": "R1", "conditions": {"any": []}}]
+    results = cdisc.validate_rules(engine, rules, datasets)
+    assert results and results[0].violations
+
+
+def test_write_validation_report(tmp_path, monkeypatch):
+    _setup_cdisc(monkeypatch)
+    result = cdisc.validate_rules(
+        cdisc.create_rules_engine(
+            cache=None,
+            data_service=None,
+            library_metadata=None,
+            standard="sdtmig",
+            standard_version="3-4",
+            dataset_paths=[],
+        ),
+        [{"core_id": "R1", "conditions": {}}],
+        [object()],
+    )[0]
+    out = tmp_path / "report.txt"
+    cdisc.write_validation_report([result], str(out))
+    text = out.read_text()
+    assert "Rule: R1" in text


### PR DESCRIPTION
## Summary
- add dataset helpers to run CDISC business rules
- export new helpers in `imednet.validation`
- extend tests for cdisc helpers
- document new functionality
- implement RulesEngine dataset utilities

## Testing
- `poetry run ruff check --fix .`
- `poetry run black --check .`
- `poetry run mypy imednet`
- `poetry run pytest -q` *(fails: ModuleNotFoundError: No module named 'faker')*

------
https://chatgpt.com/codex/tasks/task_e_6851d4de4948832c850b6f50b5872252