### PR TITLE
Refactor sync endpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `examples/workflows/queries_by_site.py`.
 - Updated imports in all example scripts to use the package root for `ImednetSDK`.
 - Updated documentation examples to import `ImednetSDK` from the package root.
+- Introduced `AsyncEndpointMixin` and refactored async endpoints to reuse
+  pagination logic and client validation.
+- Added `SyncEndpointMixin` to consolidate synchronous list/get logic across
+  endpoints.
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -33,7 +33,9 @@ https://portal.prod.imednetapi.com/
 Calls to `sdk.studies.list()`, `sdk.forms.list()`, `sdk.intervals.list()` and
 `sdk.variables.list()` cache results in memory via a shared
 ``PagedEndpointMixin``. Pass ``refresh=True`` to bypass the cache. See
-`docs/caching.rst` for details.
+`docs/caching.rst` for details. Synchronous endpoints rely on
+``SyncEndpointMixin`` while asynchronous counterparts use
+``AsyncEndpointMixin`` to share pagination logic across modules.
 
 ## Installation
 

--- a/imednet/endpoints/__init__.py
+++ b/imednet/endpoints/__init__.py
@@ -4,6 +4,7 @@ Endpoints package for the iMedNet SDK.
 This package contains all API endpoint implementations for accessing iMedNet resources.
 """
 
+from imednet.endpoints.async_endpoint_mixin import AsyncEndpointMixin
 from imednet.endpoints.codings import CodingsEndpoint
 from imednet.endpoints.forms import FormsEndpoint
 from imednet.endpoints.intervals import IntervalsEndpoint
@@ -15,6 +16,7 @@ from imednet.endpoints.records import RecordsEndpoint
 from imednet.endpoints.sites import SitesEndpoint
 from imednet.endpoints.studies import StudiesEndpoint
 from imednet.endpoints.subjects import SubjectsEndpoint
+from imednet.endpoints.sync_endpoint_mixin import SyncEndpointMixin
 from imednet.endpoints.users import UsersEndpoint
 from imednet.endpoints.variables import VariablesEndpoint
 from imednet.endpoints.visits import VisitsEndpoint
@@ -25,6 +27,8 @@ __all__: list[str] = [
     "IntervalsEndpoint",
     "JobsEndpoint",
     "PagedEndpointMixin",
+    "AsyncEndpointMixin",
+    "SyncEndpointMixin",
     "QueriesEndpoint",
     "RecordRevisionsEndpoint",
     "RecordsEndpoint",

--- a/imednet/endpoints/async_endpoint_mixin.py
+++ b/imednet/endpoints/async_endpoint_mixin.py
@@ -1,0 +1,35 @@
+"""Shared async helpers for endpoint wrappers."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from imednet.core.async_client import AsyncClient
+from imednet.core.paginator import AsyncPaginator
+
+
+class AsyncEndpointMixin:
+    """Mixin providing async ``list`` and ``get`` helpers."""
+
+    def _require_async_client(self: Any) -> AsyncClient:
+        """Return the configured async client or raise a helpful error."""
+        if self._async_client is None:
+            raise RuntimeError("Async client not configured")
+        return self._async_client
+
+    async def async_list(self: Any, *args: Any, **kwargs: Any) -> Any:
+        """Delegate to ``_list_impl`` using :class:`AsyncPaginator`."""
+        if args:
+            if len(args) == 1 and "study_key" not in kwargs:
+                kwargs["study_key"] = args[0]
+            else:
+                raise TypeError("Invalid positional arguments")
+        client = self._require_async_client()
+        return await self._list_impl(client, AsyncPaginator, **kwargs)
+
+    async def async_get(self: Any, identifier: Any, *args: Any, **kwargs: Any) -> Any:
+        """Delegate to ``_get_impl`` using :class:`AsyncPaginator`."""
+        if args:
+            raise TypeError("Invalid positional arguments")
+        client = self._require_async_client()
+        return await self._get_impl(client, AsyncPaginator, identifier, **kwargs)

--- a/imednet/endpoints/codings.py
+++ b/imednet/endpoints/codings.py
@@ -1,13 +1,15 @@
 """Endpoint for managing codings (medical coding) in a study."""
 
-from typing import Any, List, Optional
+from typing import Any
 
-from imednet.core.paginator import AsyncPaginator, Paginator
+from imednet.core.paginator import Paginator  # noqa: F401
+from imednet.endpoints.async_endpoint_mixin import AsyncEndpointMixin
 from imednet.endpoints.paged_endpoint_mixin import PagedEndpointMixin
+from imednet.endpoints.sync_endpoint_mixin import SyncEndpointMixin
 from imednet.models.codings import Coding
 
 
-class CodingsEndpoint(PagedEndpointMixin):
+class CodingsEndpoint(SyncEndpointMixin, AsyncEndpointMixin, PagedEndpointMixin):
     """API endpoint for interacting with codings in an iMedNet study."""
 
     PATH = "/api/v1/edc/studies"
