### PR TITLE
Add PagedEndpointMixin for endpoint pagination

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Documented caching thread-safety and added a quick start guide.
 - Added `examples/quick_start.py` demonstrating minimal SDK usage with
   environment variable validation.
+- Consolidated paginated endpoint logic via new ``PagedEndpointMixin`` and
+  updated endpoints accordingly.
 - Renamed the project from `imednet-sdk` to `imednet` and updated repository links to `fderuiter/imednet-python-sdk`.
 - Added workflow examples `examples/workflows/extract_audit_trail.py` and
   `examples/workflows/queries_by_site.py`.

--- a/README.md
+++ b/README.md
@@ -31,8 +31,9 @@ https://portal.prod.imednetapi.com/
 - Async client and CLI for common tasks
 
 Calls to `sdk.studies.list()`, `sdk.forms.list()`, `sdk.intervals.list()` and
-`sdk.variables.list()` cache results in memory. Pass `refresh=True` to bypass
-the cache. See `docs/caching.rst` for details.
+`sdk.variables.list()` cache results in memory via a shared
+``PagedEndpointMixin``. Pass ``refresh=True`` to bypass the cache. See
+`docs/caching.rst` for details.
 
 ## Installation
 

--- a/docs/caching.rst
+++ b/docs/caching.rst
@@ -7,7 +7,7 @@ Endpoint Caches
 ---------------
 
 The endpoints for studies, forms, variables and intervals maintain simple in-memory
-caches. When `list()` or `async_list()` is called without any filters, the
+caches implemented by ``PagedEndpointMixin``. When `list()` or `async_list()` is called without any filters, the
 results are stored on the endpoint instance. Subsequent calls return the cached
 list instead of performing another request. Passing ``refresh=True`` bypasses the
 cache and stores the fresh response.

--- a/imednet/endpoints/__init__.py
+++ b/imednet/endpoints/__init__.py
@@ -8,6 +8,7 @@ from imednet.endpoints.codings import CodingsEndpoint
 from imednet.endpoints.forms import FormsEndpoint
 from imednet.endpoints.intervals import IntervalsEndpoint
 from imednet.endpoints.jobs import JobsEndpoint
+from imednet.endpoints.paged_endpoint_mixin import PagedEndpointMixin
 from imednet.endpoints.queries import QueriesEndpoint
 from imednet.endpoints.record_revisions import RecordRevisionsEndpoint
 from imednet.endpoints.records import RecordsEndpoint
