### PR TITLE
Update docs to use iMednet spelling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added workflow examples `examples/workflows/extract_audit_trail.py` and
   `examples/workflows/queries_by_site.py`.
 - Updated imports in all example scripts to use the package root for `ImednetSDK`.
+- Updated documentation examples to import `ImednetSDK` from the package root.
 
 ### Fixed
 
@@ -36,7 +37,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Initial Features
 
-- Initial release of the iMedNet Python SDK.
+- Initial release of the iMednet Python SDK.
 - Core client (`ImednetClient`) for handling API requests, authentication, and errors.
 - Endpoints for Studies, Sites, Users, Intervals, Forms, Variables, Records, Subjects, Visits, Queries, Jobs, Codings, Record Revisions.
 - Pydantic models for all API resources with validation.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,4 @@
-# Contributing to iMedNet Python SDK
+# Contributing to iMednet Python SDK
 
 We love your input! We want to make contributing to this project as easy and transparent as possible, whether it's:
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 [![Contributor Covenant](https://img.shields.io/badge/Contributor%20Covenant-v2.1-4baaaa.svg)](CODE_OF_CONDUCT.md)
 [![Last commit](https://img.shields.io/github/last-commit/fderuiter/imednet-python-sdk.svg)](https://github.com/fderuiter/imednet-python-sdk/commits/main)
 
-A Python SDK for interacting with the iMedNet REST API. Provides client, endpoint wrappers, and data models for all resources.
+A Python SDK for interacting with the iMednet REST API. Provides client, endpoint wrappers, and data models for all resources.
 
 See the [Changelog](CHANGELOG.md) for release history.
 
@@ -66,7 +66,7 @@ environment variables.
 
 ## Usage
 
-First, ensure you have set your iMedNet API credentials as environment variables.
+First, ensure you have set your iMednet API credentials as environment variables.
 Keep these keys secure and never commit them to source control:
 
 ```powershell

--- a/docs/imednet.rst
+++ b/docs/imednet.rst
@@ -1,6 +1,12 @@
 imednet package
 ===============
 
+The main SDK classes are available directly from the package root:
+
+.. code-block:: python
+
+   from imednet import ImednetSDK, AsyncImednetSDK
+
 Subpackages
 -----------
 

--- a/docs/job_polling.rst
+++ b/docs/job_polling.rst
@@ -25,7 +25,7 @@ behavior in asynchronous code.
 
 .. code-block:: python
 
-   from imednet.sdk import ImednetSDK, AsyncImednetSDK
+   from imednet import ImednetSDK, AsyncImednetSDK
 
    # synchronous
    sdk = ImednetSDK()

--- a/docs/live_test_plan.rst
+++ b/docs/live_test_plan.rst
@@ -1,7 +1,7 @@
 Live (End-to-End) Test Plan
 ===========================
 
-These tests execute against a real iMedNet environment. They are skipped by default
+These tests execute against a real iMednet environment. They are skipped by default
 and require ``IMEDNET_RUN_E2E=1`` with valid credentials. Each item below should be
 covered by a dedicated test case so failures are easy to diagnose.
 

--- a/docs/live_tests.rst
+++ b/docs/live_tests.rst
@@ -2,7 +2,7 @@ Live Test Overview
 ==================
 
 This document summarizes the end-to-end tests located in ``tests/live``. These tests
-execute against a real iMedNet environment and are skipped unless the environment
+execute against a real iMednet environment and are skipped unless the environment
 variable ``IMEDNET_RUN_E2E=1`` is set along with valid credentials (``IMEDNET_API_KEY``
 and ``IMEDNET_SECURITY_KEY``). Each test verifies that the SDK behaves correctly
 when interacting with a running server.
@@ -86,4 +86,4 @@ The ``imednet.testing.fake_data`` module offers helper functions for generating 
 
 Expected Results
 ----------------
-All live tests should pass when run against a properly configured iMedNet environment. Each test ensures that API calls succeed without raising exceptions and that any created files or returned objects match the requested parameters. Failures typically indicate connectivity issues or a mismatch between the SDK and server APIs.
+All live tests should pass when run against a properly configured iMednet environment. Each test ensures that API calls succeed without raising exceptions and that any created files or returned objects match the requested parameters. Failures typically indicate connectivity issues or a mismatch between the SDK and server APIs.

--- a/docs/test_skip_conditions.rst
+++ b/docs/test_skip_conditions.rst
@@ -7,7 +7,7 @@ runs match the behaviour seen in CI.
 
 End-to-End Tests
 ----------------
-The files under ``tests/live`` exercise the SDK against a real iMedNet
+The files under ``tests/live`` exercise the SDK against a real iMednet
 environment. All of these tests are skipped unless ``IMEDNET_RUN_E2E=1`` and valid
 credentials are supplied via ``IMEDNET_API_KEY`` and ``IMEDNET_SECURITY_KEY``
 (optionally ``IMEDNET_BASE_URL``).

--- a/examples/basic/get_subjects.py
+++ b/examples/basic/get_subjects.py
@@ -1,15 +1,15 @@
 from imednet import ImednetSDK as ImednetClient
 
 """
-Example script demonstrating how to retrieve subjects from IMedNet studies using the IMedNet SDK.
+Example script demonstrating how to retrieve subjects from iMednet studies using the iMednet SDK.
 This script:
-1. Initializes the IMedNet client with API credentials
+1. Initializes the iMednet client with API credentials
 2. Retrieves a list of available studies
 3. For the first study, retrieves and displays information about its subjects
 4. Prints the subject key and status for up to 5 subjects
 Required environment variables or configurations:
-    - api_key (str): Your IMedNet API key
-    - security_key (str): Your IMedNet security key
+    - api_key (str): Your iMednet API key
+    - security_key (str): Your iMednet security key
     - base_url (str, optional): Custom base URL for the API endpoint
     - study_key (str): The study identifier
 Returns:

--- a/examples/basic/get_users.py
+++ b/examples/basic/get_users.py
@@ -1,9 +1,9 @@
 from imednet import ImednetSDK as ImednetClient
 
 """
-Example script demonstrating how to retrieve users from an iMedNet study using the iMedNet SDK.
+Example script demonstrating how to retrieve users from an iMednet study using the iMednet SDK.
 This script shows how to:
-1. Initialize the iMedNet SDK client with authentication credentials
+1. Initialize the iMednet SDK client with authentication credentials
 2. List available studies
 3. Get users for the first study
 4. Print basic user information for up to 5 users

--- a/examples/basic/get_variables.py
+++ b/examples/basic/get_variables.py
@@ -5,11 +5,11 @@ import os
 from imednet import ImednetSDK as ImednetClient
 
 """
-A script to retrieve and save study variables from the iMedNet API.
-This script connects to the iMedNet API, retrieves a list of studies and their variables,
+A script to retrieve and save study variables from the iMednet API.
+This script connects to the iMednet API, retrieves a list of studies and their variables,
 and saves the variable information in both JSON and CSV formats.
 The script performs the following operations:
-1. Connects to iMedNet API using provided credentials
+1. Connects to iMednet API using provided credentials
 2. Retrieves list of available studies
 3. For the first study found:
     - Gets all variables for that study
@@ -17,8 +17,8 @@ The script performs the following operations:
     - Saves variables data to CSV file with flattened structure
     - Prints first 5 variables basic information
 Required Environment Variables or Constants:
-     api_key (str): iMedNet API key
-     security_key (str): iMedNet security key
+     api_key (str): iMednet API key
+     security_key (str): iMednet security key
      base_url (str, optional): Custom base URL for the API
      study_key (str): Study identifier key
 Output Files:

--- a/examples/basic/get_visits.py
+++ b/examples/basic/get_visits.py
@@ -1,15 +1,15 @@
 from imednet import ImednetSDK as ImednetClient
 
 """
-Example script demonstrating how to retrieve visits from the IMedNet API.
+Example script demonstrating how to retrieve visits from the iMednet API.
 This script showcases:
-1. Connecting to the IMedNet API using the SDK client
+1. Connecting to the iMednet API using the SDK client
 2. Listing available studies
 3. Retrieving visits for the first study
 4. Displaying basic visit information
 Requirements:
     - imednet
-    - Valid IMedNet API credentials (api_key and security_key)
+    - Valid iMednet API credentials (api_key and security_key)
 Returns:
     Prints the number of visits for the first study and displays details of up to 5 visits
     including their visit IDs and subject keys.

--- a/examples/post_register_subjects.py
+++ b/examples/post_register_subjects.py
@@ -5,7 +5,7 @@ from imednet import ImednetSDK
 from imednet.workflows.register_subjects import RegisterSubjectsWorkflow
 
 """
-Example script demonstrating how to register multiple subjects in an iMedNet study.
+Example script demonstrating how to register multiple subjects in an iMednet study.
 This script initializes the ImednetSDK and the RegisterSubjectsWorkflow.
 It reads subject data from a JSON file (`sample_subjects.json`) located
 in the ``register_subjects_input`` subdirectory relative to the script's location.
@@ -14,14 +14,14 @@ A copy of ``sample_subjects.json`` is included in this repository under
 The script then uses the workflow's ``register_subjects`` method to register all
 subjects defined in the JSON file for the specified study.
 The script requires API credentials (api_key, security_key) and the study_key
-to be set. The base_url can optionally be set for custom iMedNet instances.
+to be set. The base_url can optionally be set for custom iMednet instances.
 It prints the result of the registration process or an error message if
 the registration fails.
 Attributes:
-    api_key (str): The API key for iMedNet authentication.
-    security_key (str): The security key for iMedNet authentication.
-    base_url (str | None): The base URL of the iMedNet instance. Defaults to None,
-        which uses the standard iMedNet production URL.
+    api_key (str): The API key for iMednet authentication.
+    security_key (str): The security key for iMednet authentication.
+    base_url (str | None): The base URL of the iMednet instance. Defaults to None,
+        which uses the standard iMednet production URL.
     study_key (str): The unique identifier for the target study.
     input_path (str): The file path to the JSON file containing the subject data.
 """

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ imednet = "imednet.cli:app"
 [tool.poetry]
 name = "imednet"
 version = "0.1.0"
-description = "Official Python client for the iMedNet clinical trials API"
+description = "Official Python client for the iMednet clinical trials API"
 readme = "README.md"
 keywords = ["imednet", "clinical trials", "sdk", "api"]
 classifiers = [


### PR DESCRIPTION
## Summary
- standardize the `iMednet` spelling across documentation
- update examples to mention `iMednet`
- fix packaging description

## Testing
- `poetry run ruff check --fix .`
- `poetry run black --check .`
- `poetry run mypy imednet`
- `poetry run pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685c588d00c4832c8a4f867a89b03a82