@@ -15,37 +17,10 @@ class CodingsEndpoint(PagedEndpointMixin):
     PATH_SUFFIX = "codings"
     ID_FILTER = "codingId"
 
-    def list(self, study_key: Optional[str] = None, **filters: Any) -> List[Coding]:
+    def list(self, study_key: str | None = None, **filters: Any) -> list[Coding]:
         """List codings in a study with optional filtering."""
-        result = self._list_impl(
-            self._client,
-            Paginator,
-            study_key=study_key,
-            **filters,
-        )
-        return result  # type: ignore[return-value]
+        return super().list(study_key=study_key, **filters)
 
-    async def async_list(self, study_key: Optional[str] = None, **filters: Any) -> List[Coding]:
-        """Asynchronous version of :meth:`list`."""
-        if self._async_client is None:
-            raise RuntimeError("Async client not configured")
-        result = await self._list_impl(
-            self._async_client,
-            AsyncPaginator,
-            study_key=study_key,
-            **filters,
-        )
-        return result
-
-    def get(self, study_key: str, coding_id: str) -> Coding:
+    def get(self, study_key: str, coding_id: str) -> Coding:  # type: ignore[override]
         """Get a specific coding by ID."""
-        result = self._get_impl(self._client, Paginator, coding_id, study_key=study_key)
-        return result  # type: ignore[return-value]
-
-    async def async_get(self, study_key: str, coding_id: str) -> Coding:
-        """Asynchronous version of :meth:`get`."""
-        if self._async_client is None:
-            raise RuntimeError("Async client not configured")
-        return await self._get_impl(
-            self._async_client, AsyncPaginator, coding_id, study_key=study_key
-        )
+        return super().get(coding_id, study_key=study_key)

--- a/imednet/endpoints/forms.py
+++ b/imednet/endpoints/forms.py
@@ -2,15 +2,14 @@
 
 from typing import Any, List, Optional
 
-from imednet.core.async_client import AsyncClient
-from imednet.core.client import Client
-from imednet.core.context import Context
-from imednet.core.paginator import AsyncPaginator, Paginator
+from imednet.core.paginator import Paginator  # noqa: F401
+from imednet.endpoints.async_endpoint_mixin import AsyncEndpointMixin
 from imednet.endpoints.paged_endpoint_mixin import PagedEndpointMixin
+from imednet.endpoints.sync_endpoint_mixin import SyncEndpointMixin
 from imednet.models.forms import Form
 
 
-class FormsEndpoint(PagedEndpointMixin):
+class FormsEndpoint(SyncEndpointMixin, AsyncEndpointMixin, PagedEndpointMixin):
     """API endpoint for interacting with forms in an iMedNet study."""
 
     PATH = "/api/v1/edc/studies"
@@ -20,14 +19,6 @@ class FormsEndpoint(PagedEndpointMixin):
     PAGE_SIZE = 500
     CACHE_ENABLED = True
 
-    def __init__(
-        self,
-        client: Client,
-        ctx: Context,
-        async_client: AsyncClient | None = None,
-    ) -> None:
-        super().__init__(client, ctx, async_client)
-
     def list(
         self,
         study_key: Optional[str] = None,
@@ -35,42 +26,8 @@ class FormsEndpoint(PagedEndpointMixin):
         **filters: Any,
     ) -> List[Form]:
         """List forms in a study with optional filtering."""
-        result = self._list_impl(
-            self._client,
-            Paginator,
-            study_key=study_key,
-            refresh=refresh,
-            **filters,
-        )
-        return result  # type: ignore[return-value]
+        return super().list(study_key=study_key, refresh=refresh, **filters)
 
-    async def async_list(
-        self,
-        study_key: Optional[str] = None,
-        refresh: bool = False,
-        **filters: Any,
-    ) -> List[Form]:
-        """Asynchronous version of :meth:`list`."""
-        if self._async_client is None:
-            raise RuntimeError("Async client not configured")
-        result = await self._list_impl(
-            self._async_client,
-            AsyncPaginator,
-            study_key=study_key,
-            refresh=refresh,
-            **filters,
-        )
-        return result
-
-    def get(self, study_key: str, form_id: int) -> Form:
+    def get(self, study_key: str, form_id: int) -> Form:  # type: ignore[override]
         """Get a specific form by ID."""
-        result = self._get_impl(self._client, Paginator, form_id, study_key=study_key)
-        return result  # type: ignore[return-value]
-
-    async def async_get(self, study_key: str, form_id: int) -> Form:
-        """Asynchronous version of :meth:`get`."""
-        if self._async_client is None:
-            raise RuntimeError("Async client not configured")
-        return await self._get_impl(
-            self._async_client, AsyncPaginator, form_id, study_key=study_key
-        )
+        return super().get(form_id, study_key=study_key)