@@ -23,6 +24,7 @@ __all__: list[str] = [
     "FormsEndpoint",
     "IntervalsEndpoint",
     "JobsEndpoint",
+    "PagedEndpointMixin",
     "QueriesEndpoint",
     "RecordRevisionsEndpoint",
     "RecordsEndpoint",

--- a/imednet/endpoints/codings.py
+++ b/imednet/endpoints/codings.py
@@ -1,80 +1,21 @@
 """Endpoint for managing codings (medical coding) in a study."""
 
-import inspect
-from typing import Any, Dict, List, Optional
+from typing import Any, List, Optional
 
 from imednet.core.paginator import AsyncPaginator, Paginator
-from imednet.endpoints.base import BaseEndpoint
+from imednet.endpoints.paged_endpoint_mixin import PagedEndpointMixin
 from imednet.models.codings import Coding
-from imednet.utils.filters import build_filter_string
 
 
-class CodingsEndpoint(BaseEndpoint):
-    """
-    API endpoint for interacting with codings (medical coding) in an iMedNet study.
-
-    Provides methods to list and retrieve individual codings.
-    """
+class CodingsEndpoint(PagedEndpointMixin):
+    """API endpoint for interacting with codings in an iMedNet study."""
 
     PATH = "/api/v1/edc/studies"
+    MODEL = Coding
+    PATH_SUFFIX = "codings"
+    ID_FILTER = "codingId"
 
-    def _list_impl(
-        self,
-        client: Any,
-        paginator_cls: type[Any],
-        *,
-        study_key: Optional[str] = None,
-        **filters: Any,
-    ) -> Any:
-        filters = self._auto_filter(filters)
-        if study_key:
-            filters["studyKey"] = study_key
-
-        study = filters.pop("studyKey")
-        if not study:
-            raise ValueError("Study key must be provided or set in the context")
-
-        params: Dict[str, Any] = {}
-        if filters:
-            params["filter"] = build_filter_string(filters)
-
-        path = self._build_path(study, "codings")
-        paginator = paginator_cls(client, path, params=params)
-
-        if hasattr(paginator, "__aiter__"):
-
-            async def _collect() -> List[Coding]:
-                return [Coding.from_json(item) async for item in paginator]
-
-            return _collect()
-
-        return [Coding.from_json(item) for item in paginator]
-
-    def _get_impl(
-        self, client: Any, paginator_cls: type[Any], study_key: str, coding_id: str
-    ) -> Any:
-        result = self._list_impl(
-            client,
-            paginator_cls,
-            study_key=study_key,
-            codingId=coding_id,
-        )
-
-        if inspect.isawaitable(result):
-
-            async def _await() -> Coding:
-                items = await result
-                if not items:
-                    raise ValueError(f"Coding {coding_id} not found in study {study_key}")
-                return items[0]
-
-            return _await()
-
-        if not result:
-            raise ValueError(f"Coding {coding_id} not found in study {study_key}")
-        return result[0]
-
-    def list(self, study_key: Optional[str] = None, **filters) -> List[Coding]:
+    def list(self, study_key: Optional[str] = None, **filters: Any) -> List[Coding]:
         """List codings in a study with optional filtering."""
         result = self._list_impl(
             self._client,
@@ -97,27 +38,14 @@ class CodingsEndpoint(BaseEndpoint):
         return result
 
     def get(self, study_key: str, coding_id: str) -> Coding:
-        """
-        Get a specific coding by ID.
-
-        The ``coding_id`` value is supplied as a filter to :meth:`list`.
-
-        Args:
-            study_key: Study identifier
-            coding_id: Coding identifier
-
-        Returns:
-            Coding object
-        """
-
-        result = self._get_impl(self._client, Paginator, study_key, coding_id)
+        """Get a specific coding by ID."""
+        result = self._get_impl(self._client, Paginator, coding_id, study_key=study_key)
         return result  # type: ignore[return-value]
 
     async def async_get(self, study_key: str, coding_id: str) -> Coding:
-        """Asynchronous version of :meth:`get`.
-
-        This method also filters :meth:`async_list` by ``coding_id``.
-        """
+        """Asynchronous version of :meth:`get`."""
         if self._async_client is None:
             raise RuntimeError("Async client not configured")
-        return await self._get_impl(self._async_client, AsyncPaginator, study_key, coding_id)
+        return await self._get_impl(
+            self._async_client, AsyncPaginator, coding_id, study_key=study_key
+        )

--- a/imednet/endpoints/forms.py
+++ b/imednet/endpoints/forms.py
@@ -1,89 +1,24 @@
 """Endpoint for managing forms (eCRFs) in a study."""
 
-import inspect
-from typing import Any, Dict, List, Optional
+from typing import Any, List, Optional
 
 from imednet.core.async_client import AsyncClient
 from imednet.core.client import Client
 from imednet.core.context import Context
 from imednet.core.paginator import AsyncPaginator, Paginator
-from imednet.endpoints.base import BaseEndpoint
+from imednet.endpoints.paged_endpoint_mixin import PagedEndpointMixin
 from imednet.models.forms import Form
-from imednet.utils.filters import build_filter_string
 
 
-class FormsEndpoint(BaseEndpoint):
-    """
-    API endpoint for interacting with forms (eCRFs) in an iMedNet study.
-
-    Provides methods to list and retrieve individual forms.
-    """
+class FormsEndpoint(PagedEndpointMixin):
+    """API endpoint for interacting with forms in an iMedNet study."""
 
     PATH = "/api/v1/edc/studies"
-
-    def _list_impl(
-        self,
-        client: Any,
-        paginator_cls: type[Any],
-        *,
-        study_key: Optional[str] = None,
-        refresh: bool = False,
-        **filters: Any,
-    ) -> Any:
-        filters = self._auto_filter(filters)
-        if study_key:
-            filters["studyKey"] = study_key
-
-        study = filters.pop("studyKey")
-        if not study:
-            raise ValueError("Study key must be provided or set in the context")
-        if not filters and not refresh and study in self._forms_cache:
-            return self._forms_cache[study]
-
-        params: Dict[str, Any] = {}
-        if filters:
-            params["filter"] = build_filter_string(filters)
-
-        path = self._build_path(study, "forms")
-        paginator = paginator_cls(client, path, params=params, page_size=500)
-
-        if hasattr(paginator, "__aiter__"):
-
-            async def _collect() -> List[Form]:
-                result = [Form.from_json(item) async for item in paginator]
-                if not filters:
-                    self._forms_cache[study] = result
-                return result
-
-            return _collect()
-
-        result = [Form.from_json(item) for item in paginator]
-        if not filters:
-            self._forms_cache[study] = result
-        return result
-
-    def _get_impl(self, client: Any, paginator_cls: type[Any], study_key: str, form_id: int) -> Any:
-        result = self._list_impl(
-            client,
-            paginator_cls,
-            study_key=study_key,
-            refresh=True,
-            formId=form_id,
-        )
-
-        if inspect.isawaitable(result):
-
-            async def _await() -> Form:
-                items = await result
-                if not items:
-                    raise ValueError(f"Form {form_id} not found in study {study_key}")
-                return items[0]
-
-            return _await()
-
-        if not result:
-            raise ValueError(f"Form {form_id} not found in study {study_key}")
-        return result[0]
+    MODEL = Form
+    PATH_SUFFIX = "forms"
+    ID_FILTER = "formId"
+    PAGE_SIZE = 500
+    CACHE_ENABLED = True
 
     def __init__(
         self,
@@ -92,7 +27,6 @@ class FormsEndpoint(BaseEndpoint):
         async_client: AsyncClient | None = None,
     ) -> None:
         super().__init__(client, ctx, async_client)
-        self._forms_cache: Dict[str, List[Form]] = {}
 
     def list(
         self,
@@ -129,28 +63,14 @@ class FormsEndpoint(BaseEndpoint):
         return result
 
     def get(self, study_key: str, form_id: int) -> Form:
-        """
-        Get a specific form by ID.
-
-        This endpoint caches form listings. ``refresh=True`` is used when
-        calling :meth:`list` so that the most recent data is returned.
-
-        Args:
-            study_key: Study identifier
-            form_id: Form identifier
-
-        Returns:
-            Form object
-        """
-        result = self._get_impl(self._client, Paginator, study_key, form_id)
+        """Get a specific form by ID."""
+        result = self._get_impl(self._client, Paginator, form_id, study_key=study_key)
         return result  # type: ignore[return-value]
 
     async def async_get(self, study_key: str, form_id: int) -> Form:
-        """Asynchronous version of :meth:`get`.
-
-        ``refresh=True`` is also passed to :meth:`async_list` to bypass the
-        cache.
-        """
+        """Asynchronous version of :meth:`get`."""
         if self._async_client is None:
             raise RuntimeError("Async client not configured")
-        return await self._get_impl(self._async_client, AsyncPaginator, study_key, form_id)
+        return await self._get_impl(
+            self._async_client, AsyncPaginator, form_id, study_key=study_key
+        )

--- a/imednet/endpoints/intervals.py
+++ b/imednet/endpoints/intervals.py
@@ -1,91 +1,24 @@
 """Endpoint for managing intervals (visit definitions) in a study."""
 
-import inspect
-from typing import Any, Dict, List, Optional
+from typing import Any, List, Optional
 
 from imednet.core.async_client import AsyncClient
 from imednet.core.client import Client
 from imednet.core.context import Context
 from imednet.core.paginator import AsyncPaginator, Paginator
-from imednet.endpoints.base import BaseEndpoint
+from imednet.endpoints.paged_endpoint_mixin import PagedEndpointMixin
 from imednet.models.intervals import Interval
-from imednet.utils.filters import build_filter_string
 
 
-class IntervalsEndpoint(BaseEndpoint):
-    """
-    API endpoint for interacting with intervals (visit definitions) in an iMedNet study.
-
-    Provides methods to list and retrieve individual intervals.
-    """
+class IntervalsEndpoint(PagedEndpointMixin):
+    """API endpoint for interacting with intervals in an iMedNet study."""
 
     PATH = "/api/v1/edc/studies"
-
-    def _list_impl(
-        self,
-        client: Any,
-        paginator_cls: type[Any],
-        *,
-        study_key: Optional[str] = None,
-        refresh: bool = False,
-        **filters: Any,
-    ) -> Any:
-        filters = self._auto_filter(filters)
-        if study_key:
-            filters["studyKey"] = study_key
-
-        study = filters.pop("studyKey")
-        if not study:
-            raise ValueError("Study key must be provided or set in the context")
-        if not filters and not refresh and study in self._intervals_cache:
-            return self._intervals_cache[study]
-
-        params: Dict[str, Any] = {}
-        if filters:
-            params["filter"] = build_filter_string(filters)
-
-        path = self._build_path(study, "intervals")
-        paginator = paginator_cls(client, path, params=params, page_size=500)
-
-        if hasattr(paginator, "__aiter__"):
-
-            async def _collect() -> List[Interval]:
-                result = [Interval.from_json(item) async for item in paginator]
-                if not filters:
-                    self._intervals_cache[study] = result
-                return result
-
-            return _collect()
-
-        result = [Interval.from_json(item) for item in paginator]
-        if not filters:
-            self._intervals_cache[study] = result
-        return result
-
-    def _get_impl(
-        self, client: Any, paginator_cls: type[Any], study_key: str, interval_id: int
-    ) -> Any:
-        result = self._list_impl(
-            client,
-            paginator_cls,
-            study_key=study_key,
-            refresh=True,
-            intervalId=interval_id,
-        )
-
-        if inspect.isawaitable(result):
-
-            async def _await() -> Interval:
-                items = await result
-                if not items:
-                    raise ValueError(f"Interval {interval_id} not found in study {study_key}")
-                return items[0]
-
-            return _await()
-
-        if not result:
-            raise ValueError(f"Interval {interval_id} not found in study {study_key}")
-        return result[0]
+    MODEL = Interval
+    PATH_SUFFIX = "intervals"
+    ID_FILTER = "intervalId"
+    PAGE_SIZE = 500
+    CACHE_ENABLED = True
 
     def __init__(
         self,
@@ -94,7 +27,6 @@ class IntervalsEndpoint(BaseEndpoint):
         async_client: AsyncClient | None = None,
     ) -> None:
         super().__init__(client, ctx, async_client)
-        self._intervals_cache: Dict[str, List[Interval]] = {}
 
     def list(
         self, study_key: Optional[str] = None, refresh: bool = False, **filters: Any
@@ -125,28 +57,14 @@ class IntervalsEndpoint(BaseEndpoint):
         return result
 
     def get(self, study_key: str, interval_id: int) -> Interval:
-        """
-        Get a specific interval by ID.
-
-        ``refresh=True`` is passed to :meth:`list` to override the cached
-        interval list when performing the lookup.
-
-        Args:
-            study_key: Study identifier
-            interval_id: Interval identifier
-
-        Returns:
-            Interval object
-        """
-        result = self._get_impl(self._client, Paginator, study_key, interval_id)
+        """Get a specific interval by ID."""
+        result = self._get_impl(self._client, Paginator, interval_id, study_key=study_key)
         return result  # type: ignore[return-value]
 
     async def async_get(self, study_key: str, interval_id: int) -> Interval:
-        """Asynchronous version of :meth:`get`.
-
-        The asynchronous call also passes ``refresh=True`` to
-        :meth:`async_list`.
-        """
+        """Asynchronous version of :meth:`get`."""
         if self._async_client is None:
             raise RuntimeError("Async client not configured")
-        return await self._get_impl(self._async_client, AsyncPaginator, study_key, interval_id)
+        return await self._get_impl(
+            self._async_client, AsyncPaginator, interval_id, study_key=study_key
+        )

--- a/imednet/endpoints/paged_endpoint_mixin.py
+++ b/imednet/endpoints/paged_endpoint_mixin.py
@@ -1,0 +1,166 @@
+"""Shared pagination utilities for list/get endpoints."""
+
+from __future__ import annotations
+
+import inspect
+from typing import Any, Dict, List, Optional
+
+from imednet.core.async_client import AsyncClient
+from imednet.core.client import Client
+from imednet.core.context import Context
+from imednet.endpoints.base import BaseEndpoint
+from imednet.utils.filters import build_filter_string
+
+
+class PagedEndpointMixin(BaseEndpoint):
+    """Mixin providing paginated ``list``/``get`` helpers with optional caching."""
+
+    MODEL: Any
+    PATH_SUFFIX: str | None = None
+    ID_FILTER: str
+    PAGE_SIZE: int = 100
+    CACHE_ENABLED: bool = False
+    INCLUDE_STUDY_IN_FILTER: bool = False
+    MISSING_STUDY_ERROR: type[Exception] = KeyError
+
+    def __init__(
+        self,
+        client: Client,
+        ctx: Context,
+        async_client: AsyncClient | None = None,
+    ) -> None:
+        super().__init__(client, ctx, async_client)
+        self._cache: Any
+        if self.CACHE_ENABLED:
+            if self.PATH_SUFFIX:
+                self._cache = {}
+            else:
+                self._cache = None
+
+    # ---------------------------------------------------------------
+    # Internal helpers
+    # ---------------------------------------------------------------
+    def _parse(self, item: Any) -> Any:
+        parser = getattr(self.MODEL, "from_json", None) or getattr(
+            self.MODEL, "model_validate", None
+        )
+        if parser is None:
+            raise TypeError("MODEL must provide 'from_json' or 'model_validate'")
+        return parser(item)
+
+    def _list_impl(
+        self,
+        client: Any,
+        paginator_cls: type[Any],
+        *,
+        study_key: Optional[str] = None,
+        refresh: bool = False,
+        **filters: Any,
+    ) -> Any:
+        filters = self._auto_filter(filters)
+        include_inactive = filters.pop("include_inactive", False)
+        record_data_filter = filters.pop("record_data_filter", None)
+        if study_key:
+            filters["studyKey"] = study_key
+
+        study = None
+        if self.PATH_SUFFIX:
+            try:
+                study = filters.pop("studyKey")
+            except KeyError as exc:
+                raise self.MISSING_STUDY_ERROR("studyKey") from exc
+            if not study:
+                raise ValueError("Study key must be provided or set in the context")
+            if (
+                self.CACHE_ENABLED
+                and not filters
+                and not refresh
+                and study in getattr(self, "_cache", {})
+            ):
+                return getattr(self, "_cache")[study]
+            path = self._build_path(study, self.PATH_SUFFIX)
+            if self.INCLUDE_STUDY_IN_FILTER:
+                filters_with_study = {**filters, "studyKey": study}
+            else:
+                filters_with_study = filters
+        else:
+            if (
+                self.CACHE_ENABLED
+                and not filters
+                and not refresh
+                and getattr(self, "_cache", None) is not None
+            ):
+                return getattr(self, "_cache")
+            path = self.PATH
+            filters_with_study = filters
+
+        params: Dict[str, Any] = {}
+        if filters_with_study:
+            params["filter"] = build_filter_string(filters_with_study)
+        if record_data_filter is not None:
+            params["recordDataFilter"] = record_data_filter
+        if include_inactive:
+            params["includeInactive"] = str(include_inactive).lower()
+
+        paginator = paginator_cls(client, path, params=params, page_size=self.PAGE_SIZE)
+
+        if hasattr(paginator, "__aiter__"):
+
+            async def _collect() -> List[Any]:
+                result = [self._parse(item) async for item in paginator]
+                if self.CACHE_ENABLED and not filters:
+                    if self.PATH_SUFFIX:
+                        getattr(self, "_cache")[study] = result
+                    else:
+                        setattr(self, "_cache", result)
+                return result
+
+            return _collect()
+
+        result = [self._parse(item) for item in paginator]
+        if self.CACHE_ENABLED and not filters:
+            if self.PATH_SUFFIX:
+                getattr(self, "_cache")[study] = result
+            else:
+                setattr(self, "_cache", result)
+        return result
+
+    def _get_impl(
+        self,
+        client: Any,
+        paginator_cls: type[Any],
+        identifier: Any,
+        *,
+        study_key: Optional[str] = None,
+    ) -> Any:
+        kwargs = {self.ID_FILTER: identifier}
+        if self.CACHE_ENABLED:
+            kwargs["refresh"] = True
+        result = self._list_impl(
+            client,
+            paginator_cls,
+            study_key=study_key,
+            **kwargs,
+        )
+
+        if inspect.isawaitable(result):
+
+            async def _await() -> Any:
+                items = await result
+                if not items:
+                    if self.PATH_SUFFIX:
+                        raise ValueError(
+                            f"{self.MODEL.__name__} {identifier} not found in study {study_key}"
+                        )
+                    raise ValueError(f"{self.MODEL.__name__} {identifier} not found")
+                return items[0]
+
+            return _await()
+
+        if not result:
+            if self.PATH_SUFFIX:
+                raise ValueError(
+                    f"{self.MODEL.__name__} {identifier} not found in study {study_key}"
+                )
+            raise ValueError(f"{self.MODEL.__name__} {identifier} not found")
+        return result[0]

--- a/imednet/endpoints/queries.py
+++ b/imednet/endpoints/queries.py
@@ -1,76 +1,22 @@
 """Endpoint for managing queries (dialogue/questions) in a study."""
 
-import inspect
-from typing import Any, Dict, List, Optional
+from typing import Any, List, Optional
 
 from imednet.core.paginator import AsyncPaginator, Paginator
-from imednet.endpoints.base import BaseEndpoint
+from imednet.endpoints.paged_endpoint_mixin import PagedEndpointMixin
 from imednet.models.queries import Query
-from imednet.utils.filters import build_filter_string
 
 
-class QueriesEndpoint(BaseEndpoint):
-    """
-    API endpoint for interacting with queries (dialogue/questions) in an iMedNet study.
-
-    Provides methods to list and retrieve queries.
-    """
+class QueriesEndpoint(PagedEndpointMixin):
+    """API endpoint for interacting with queries in an iMedNet study."""
 
     PATH = "/api/v1/edc/studies"
+    MODEL = Query
+    PATH_SUFFIX = "queries"
+    ID_FILTER = "annotationId"
+    INCLUDE_STUDY_IN_FILTER = True
 
-    def _list_impl(
-        self,
-        client: Any,
-        paginator_cls: type[Any],
-        *,
-        study_key: Optional[str] = None,
-        **filters: Any,
-    ) -> Any:
-        filters = self._auto_filter(filters)
-        if study_key:
-            filters["studyKey"] = study_key
-
-        params: Dict[str, Any] = {}
-        if filters:
-            params["filter"] = build_filter_string(filters)
-
-        path = self._build_path(filters.get("studyKey", ""), "queries")
-        paginator = paginator_cls(client, path, params=params)
-
-        if hasattr(paginator, "__aiter__"):
-
-            async def _collect() -> List[Query]:
-                return [Query.from_json(item) async for item in paginator]
-
-            return _collect()
-
-        return [Query.from_json(item) for item in paginator]
-
-    def _get_impl(
-        self, client: Any, paginator_cls: type[Any], study_key: str, annotation_id: int
-    ) -> Any:
-        result = self._list_impl(
-            client,
-            paginator_cls,
-            study_key=study_key,
-            annotationId=annotation_id,
-        )
-
-        if inspect.isawaitable(result):
-
-            async def _await() -> Query:
-                items = await result
-                if not items:
-                    raise ValueError(f"Query {annotation_id} not found in study {study_key}")
-                return items[0]
-
-            return _await()
-
-        if not result:
-            raise ValueError(f"Query {annotation_id} not found in study {study_key}")
-        return result[0]
-
-    def list(self, study_key: Optional[str] = None, **filters) -> List[Query]:
+    def list(self, study_key: Optional[str] = None, **filters: Any) -> List[Query]:
         """List queries in a study with optional filtering."""
         result = self._list_impl(
             self._client,
@@ -93,26 +39,14 @@ class QueriesEndpoint(BaseEndpoint):
         return result
 
     def get(self, study_key: str, annotation_id: int) -> Query:
-        """
-        Get a specific query by annotation ID.
-
-        The annotation ID filter is forwarded to :meth:`list`.
-
-        Args:
-            study_key: Study identifier
-            annotation_id: Query annotation identifier
-
-        Returns:
-            Query object
-        """
-        result = self._get_impl(self._client, Paginator, study_key, annotation_id)
+        """Get a specific query by annotation ID."""
+        result = self._get_impl(self._client, Paginator, annotation_id, study_key=study_key)
         return result  # type: ignore[return-value]
 
     async def async_get(self, study_key: str, annotation_id: int) -> Query:
-        """Asynchronous version of :meth:`get`.
-
-        This call filters :meth:`async_list` by ``annotation_id``.
-        """
+        """Asynchronous version of :meth:`get`."""
         if self._async_client is None:
             raise RuntimeError("Async client not configured")
-        return await self._get_impl(self._async_client, AsyncPaginator, study_key, annotation_id)
+        return await self._get_impl(
+            self._async_client, AsyncPaginator, annotation_id, study_key=study_key
+        )

--- a/imednet/endpoints/record_revisions.py
+++ b/imednet/endpoints/record_revisions.py
@@ -1,78 +1,22 @@
 """Endpoint for retrieving record revision history in a study."""
 
-import inspect
-from typing import Any, Dict, List, Optional
+from typing import Any, List, Optional
 
 from imednet.core.paginator import AsyncPaginator, Paginator
-from imednet.endpoints.base import BaseEndpoint
+from imednet.endpoints.paged_endpoint_mixin import PagedEndpointMixin
 from imednet.models.record_revisions import RecordRevision
-from imednet.utils.filters import build_filter_string
 
 
-class RecordRevisionsEndpoint(BaseEndpoint):
-    """
-    API endpoint for accessing record revision history in an iMedNet study.
-
-    Provides methods to list and retrieve record revisions.
-    """
+class RecordRevisionsEndpoint(PagedEndpointMixin):
+    """API endpoint for accessing record revision history in an iMedNet study."""
 
     PATH = "/api/v1/edc/studies"
+    MODEL = RecordRevision
+    PATH_SUFFIX = "recordRevisions"
+    ID_FILTER = "recordRevisionId"
+    INCLUDE_STUDY_IN_FILTER = True
 
-    def _list_impl(
-        self,
-        client: Any,
-        paginator_cls: type[Any],
-        *,
-        study_key: Optional[str] = None,
-        **filters: Any,
-    ) -> Any:
-        filters = self._auto_filter(filters)
-        if study_key:
-            filters["studyKey"] = study_key
-
-        params: Dict[str, Any] = {}
-        if filters:
-            params["filter"] = build_filter_string(filters)
-
-        path = self._build_path(filters.get("studyKey", ""), "recordRevisions")
-        paginator = paginator_cls(client, path, params=params)
-
-        if hasattr(paginator, "__aiter__"):
-
-            async def _collect() -> List[RecordRevision]:
-                return [RecordRevision.from_json(item) async for item in paginator]
-
-            return _collect()
-
-        return [RecordRevision.from_json(item) for item in paginator]
-
-    def _get_impl(
-        self, client: Any, paginator_cls: type[Any], study_key: str, record_revision_id: int
-    ) -> Any:
-        result = self._list_impl(
-            client,
-            paginator_cls,
-            study_key=study_key,
-            recordRevisionId=record_revision_id,
-        )
-
-        if inspect.isawaitable(result):
-
-            async def _await() -> RecordRevision:
-                items = await result
-                if not items:
-                    raise ValueError(
-                        f"Record revision {record_revision_id} not found in study {study_key}"
-                    )
-                return items[0]
-
-            return _await()
-
-        if not result:
-            raise ValueError(f"Record revision {record_revision_id} not found in study {study_key}")
-        return result[0]
-
-    def list(self, study_key: Optional[str] = None, **filters) -> List[RecordRevision]:
+    def list(self, study_key: Optional[str] = None, **filters: Any) -> List[RecordRevision]:
         """List record revisions in a study with optional filtering."""
         result = self._list_impl(
             self._client,
@@ -97,28 +41,17 @@ class RecordRevisionsEndpoint(BaseEndpoint):
         return result
 
     def get(self, study_key: str, record_revision_id: int) -> RecordRevision:
-        """
-        Get a specific record revision by ID.
-
-        The ID is forwarded to :meth:`list` as a filter; no caching is used.
-
-        Args:
-            study_key: Study identifier
-            record_revision_id: Record revision identifier
-
-        Returns:
-            RecordRevision object
-        """
-        result = self._get_impl(self._client, Paginator, study_key, record_revision_id)
+        """Get a specific record revision by ID."""
+        result = self._get_impl(self._client, Paginator, record_revision_id, study_key=study_key)
         return result  # type: ignore[return-value]
 
     async def async_get(self, study_key: str, record_revision_id: int) -> RecordRevision:
-        """Asynchronous version of :meth:`get`.
-
-        This call also filters :meth:`async_list` by ``record_revision_id``.
-        """
+        """Asynchronous version of :meth:`get`."""
         if self._async_client is None:
             raise RuntimeError("Async client not configured")
         return await self._get_impl(
-            self._async_client, AsyncPaginator, study_key, record_revision_id
+            self._async_client,
+            AsyncPaginator,
+            record_revision_id,
+            study_key=study_key,
         )

--- a/imednet/endpoints/sites.py
+++ b/imednet/endpoints/sites.py
@@ -1,78 +1,21 @@
 """Endpoint for managing sites (study locations) in a study."""
 
-import inspect
-from typing import Any, Dict, List, Optional
+from typing import Any, List, Optional
 
 from imednet.core.paginator import AsyncPaginator, Paginator
-from imednet.endpoints.base import BaseEndpoint
+from imednet.endpoints.paged_endpoint_mixin import PagedEndpointMixin
 from imednet.models.sites import Site
-from imednet.utils.filters import build_filter_string
 
 
-class SitesEndpoint(BaseEndpoint):
-    """
-    API endpoint for interacting with sites (study locations) in an iMedNet study.
-
-    Provides methods to list and retrieve individual sites.
-    """
+class SitesEndpoint(PagedEndpointMixin):
+    """API endpoint for interacting with sites in an iMedNet study."""
 
     PATH = "/api/v1/edc/studies"
+    MODEL = Site
+    PATH_SUFFIX = "sites"
+    ID_FILTER = "siteId"
 
-    def _list_impl(
-        self,
-        client: Any,
-        paginator_cls: type[Any],
-        *,
-        study_key: Optional[str] = None,
-        **filters: Any,
-    ) -> Any:
-        filters = self._auto_filter(filters)
-        if study_key:
-            filters["studyKey"] = study_key
-
-        study = filters.pop("studyKey")
-        if not study:
-            raise ValueError("Study key must be provided or set in the context")
-
-        params: Dict[str, Any] = {}
-        if filters:
-            params["filter"] = build_filter_string(filters)
-
-        path = self._build_path(study, "sites")
-        paginator = paginator_cls(client, path, params=params)
-
-        if hasattr(paginator, "__aiter__"):
-
-            async def _collect() -> List[Site]:
-                return [Site.from_json(item) async for item in paginator]
-
-            return _collect()
-
-        return [Site.from_json(item) for item in paginator]
-
-    def _get_impl(self, client: Any, paginator_cls: type[Any], study_key: str, site_id: int) -> Any:
-        result = self._list_impl(
-            client,
-            paginator_cls,
-            study_key=study_key,
-            siteId=site_id,
-        )
-
-        if inspect.isawaitable(result):
-
-            async def _await() -> Site:
-                items = await result
-                if not items:
-                    raise ValueError(f"Site {site_id} not found in study {study_key}")
-                return items[0]
-
-            return _await()
-
-        if not result:
-            raise ValueError(f"Site {site_id} not found in study {study_key}")
-        return result[0]
-
-    def list(self, study_key: Optional[str] = None, **filters) -> List[Site]:
+    def list(self, study_key: Optional[str] = None, **filters: Any) -> List[Site]:
         """List sites in a study with optional filtering."""
         result = self._list_impl(
             self._client,
@@ -95,26 +38,14 @@ class SitesEndpoint(BaseEndpoint):
         return result
 
     def get(self, study_key: str, site_id: int) -> Site:
-        """
-        Get a specific site by ID.
-
-        The ``site_id`` is applied as a filter when calling :meth:`list`.
-
-        Args:
-            study_key: Study identifier
-            site_id: Site identifier
-
-        Returns:
-            Site object
-        """
-        result = self._get_impl(self._client, Paginator, study_key, site_id)
+        """Get a specific site by ID."""
+        result = self._get_impl(self._client, Paginator, site_id, study_key=study_key)
         return result  # type: ignore[return-value]
 
     async def async_get(self, study_key: str, site_id: int) -> Site:
-        """Asynchronous version of :meth:`get`.
-
-        This method also filters :meth:`async_list` by ``site_id``.
-        """
+        """Asynchronous version of :meth:`get`."""
         if self._async_client is None:
             raise RuntimeError("Async client not configured")
-        return await self._get_impl(self._async_client, AsyncPaginator, study_key, site_id)
+        return await self._get_impl(
+            self._async_client, AsyncPaginator, site_id, study_key=study_key
+        )

--- a/imednet/endpoints/studies.py
+++ b/imednet/endpoints/studies.py
@@ -1,80 +1,22 @@
 """Endpoint for managing studies in the iMedNet system."""
 
-import inspect
-from typing import Any, Dict, List, Optional
+from typing import Any, List
 
 from imednet.core.async_client import AsyncClient
 from imednet.core.client import Client
 from imednet.core.context import Context
 from imednet.core.paginator import AsyncPaginator, Paginator
-from imednet.endpoints.base import BaseEndpoint
+from imednet.endpoints.paged_endpoint_mixin import PagedEndpointMixin
 from imednet.models.studies import Study
-from imednet.utils.filters import build_filter_string
 
 
-class StudiesEndpoint(BaseEndpoint):
-    """
-    API endpoint for interacting with studies in the iMedNet system.
-
-    Provides methods to list available studies and retrieve specific studies.
-    """
+class StudiesEndpoint(PagedEndpointMixin):
+    """API endpoint for interacting with studies in the iMedNet system."""
 
     PATH = "/api/v1/edc/studies"
-    _studies_cache: Optional[List[Study]]
-
-    def _list_impl(
-        self,
-        client: Any,
-        paginator_cls: type[Any],
-        *,
-        refresh: bool = False,
-        **filters: Any,
-    ) -> Any:
-        filters = self._auto_filter(filters)
-        if not filters and not refresh and self._studies_cache is not None:
-            return self._studies_cache
-
-        params: Dict[str, Any] = {}
-        if filters:
-            params["filter"] = build_filter_string(filters)
-        paginator = paginator_cls(client, self.PATH, params=params)
-
-        if hasattr(paginator, "__aiter__"):
-
-            async def _collect() -> List[Study]:
-                result = [Study.model_validate(item) async for item in paginator]
-                if not filters:
-                    self._studies_cache = result
-                return result
-
-            return _collect()
-
-        result = [Study.model_validate(item) for item in paginator]
-        if not filters:
-            self._studies_cache = result
-        return result
-
-    def _get_impl(self, client: Any, paginator_cls: type[Any], study_key: str) -> Any:
-        result = self._list_impl(
-            client,
-            paginator_cls,
-            refresh=True,
-            studyKey=study_key,
-        )
-
-        if inspect.isawaitable(result):
-
-            async def _await() -> Study:
-                items = await result
-                if not items:
-                    raise ValueError(f"Study {study_key} not found")
-                return items[0]
-
-            return _await()
-
-        if not result:
-            raise ValueError(f"Study {study_key} not found")
-        return result[0]
+    MODEL = Study
+    ID_FILTER = "studyKey"
+    CACHE_ENABLED = True
 
     def __init__(
         self,
@@ -83,9 +25,8 @@ class StudiesEndpoint(BaseEndpoint):
         async_client: AsyncClient | None = None,
     ) -> None:
         super().__init__(client, ctx, async_client)
-        self._studies_cache: Optional[List[Study]] = None
 
-    def list(self, refresh: bool = False, **filters) -> List[Study]:
+    def list(self, refresh: bool = False, **filters: Any) -> List[Study]:
         """List studies with optional filtering."""
         result = self._list_impl(
             self._client,
@@ -108,27 +49,12 @@ class StudiesEndpoint(BaseEndpoint):
         return result
 
     def get(self, study_key: str) -> Study:
-        """
-        Get a specific study by key.
-
-        This endpoint maintains a local cache. ``refresh=True`` is passed to
-        :meth:`list` to ensure the latest data is fetched for the lookup.
-
-        Args:
-            study_key: Study identifier
-
-        Returns:
-            Study object
-        """
+        """Get a specific study by key."""
         result = self._get_impl(self._client, Paginator, study_key)
         return result  # type: ignore[return-value]
 
     async def async_get(self, study_key: str) -> Study:
-        """Asynchronous version of :meth:`get`.
-
-        Like the synchronous variant, this call passes ``refresh=True`` to
-        :meth:`async_list` to bypass the cache.
-        """
+        """Asynchronous version of :meth:`get`."""
         if self._async_client is None:
             raise RuntimeError("Async client not configured")
         return await self._get_impl(self._async_client, AsyncPaginator, study_key)

--- a/imednet/endpoints/subjects.py
+++ b/imednet/endpoints/subjects.py
@@ -1,76 +1,22 @@
 """Endpoint for managing subjects in a study."""
 
-import inspect
-from typing import Any, Dict, List, Optional
+from typing import Any, List, Optional
 
 from imednet.core.paginator import AsyncPaginator, Paginator
-from imednet.endpoints.base import BaseEndpoint
+from imednet.endpoints.paged_endpoint_mixin import PagedEndpointMixin
 from imednet.models.subjects import Subject
-from imednet.utils.filters import build_filter_string
 
 
-class SubjectsEndpoint(BaseEndpoint):
-    """
-    API endpoint for interacting with subjects in an iMedNet study.
-
-    Provides methods to list and retrieve individual subjects.
-    """
+class SubjectsEndpoint(PagedEndpointMixin):
+    """API endpoint for interacting with subjects in an iMedNet study."""
 
     PATH = "/api/v1/edc/studies"
+    MODEL = Subject
+    PATH_SUFFIX = "subjects"
+    ID_FILTER = "subjectKey"
+    INCLUDE_STUDY_IN_FILTER = True
 
-    def _list_impl(
-        self,
-        client: Any,
-        paginator_cls: type[Any],
-        *,
-        study_key: Optional[str] = None,
-        **filters: Any,
-    ) -> Any:
-        filters = self._auto_filter(filters)
-        if study_key:
-            filters["studyKey"] = study_key
-
-        params: Dict[str, Any] = {}
-        if filters:
-            params["filter"] = build_filter_string(filters)
-
-        path = self._build_path(filters.get("studyKey", ""), "subjects")
-        paginator = paginator_cls(client, path, params=params)
-
-        if hasattr(paginator, "__aiter__"):
-
-            async def _collect() -> List[Subject]:
-                return [Subject.from_json(item) async for item in paginator]
-
-            return _collect()
-
-        return [Subject.from_json(item) for item in paginator]
-
-    def _get_impl(
-        self, client: Any, paginator_cls: type[Any], study_key: str, subject_key: str
-    ) -> Any:
-        result = self._list_impl(
-            client,
-            paginator_cls,
-            study_key=study_key,
-            subjectKey=subject_key,
-        )
-
-        if inspect.isawaitable(result):
-
-            async def _await() -> Subject:
-                items = await result
-                if not items:
-                    raise ValueError(f"Subject {subject_key} not found in study {study_key}")
-                return items[0]
-
-            return _await()
-
-        if not result:
-            raise ValueError(f"Subject {subject_key} not found in study {study_key}")
-        return result[0]
-
-    def list(self, study_key: Optional[str] = None, **filters) -> List[Subject]:
+    def list(self, study_key: Optional[str] = None, **filters: Any) -> List[Subject]:
         """List subjects in a study with optional filtering."""
         result = self._list_impl(
             self._client,
@@ -93,31 +39,17 @@ class SubjectsEndpoint(BaseEndpoint):
         return result
 
     def get(self, study_key: str, subject_key: str) -> Subject:
-        """
-        Get a specific subject by key.
-
-        The ``subject_key`` is passed as a filter to :meth:`list`.
-
-        Args:
-            study_key: Study identifier
-            subject_key: Subject identifier
-
-        Returns:
-            Subject object
-        """
-        result = self._get_impl(self._client, Paginator, study_key, subject_key)
+        """Get a specific subject by key."""
+        result = self._get_impl(self._client, Paginator, subject_key, study_key=study_key)
         return result  # type: ignore[return-value]
 
     async def async_get(self, study_key: str, subject_key: str) -> Subject:
-        """Asynchronous version of :meth:`get`.
-
-        This call also filters :meth:`async_list` by ``subject_key``.
-        """
+        """Asynchronous version of :meth:`get`."""
         if self._async_client is None:
             raise RuntimeError("Async client not configured")
         return await self._get_impl(
             self._async_client,
             AsyncPaginator,
-            study_key,
             subject_key,
+            study_key=study_key,
         )

--- a/imednet/endpoints/variables.py
+++ b/imednet/endpoints/variables.py
@@ -1,91 +1,24 @@
 """Endpoint for managing variables (data points on eCRFs) in a study."""
 
-import inspect
-from typing import Any, Dict, List, Optional
+from typing import Any, List, Optional
 
 from imednet.core.async_client import AsyncClient
 from imednet.core.client import Client
 from imednet.core.context import Context
 from imednet.core.paginator import AsyncPaginator, Paginator
-from imednet.endpoints.base import BaseEndpoint
+from imednet.endpoints.paged_endpoint_mixin import PagedEndpointMixin
 from imednet.models.variables import Variable
-from imednet.utils.filters import build_filter_string
 
 
-class VariablesEndpoint(BaseEndpoint):
-    """
-    API endpoint for interacting with variables (data points on eCRFs) in an iMedNet study.
-
-    Provides methods to list and retrieve individual variables.
-    """
+class VariablesEndpoint(PagedEndpointMixin):
+    """API endpoint for interacting with variables in an iMedNet study."""
 
     PATH = "/api/v1/edc/studies"
-
-    def _list_impl(
-        self,
-        client: Any,
-        paginator_cls: type[Any],
-        *,
-        study_key: Optional[str] = None,
-        refresh: bool = False,
-        **filters: Any,
-    ) -> Any:
-        filters = self._auto_filter(filters)
-        if study_key:
-            filters["studyKey"] = study_key
-
-        study = filters.pop("studyKey")
-        if not study:
-            raise ValueError("Study key must be provided or set in the context")
-        if not filters and not refresh and study in self._variables_cache:
-            return self._variables_cache[study]
-
-        params: Dict[str, Any] = {}
-        if filters:
-            params["filter"] = build_filter_string(filters)
-
-        path = self._build_path(study, "variables")
-        paginator = paginator_cls(client, path, params=params, page_size=500)
-
-        if hasattr(paginator, "__aiter__"):
-
-            async def _collect() -> List[Variable]:
-                result = [Variable.from_json(item) async for item in paginator]
-                if not filters:
-                    self._variables_cache[study] = result
-                return result
-
-            return _collect()
-
-        result = [Variable.from_json(item) for item in paginator]
-        if not filters:
-            self._variables_cache[study] = result
-        return result
-
-    def _get_impl(
-        self, client: Any, paginator_cls: type[Any], study_key: str, variable_id: int
-    ) -> Any:
-        result = self._list_impl(
-            client,
-            paginator_cls,
-            study_key=study_key,
-            refresh=True,
-            variableId=variable_id,
-        )
-
-        if inspect.isawaitable(result):
-
-            async def _await() -> Variable:
-                items = await result
-                if not items:
-                    raise ValueError(f"Variable {variable_id} not found in study {study_key}")
-                return items[0]
-
-            return _await()
-
-        if not result:
-            raise ValueError(f"Variable {variable_id} not found in study {study_key}")
-        return result[0]
+    MODEL = Variable
+    PATH_SUFFIX = "variables"
+    ID_FILTER = "variableId"
+    PAGE_SIZE = 500
+    CACHE_ENABLED = True
 
     def __init__(
         self,
@@ -94,10 +27,9 @@ class VariablesEndpoint(BaseEndpoint):
         async_client: AsyncClient | None = None,
     ) -> None:
         super().__init__(client, ctx, async_client)
-        self._variables_cache: Dict[str, List[Variable]] = {}
 
     def list(
-        self, study_key: Optional[str] = None, refresh: bool = False, **filters
+        self, study_key: Optional[str] = None, refresh: bool = False, **filters: Any
     ) -> List[Variable]:
         """List variables in a study with optional filtering."""
         result = self._list_impl(
@@ -125,28 +57,14 @@ class VariablesEndpoint(BaseEndpoint):
         return result
 
     def get(self, study_key: str, variable_id: int) -> Variable:
-        """
-        Get a specific variable by ID.
-
-        The variables list is cached, so ``refresh=True`` is used when
-        calling :meth:`list` to retrieve the latest data.
-
-        Args:
-            study_key: Study identifier
-            variable_id: Variable identifier
-
-        Returns:
-            Variable object
-        """
-        result = self._get_impl(self._client, Paginator, study_key, variable_id)
+        """Get a specific variable by ID."""
+        result = self._get_impl(self._client, Paginator, variable_id, study_key=study_key)
         return result  # type: ignore[return-value]
 
     async def async_get(self, study_key: str, variable_id: int) -> Variable:
-        """Asynchronous version of :meth:`get`.
-
-        ``refresh=True`` is also passed to :meth:`async_list` to bypass the
-        cache.
-        """
+        """Asynchronous version of :meth:`get`."""
         if self._async_client is None:
             raise RuntimeError("Async client not configured")
-        return await self._get_impl(self._async_client, AsyncPaginator, study_key, variable_id)
+        return await self._get_impl(
+            self._async_client, AsyncPaginator, variable_id, study_key=study_key
+        )

--- a/imednet/endpoints/visits.py
+++ b/imednet/endpoints/visits.py
@@ -1,76 +1,22 @@
 """Endpoint for managing visits (interval instances) in a study."""
 
-import inspect
-from typing import Any, Dict, List, Optional
+from typing import Any, List, Optional
 
 from imednet.core.paginator import AsyncPaginator, Paginator
-from imednet.endpoints.base import BaseEndpoint
+from imednet.endpoints.paged_endpoint_mixin import PagedEndpointMixin
 from imednet.models.visits import Visit
-from imednet.utils.filters import build_filter_string
 
 
-class VisitsEndpoint(BaseEndpoint):
-    """
-    API endpoint for interacting with visits (interval instances) in an iMedNet study.
-
-    Provides methods to list and retrieve individual visits.
-    """
+class VisitsEndpoint(PagedEndpointMixin):
+    """API endpoint for interacting with visits in an iMedNet study."""
 
     PATH = "/api/v1/edc/studies"
+    MODEL = Visit
+    PATH_SUFFIX = "visits"
+    ID_FILTER = "visitId"
+    INCLUDE_STUDY_IN_FILTER = True
 
-    def _list_impl(
-        self,
-        client: Any,
-        paginator_cls: type[Any],
-        *,
-        study_key: Optional[str] = None,
-        **filters: Any,
-    ) -> Any:
-        filters = self._auto_filter(filters)
-        if study_key:
-            filters["studyKey"] = study_key
-
-        params: Dict[str, Any] = {}
-        if filters:
-            params["filter"] = build_filter_string(filters)
-
-        path = self._build_path(filters.get("studyKey", ""), "visits")
-        paginator = paginator_cls(client, path, params=params)
-
-        if hasattr(paginator, "__aiter__"):
-
-            async def _collect() -> List[Visit]:
-                return [Visit.from_json(item) async for item in paginator]
-
-            return _collect()
-
-        return [Visit.from_json(item) for item in paginator]
-
-    def _get_impl(
-        self, client: Any, paginator_cls: type[Any], study_key: str, visit_id: int
-    ) -> Any:
-        result = self._list_impl(
-            client,
-            paginator_cls,
-            study_key=study_key,
-            visitId=visit_id,
-        )
-
-        if inspect.isawaitable(result):
-
-            async def _await() -> Visit:
-                items = await result
-                if not items:
-                    raise ValueError(f"Visit {visit_id} not found in study {study_key}")
-                return items[0]
-
-            return _await()
-
-        if not result:
-            raise ValueError(f"Visit {visit_id} not found in study {study_key}")
-        return result[0]
-
-    def list(self, study_key: Optional[str] = None, **filters) -> List[Visit]:
+    def list(self, study_key: Optional[str] = None, **filters: Any) -> List[Visit]:
         """List visits in a study with optional filtering."""
         result = self._list_impl(
             self._client,
@@ -93,26 +39,14 @@ class VisitsEndpoint(BaseEndpoint):
         return result
 
     def get(self, study_key: str, visit_id: int) -> Visit:
-        """
-        Get a specific visit by ID.
-
-        ``visit_id`` is sent as a filter to :meth:`list` for retrieval.
-
-        Args:
-            study_key: Study identifier
-            visit_id: Visit identifier
-
-        Returns:
-            Visit object
-        """
-        result = self._get_impl(self._client, Paginator, study_key, visit_id)
+        """Get a specific visit by ID."""
+        result = self._get_impl(self._client, Paginator, visit_id, study_key=study_key)
         return result  # type: ignore[return-value]
 
     async def async_get(self, study_key: str, visit_id: int) -> Visit:
-        """Asynchronous version of :meth:`get`.
-
-        The asynchronous call also filters by ``visit_id``.
-        """
+        """Asynchronous version of :meth:`get`."""
         if self._async_client is None:
             raise RuntimeError("Async client not configured")
-        return await self._get_impl(self._async_client, AsyncPaginator, study_key, visit_id)
+        return await self._get_impl(
+            self._async_client, AsyncPaginator, visit_id, study_key=study_key
+        )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -104,6 +104,7 @@ target-version = ["py310"]
 [tool.ruff]
 line-length = 100
 src = ["imednet"]
+extend-exclude = ["docs/**"]
 
 [tool.ruff.lint]
 select = ["E", "F", "I", "N"]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -82,14 +82,15 @@ def async_paginator_factory(monkeypatch):
 
 @pytest.fixture
 def patch_build_filter(monkeypatch):
-    def patch(module):
+    def patch(_module):
         captured = {}
 
         def fake(filters):
             captured["filters"] = filters
             return "FILTERED"
 
-        monkeypatch.setattr(module, "build_filter_string", fake)
+        monkeypatch.setattr("imednet.utils.filters.build_filter_string", fake)
+        monkeypatch.setattr("imednet.endpoints.paged_endpoint_mixin.build_filter_string", fake)
         return captured
 
     return patch


### PR DESCRIPTION
## Summary
- add `PagedEndpointMixin` providing shared pagination, caching and get logic
- update endpoints to use the mixin
- document new mixin usage
- update tests and configuration

## Testing
- `poetry run ruff check --fix .`
- `poetry run black --check .`
- `poetry run mypy imednet`
- `poetry run pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6862dca3d65c832cbfc858eb9c8bda54