--- a/imednet/endpoints/intervals.py
+++ b/imednet/endpoints/intervals.py
@@ -2,15 +2,14 @@
 
 from typing import Any, List, Optional
 
-from imednet.core.async_client import AsyncClient
-from imednet.core.client import Client
-from imednet.core.context import Context
-from imednet.core.paginator import AsyncPaginator, Paginator
+from imednet.core.paginator import Paginator  # noqa: F401
+from imednet.endpoints.async_endpoint_mixin import AsyncEndpointMixin
 from imednet.endpoints.paged_endpoint_mixin import PagedEndpointMixin
+from imednet.endpoints.sync_endpoint_mixin import SyncEndpointMixin
 from imednet.models.intervals import Interval
 
 
-class IntervalsEndpoint(PagedEndpointMixin):
+class IntervalsEndpoint(SyncEndpointMixin, AsyncEndpointMixin, PagedEndpointMixin):
     """API endpoint for interacting with intervals in an iMedNet study."""
 
     PATH = "/api/v1/edc/studies"
@@ -20,51 +19,12 @@ class IntervalsEndpoint(PagedEndpointMixin):
     PAGE_SIZE = 500
     CACHE_ENABLED = True
 
-    def __init__(
-        self,
-        client: Client,
-        ctx: Context,
-        async_client: AsyncClient | None = None,
-    ) -> None:
-        super().__init__(client, ctx, async_client)
-
     def list(
         self, study_key: Optional[str] = None, refresh: bool = False, **filters: Any
     ) -> List[Interval]:
         """List intervals in a study with optional filtering."""
-        result = self._list_impl(
-            self._client,
-            Paginator,
-            study_key=study_key,
-            refresh=refresh,
-            **filters,
-        )
-        return result  # type: ignore[return-value]
+        return super().list(study_key=study_key, refresh=refresh, **filters)
 
-    async def async_list(
-        self, study_key: Optional[str] = None, refresh: bool = False, **filters: Any
-    ) -> List[Interval]:
-        """Asynchronous version of :meth:`list`."""
-        if self._async_client is None:
-            raise RuntimeError("Async client not configured")
-        result = await self._list_impl(
-            self._async_client,
-            AsyncPaginator,
-            study_key=study_key,
-            refresh=refresh,
-            **filters,
-        )
-        return result
-
-    def get(self, study_key: str, interval_id: int) -> Interval:
+    def get(self, study_key: str, interval_id: int) -> Interval:  # type: ignore[override]
         """Get a specific interval by ID."""
-        result = self._get_impl(self._client, Paginator, interval_id, study_key=study_key)
-        return result  # type: ignore[return-value]
-
-    async def async_get(self, study_key: str, interval_id: int) -> Interval:
-        """Asynchronous version of :meth:`get`."""
-        if self._async_client is None:
-            raise RuntimeError("Async client not configured")
-        return await self._get_impl(
-            self._async_client, AsyncPaginator, interval_id, study_key=study_key
-        )
+        return super().get(interval_id, study_key=study_key)

--- a/imednet/endpoints/jobs.py
+++ b/imednet/endpoints/jobs.py
@@ -3,11 +3,12 @@
 import inspect
 from typing import Any
 
+from imednet.endpoints.async_endpoint_mixin import AsyncEndpointMixin
 from imednet.endpoints.base import BaseEndpoint
 from imednet.models.jobs import JobStatus
 
 
-class JobsEndpoint(BaseEndpoint):
+class JobsEndpoint(AsyncEndpointMixin, BaseEndpoint):
     """
     API endpoint for retrieving status and details of jobs in an iMedNet study.
 
@@ -52,12 +53,11 @@ class JobsEndpoint(BaseEndpoint):
         result = self._get_impl(self._client, study_key, batch_id)
         return result  # type: ignore[return-value]
 
-    async def async_get(self, study_key: str, batch_id: str) -> JobStatus:
+    async def async_get(self, study_key: str, batch_id: str) -> JobStatus:  # type: ignore[override]
         """Asynchronous version of :meth:`get`.
 
         Like the sync variant, it simply issues a request by ``batch_id``
         without any caching.
         """
-        if self._async_client is None:
-            raise RuntimeError("Async client not configured")
-        return await self._get_impl(self._async_client, study_key, batch_id)
+        client = self._require_async_client()
+        return await self._get_impl(client, study_key, batch_id)

--- a/imednet/endpoints/queries.py
+++ b/imednet/endpoints/queries.py
@@ -1,13 +1,15 @@
 """Endpoint for managing queries (dialogue/questions) in a study."""
 
-from typing import Any, List, Optional
+from typing import Any
 
-from imednet.core.paginator import AsyncPaginator, Paginator
+from imednet.core.paginator import Paginator  # noqa: F401
+from imednet.endpoints.async_endpoint_mixin import AsyncEndpointMixin
 from imednet.endpoints.paged_endpoint_mixin import PagedEndpointMixin
+from imednet.endpoints.sync_endpoint_mixin import SyncEndpointMixin
 from imednet.models.queries import Query
 
 
-class QueriesEndpoint(PagedEndpointMixin):
+class QueriesEndpoint(SyncEndpointMixin, AsyncEndpointMixin, PagedEndpointMixin):
     """API endpoint for interacting with queries in an iMedNet study."""
 
     PATH = "/api/v1/edc/studies"
@@ -16,37 +18,10 @@ class QueriesEndpoint(PagedEndpointMixin):
     ID_FILTER = "annotationId"
     INCLUDE_STUDY_IN_FILTER = True
 
-    def list(self, study_key: Optional[str] = None, **filters: Any) -> List[Query]:
+    def list(self, study_key: str | None = None, **filters: Any) -> list[Query]:
         """List queries in a study with optional filtering."""
-        result = self._list_impl(
-            self._client,
-            Paginator,
-            study_key=study_key,
-            **filters,
-        )
-        return result  # type: ignore[return-value]
+        return super().list(study_key=study_key, **filters)
 
-    async def async_list(self, study_key: Optional[str] = None, **filters: Any) -> List[Query]:
-        """Asynchronous version of :meth:`list`."""
-        if self._async_client is None:
-            raise RuntimeError("Async client not configured")
-        result = await self._list_impl(
-            self._async_client,
-            AsyncPaginator,
-            study_key=study_key,
-            **filters,
-        )
-        return result
-
-    def get(self, study_key: str, annotation_id: int) -> Query:
+    def get(self, study_key: str, annotation_id: int) -> Query:  # type: ignore[override]
         """Get a specific query by annotation ID."""
-        result = self._get_impl(self._client, Paginator, annotation_id, study_key=study_key)
-        return result  # type: ignore[return-value]
-
-    async def async_get(self, study_key: str, annotation_id: int) -> Query:
-        """Asynchronous version of :meth:`get`."""
-        if self._async_client is None:
-            raise RuntimeError("Async client not configured")
-        return await self._get_impl(
-            self._async_client, AsyncPaginator, annotation_id, study_key=study_key
-        )
+        return super().get(annotation_id, study_key=study_key)

--- a/imednet/endpoints/record_revisions.py
+++ b/imednet/endpoints/record_revisions.py
@@ -1,13 +1,15 @@
 """Endpoint for retrieving record revision history in a study."""
 
-from typing import Any, List, Optional
+from typing import Any
 
-from imednet.core.paginator import AsyncPaginator, Paginator
+from imednet.core.paginator import Paginator  # noqa: F401
+from imednet.endpoints.async_endpoint_mixin import AsyncEndpointMixin
 from imednet.endpoints.paged_endpoint_mixin import PagedEndpointMixin
+from imednet.endpoints.sync_endpoint_mixin import SyncEndpointMixin
 from imednet.models.record_revisions import RecordRevision
 
 
-class RecordRevisionsEndpoint(PagedEndpointMixin):
+class RecordRevisionsEndpoint(SyncEndpointMixin, AsyncEndpointMixin, PagedEndpointMixin):
     """API endpoint for accessing record revision history in an iMedNet study."""
 
     PATH = "/api/v1/edc/studies"
@@ -16,42 +18,10 @@ class RecordRevisionsEndpoint(PagedEndpointMixin):
     ID_FILTER = "recordRevisionId"
     INCLUDE_STUDY_IN_FILTER = True
 
-    def list(self, study_key: Optional[str] = None, **filters: Any) -> List[RecordRevision]:
+    def list(self, study_key: str | None = None, **filters: Any) -> list[RecordRevision]:
         """List record revisions in a study with optional filtering."""
-        result = self._list_impl(
-            self._client,
-            Paginator,
-            study_key=study_key,
-            **filters,
-        )
-        return result  # type: ignore[return-value]
+        return super().list(study_key=study_key, **filters)
 
-    async def async_list(
-        self, study_key: Optional[str] = None, **filters: Any
-    ) -> List[RecordRevision]:
-        """Asynchronous version of :meth:`list`."""
-        if self._async_client is None:
-            raise RuntimeError("Async client not configured")
-        result = await self._list_impl(
-            self._async_client,
-            AsyncPaginator,
-            study_key=study_key,
-            **filters,
-        )
-        return result
-
-    def get(self, study_key: str, record_revision_id: int) -> RecordRevision:
+    def get(self, study_key: str, record_revision_id: int) -> RecordRevision:  # type: ignore[override]
         """Get a specific record revision by ID."""
-        result = self._get_impl(self._client, Paginator, record_revision_id, study_key=study_key)
-        return result  # type: ignore[return-value]
-
-    async def async_get(self, study_key: str, record_revision_id: int) -> RecordRevision:
-        """Asynchronous version of :meth:`get`."""
-        if self._async_client is None:
-            raise RuntimeError("Async client not configured")
-        return await self._get_impl(
-            self._async_client,
-            AsyncPaginator,
-            record_revision_id,
-            study_key=study_key,
-        )
+        return super().get(record_revision_id, study_key=study_key)

--- a/imednet/endpoints/sites.py
+++ b/imednet/endpoints/sites.py
@@ -1,13 +1,15 @@
 """Endpoint for managing sites (study locations) in a study."""
 
-from typing import Any, List, Optional
+from typing import Any
 
-from imednet.core.paginator import AsyncPaginator, Paginator
+from imednet.core.paginator import Paginator  # noqa: F401
+from imednet.endpoints.async_endpoint_mixin import AsyncEndpointMixin
 from imednet.endpoints.paged_endpoint_mixin import PagedEndpointMixin
+from imednet.endpoints.sync_endpoint_mixin import SyncEndpointMixin
 from imednet.models.sites import Site
 
 
-class SitesEndpoint(PagedEndpointMixin):
+class SitesEndpoint(SyncEndpointMixin, AsyncEndpointMixin, PagedEndpointMixin):
     """API endpoint for interacting with sites in an iMedNet study."""
 
     PATH = "/api/v1/edc/studies"
@@ -15,37 +17,10 @@ class SitesEndpoint(PagedEndpointMixin):
     PATH_SUFFIX = "sites"
     ID_FILTER = "siteId"
 
-    def list(self, study_key: Optional[str] = None, **filters: Any) -> List[Site]:
+    def list(self, study_key: str | None = None, **filters: Any) -> list[Site]:
         """List sites in a study with optional filtering."""
-        result = self._list_impl(
-            self._client,
-            Paginator,
-            study_key=study_key,
-            **filters,
-        )
-        return result  # type: ignore[return-value]
+        return super().list(study_key=study_key, **filters)
 
-    async def async_list(self, study_key: Optional[str] = None, **filters: Any) -> List[Site]:
-        """Asynchronous version of :meth:`list`."""
-        if self._async_client is None:
-            raise RuntimeError("Async client not configured")
-        result = await self._list_impl(
-            self._async_client,
-            AsyncPaginator,
-            study_key=study_key,
-            **filters,
-        )
-        return result
-
-    def get(self, study_key: str, site_id: int) -> Site:
+    def get(self, study_key: str, site_id: int) -> Site:  # type: ignore[override]
         """Get a specific site by ID."""
-        result = self._get_impl(self._client, Paginator, site_id, study_key=study_key)
-        return result  # type: ignore[return-value]
-
-    async def async_get(self, study_key: str, site_id: int) -> Site:
-        """Asynchronous version of :meth:`get`."""
-        if self._async_client is None:
-            raise RuntimeError("Async client not configured")
-        return await self._get_impl(
-            self._async_client, AsyncPaginator, site_id, study_key=study_key
-        )
+        return super().get(site_id, study_key=study_key)

--- a/imednet/endpoints/studies.py
+++ b/imednet/endpoints/studies.py
@@ -2,15 +2,14 @@
 
 from typing import Any, List
 
-from imednet.core.async_client import AsyncClient
-from imednet.core.client import Client
-from imednet.core.context import Context
-from imednet.core.paginator import AsyncPaginator, Paginator
+from imednet.core.paginator import Paginator  # noqa: F401
+from imednet.endpoints.async_endpoint_mixin import AsyncEndpointMixin
 from imednet.endpoints.paged_endpoint_mixin import PagedEndpointMixin
+from imednet.endpoints.sync_endpoint_mixin import SyncEndpointMixin
 from imednet.models.studies import Study
 
 
-class StudiesEndpoint(PagedEndpointMixin):
+class StudiesEndpoint(SyncEndpointMixin, AsyncEndpointMixin, PagedEndpointMixin):
     """API endpoint for interacting with studies in the iMedNet system."""
 
     PATH = "/api/v1/edc/studies"
@@ -18,43 +17,10 @@ class StudiesEndpoint(PagedEndpointMixin):
     ID_FILTER = "studyKey"
     CACHE_ENABLED = True
 
-    def __init__(
-        self,
-        client: Client,
-        ctx: Context,
-        async_client: AsyncClient | None = None,
-    ) -> None:
-        super().__init__(client, ctx, async_client)
-
     def list(self, refresh: bool = False, **filters: Any) -> List[Study]:
         """List studies with optional filtering."""
-        result = self._list_impl(
-            self._client,
-            Paginator,
-            refresh=refresh,
-            **filters,
-        )
-        return result  # type: ignore[return-value]
+        return super().list(refresh=refresh, **filters)
 
-    async def async_list(self, refresh: bool = False, **filters: Any) -> List[Study]:
-        """Asynchronous version of :meth:`list`."""
-        if self._async_client is None:
-            raise RuntimeError("Async client not configured")
-        result = await self._list_impl(
-            self._async_client,
-            AsyncPaginator,
-            refresh=refresh,
-            **filters,
-        )
-        return result
-
-    def get(self, study_key: str) -> Study:
+    def get(self, study_key: str) -> Study:  # type: ignore[override]
         """Get a specific study by key."""
-        result = self._get_impl(self._client, Paginator, study_key)
-        return result  # type: ignore[return-value]
-
-    async def async_get(self, study_key: str) -> Study:
-        """Asynchronous version of :meth:`get`."""
-        if self._async_client is None:
-            raise RuntimeError("Async client not configured")
-        return await self._get_impl(self._async_client, AsyncPaginator, study_key)
+        return super().get(study_key)

--- a/imednet/endpoints/subjects.py
+++ b/imednet/endpoints/subjects.py
@@ -1,13 +1,15 @@
 """Endpoint for managing subjects in a study."""
 
-from typing import Any, List, Optional
+from typing import Any
 
-from imednet.core.paginator import AsyncPaginator, Paginator
+from imednet.core.paginator import Paginator  # noqa: F401
+from imednet.endpoints.async_endpoint_mixin import AsyncEndpointMixin
 from imednet.endpoints.paged_endpoint_mixin import PagedEndpointMixin
+from imednet.endpoints.sync_endpoint_mixin import SyncEndpointMixin
 from imednet.models.subjects import Subject
 
 
-class SubjectsEndpoint(PagedEndpointMixin):
+class SubjectsEndpoint(SyncEndpointMixin, AsyncEndpointMixin, PagedEndpointMixin):
     """API endpoint for interacting with subjects in an iMedNet study."""
 
     PATH = "/api/v1/edc/studies"
@@ -16,40 +18,10 @@ class SubjectsEndpoint(PagedEndpointMixin):
     ID_FILTER = "subjectKey"
     INCLUDE_STUDY_IN_FILTER = True
 
-    def list(self, study_key: Optional[str] = None, **filters: Any) -> List[Subject]:
+    def list(self, study_key: str | None = None, **filters: Any) -> list[Subject]:
         """List subjects in a study with optional filtering."""
-        result = self._list_impl(
-            self._client,
-            Paginator,
-            study_key=study_key,
-            **filters,
-        )
-        return result  # type: ignore[return-value]
+        return super().list(study_key=study_key, **filters)
 
-    async def async_list(self, study_key: Optional[str] = None, **filters: Any) -> List[Subject]:
-        """Asynchronous version of :meth:`list`."""
-        if self._async_client is None:
-            raise RuntimeError("Async client not configured")
-        result = await self._list_impl(
-            self._async_client,
-            AsyncPaginator,
-            study_key=study_key,
-            **filters,
-        )
-        return result
-
-    def get(self, study_key: str, subject_key: str) -> Subject:
+    def get(self, study_key: str, subject_key: str) -> Subject:  # type: ignore[override]
         """Get a specific subject by key."""
-        result = self._get_impl(self._client, Paginator, subject_key, study_key=study_key)
-        return result  # type: ignore[return-value]
-
-    async def async_get(self, study_key: str, subject_key: str) -> Subject:
-        """Asynchronous version of :meth:`get`."""
-        if self._async_client is None:
-            raise RuntimeError("Async client not configured")
-        return await self._get_impl(
-            self._async_client,
-            AsyncPaginator,
-            subject_key,
-            study_key=study_key,
-        )
+        return super().get(subject_key, study_key=study_key)

--- a/imednet/endpoints/sync_endpoint_mixin.py
+++ b/imednet/endpoints/sync_endpoint_mixin.py
@@ -1,0 +1,26 @@
+"""Shared sync helpers for endpoint wrappers."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from imednet.core.paginator import Paginator
+
+
+class SyncEndpointMixin:
+    """Mixin providing sync ``list`` and ``get`` helpers."""
+
+    def list(self: Any, *args: Any, **kwargs: Any) -> Any:
+        """Delegate to ``_list_impl`` using :class:`Paginator`."""
+        if args:
+            if len(args) == 1 and "study_key" not in kwargs:
+                kwargs["study_key"] = args[0]
+            else:
+                raise TypeError("Invalid positional arguments")
+        return self._list_impl(self._client, Paginator, **kwargs)
+
+    def get(self: Any, identifier: Any, *args: Any, **kwargs: Any) -> Any:
+        """Delegate to ``_get_impl`` using :class:`Paginator`."""
+        if args:
+            raise TypeError("Invalid positional arguments")
+        return self._get_impl(self._client, Paginator, identifier, **kwargs)

--- a/imednet/endpoints/users.py
+++ b/imednet/endpoints/users.py
@@ -2,12 +2,14 @@
 
 from typing import Any, List, Optional, Union
 
-from imednet.core.paginator import AsyncPaginator, Paginator
+from imednet.core.paginator import Paginator  # noqa: F401
+from imednet.endpoints.async_endpoint_mixin import AsyncEndpointMixin
 from imednet.endpoints.paged_endpoint_mixin import PagedEndpointMixin
+from imednet.endpoints.sync_endpoint_mixin import SyncEndpointMixin
 from imednet.models.users import User
 
 
-class UsersEndpoint(PagedEndpointMixin):
+class UsersEndpoint(SyncEndpointMixin, AsyncEndpointMixin, PagedEndpointMixin):
     """API endpoint for interacting with users in an iMedNet study."""
 
     PATH = "/api/v1/edc/studies"
@@ -23,13 +25,7 @@ class UsersEndpoint(PagedEndpointMixin):
         """List users in a study with optional filtering."""
         if include_inactive:
             filters["include_inactive"] = include_inactive
-        result = self._list_impl(
-            self._client,
-            Paginator,
-            study_key=study_key,
-            **filters,
-        )
-        return result  # type: ignore[return-value]
+        return super().list(study_key=study_key, **filters)
 
     async def async_list(
         self,
@@ -38,27 +34,14 @@ class UsersEndpoint(PagedEndpointMixin):
         **filters: Any,
     ) -> List[User]:
         """Asynchronous version of :meth:`list`."""
-        if self._async_client is None:
-            raise RuntimeError("Async client not configured")
         if include_inactive:
             filters["include_inactive"] = include_inactive
-        result = await self._list_impl(
-            self._async_client,
-            AsyncPaginator,
-            study_key=study_key,
-            **filters,
-        )
-        return result
+        return await super().async_list(study_key=study_key, **filters)
 
-    def get(self, study_key: str, user_id: Union[str, int]) -> User:
+    def get(self, study_key: str, user_id: Union[str, int]) -> User:  # type: ignore[override]
         """Get a specific user by ID."""
-        result = self._get_impl(self._client, Paginator, user_id, study_key=study_key)
-        return result  # type: ignore[return-value]
+        return super().get(user_id, study_key=study_key)
 
-    async def async_get(self, study_key: str, user_id: Union[str, int]) -> User:
+    async def async_get(self, study_key: str, user_id: Union[str, int]) -> User:  # type: ignore[override]
         """Asynchronous version of :meth:`get`."""
-        if self._async_client is None:
-            raise RuntimeError("Async client not configured")
-        return await self._get_impl(
-            self._async_client, AsyncPaginator, user_id, study_key=study_key
-        )
+        return await super().async_get(user_id, study_key=study_key)

--- a/imednet/endpoints/variables.py
+++ b/imednet/endpoints/variables.py
@@ -2,15 +2,14 @@
 
 from typing import Any, List, Optional
 
-from imednet.core.async_client import AsyncClient
-from imednet.core.client import Client
-from imednet.core.context import Context
-from imednet.core.paginator import AsyncPaginator, Paginator
+from imednet.core.paginator import Paginator  # noqa: F401
+from imednet.endpoints.async_endpoint_mixin import AsyncEndpointMixin
 from imednet.endpoints.paged_endpoint_mixin import PagedEndpointMixin
+from imednet.endpoints.sync_endpoint_mixin import SyncEndpointMixin
 from imednet.models.variables import Variable
 
 
-class VariablesEndpoint(PagedEndpointMixin):
+class VariablesEndpoint(SyncEndpointMixin, AsyncEndpointMixin, PagedEndpointMixin):
     """API endpoint for interacting with variables in an iMedNet study."""
 
     PATH = "/api/v1/edc/studies"
@@ -20,51 +19,12 @@ class VariablesEndpoint(PagedEndpointMixin):
     PAGE_SIZE = 500
     CACHE_ENABLED = True
 
-    def __init__(
-        self,
-        client: Client,
-        ctx: Context,
-        async_client: AsyncClient | None = None,
-    ) -> None:
-        super().__init__(client, ctx, async_client)
-
     def list(
         self, study_key: Optional[str] = None, refresh: bool = False, **filters: Any
     ) -> List[Variable]:
         """List variables in a study with optional filtering."""
-        result = self._list_impl(
-            self._client,
-            Paginator,
-            study_key=study_key,
-            refresh=refresh,
-            **filters,
-        )
-        return result  # type: ignore[return-value]
+        return super().list(study_key=study_key, refresh=refresh, **filters)
 
-    async def async_list(
-        self, study_key: Optional[str] = None, refresh: bool = False, **filters: Any
-    ) -> List[Variable]:
-        """Asynchronous version of :meth:`list`."""
-        if self._async_client is None:
-            raise RuntimeError("Async client not configured")
-        result = await self._list_impl(
-            self._async_client,
-            AsyncPaginator,
-            study_key=study_key,
-            refresh=refresh,
-            **filters,
-        )
-        return result
-
-    def get(self, study_key: str, variable_id: int) -> Variable:
+    def get(self, study_key: str, variable_id: int) -> Variable:  # type: ignore[override]
         """Get a specific variable by ID."""
-        result = self._get_impl(self._client, Paginator, variable_id, study_key=study_key)
-        return result  # type: ignore[return-value]
-
-    async def async_get(self, study_key: str, variable_id: int) -> Variable:
-        """Asynchronous version of :meth:`get`."""
-        if self._async_client is None:
-            raise RuntimeError("Async client not configured")
-        return await self._get_impl(
-            self._async_client, AsyncPaginator, variable_id, study_key=study_key
-        )
+        return super().get(variable_id, study_key=study_key)

--- a/imednet/endpoints/visits.py
+++ b/imednet/endpoints/visits.py
@@ -1,13 +1,15 @@
 """Endpoint for managing visits (interval instances) in a study."""
 
-from typing import Any, List, Optional
+from typing import Any
 
-from imednet.core.paginator import AsyncPaginator, Paginator
+from imednet.core.paginator import Paginator  # noqa: F401
+from imednet.endpoints.async_endpoint_mixin import AsyncEndpointMixin
 from imednet.endpoints.paged_endpoint_mixin import PagedEndpointMixin
+from imednet.endpoints.sync_endpoint_mixin import SyncEndpointMixin
 from imednet.models.visits import Visit
 
 
-class VisitsEndpoint(PagedEndpointMixin):
+class VisitsEndpoint(SyncEndpointMixin, AsyncEndpointMixin, PagedEndpointMixin):
     """API endpoint for interacting with visits in an iMedNet study."""
 
     PATH = "/api/v1/edc/studies"
@@ -16,37 +18,10 @@ class VisitsEndpoint(PagedEndpointMixin):
     ID_FILTER = "visitId"
     INCLUDE_STUDY_IN_FILTER = True
 
-    def list(self, study_key: Optional[str] = None, **filters: Any) -> List[Visit]:
+    def list(self, study_key: str | None = None, **filters: Any) -> list[Visit]:
         """List visits in a study with optional filtering."""
-        result = self._list_impl(
-            self._client,
-            Paginator,
-            study_key=study_key,
-            **filters,
-        )
-        return result  # type: ignore[return-value]
+        return super().list(study_key=study_key, **filters)
 
-    async def async_list(self, study_key: Optional[str] = None, **filters: Any) -> List[Visit]:
-        """Asynchronous version of :meth:`list`."""
-        if self._async_client is None:
-            raise RuntimeError("Async client not configured")
-        result = await self._list_impl(
-            self._async_client,
-            AsyncPaginator,
-            study_key=study_key,
-            **filters,
-        )
-        return result
-
-    def get(self, study_key: str, visit_id: int) -> Visit:
+    def get(self, study_key: str, visit_id: int) -> Visit:  # type: ignore[override]
         """Get a specific visit by ID."""
-        result = self._get_impl(self._client, Paginator, visit_id, study_key=study_key)
-        return result  # type: ignore[return-value]
-
-    async def async_get(self, study_key: str, visit_id: int) -> Visit:
-        """Asynchronous version of :meth:`get`."""
-        if self._async_client is None:
-            raise RuntimeError("Async client not configured")
-        return await self._get_impl(
-            self._async_client, AsyncPaginator, visit_id, study_key=study_key
-        )
+        return super().get(visit_id, study_key=study_key)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -50,7 +50,7 @@ def paginator_factory(monkeypatch):
             def __iter__(self):
                 yield from self._items
 
-        monkeypatch.setattr(module, "Paginator", DummyPaginator)
+        monkeypatch.setattr("imednet.endpoints.sync_endpoint_mixin.Paginator", DummyPaginator)
         return captured
 
     return factory
@@ -74,7 +74,7 @@ def async_paginator_factory(monkeypatch):
                 for item in self._items:
                     yield item
 
-        monkeypatch.setattr(module, "AsyncPaginator", DummyPaginator)
+        monkeypatch.setattr("imednet.endpoints.async_endpoint_mixin.AsyncPaginator", DummyPaginator)
         return captured
 
     return factory

--- a/tests/unit/endpoints/test_endpoints_async.py
+++ b/tests/unit/endpoints/test_endpoints_async.py
@@ -200,3 +200,10 @@ async def test_async_create_record(dummy_client, context, response_factory, monk
         headers={"x-email-notify": "user@test"},
     )
     assert job == {"jobId": "1"}
+
+
+@pytest.mark.asyncio
+async def test_async_client_required(dummy_client, context):
+    ep = codings.CodingsEndpoint(dummy_client, context)
+    with pytest.raises(RuntimeError):
+        await ep.async_list(study_key="S1")


### PR DESCRIPTION
## Summary
- introduce `SyncEndpointMixin` for synchronous list/get helpers
- update endpoint modules to delegate through the mixin
- patch tests to monkeypatch `Paginator` in the new mixin
- document mixin usage and log in changelog

## Testing
- `poetry run ruff check --fix .`
- `poetry run black --check .`
- `poetry run mypy imednet`
- `poetry run pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6863f3fa5678832c9eb35837b243d22a