### PR TITLE
Extract reusable JobPoller

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Consolidated job polling logic into a reusable ``JobPoller`` supporting sync
+  and async flows.
 ## [0.1.1] - 2025-07-02
 
 ### Features and Improvements

--- a/docs/job_polling.rst
+++ b/docs/job_polling.rst
@@ -8,7 +8,7 @@ a timeout occurs.
 .. mermaid::
 
    graph TD
-       A[start wait()] --> B[get job status]
+       A[start run()] --> B[get job status]
        B --> C{terminal state?}
        C -- Yes --> D[return status]
        C -- No --> E{timeout exceeded?}

--- a/docs/workflow_interactions.rst
+++ b/docs/workflow_interactions.rst
@@ -29,7 +29,7 @@ Record Update
        A[create_or_update_records] --> B[validate_batch]
        B --> C[records.create]
        C --> D{wait?}
-       D -- Yes --> E[JobPoller.wait]
+       D -- Yes --> E[JobPoller.run]
        D -- No --> F[return Job]
        E --> F
 

--- a/examples/workflows/update_record.py
+++ b/examples/workflows/update_record.py
@@ -35,7 +35,7 @@ try:
     if not job.batch_id:
         raise RuntimeError("Submission succeeded but no batch ID returned")
 
-    status = JobPoller(sdk, study_key, job.batch_id).wait()
+    status = JobPoller(sdk.jobs.get, False).run(study_key, job.batch_id)
     print(f"Job {status.batch_id} finished with state: {status.state}")
 except Exception as e:
     print(f"Error creating record: {e}")

--- a/imednet/workflows/record_update.py
+++ b/imednet/workflows/record_update.py
@@ -49,13 +49,12 @@ class RecordUpdateWorkflow:
             return job
         if not job.batch_id:
             raise ValueError("Submission successful but no batch_id received.")
-        return JobPoller(
-            self._sdk,
+        return JobPoller(self._sdk.jobs.get, False).run(
             study_key,
             job.batch_id,
-            timeout_s=timeout,
-            poll_interval_s=poll_interval,
-        ).wait()
+            poll_interval,
+            timeout,
+        )
 
     def submit_record_batch(self, *args: Any, **kwargs: Any) -> Job:  # pragma: no cover
         warnings.warn(

--- a/tests/unit/async/test_async_job_poller.py
+++ b/tests/unit/async/test_async_job_poller.py
@@ -1,0 +1,50 @@
+import asyncio
+from unittest.mock import AsyncMock
+
+import pytest
+from imednet.models.jobs import JobStatus
+from imednet.workflows.job_poller import JobPoller, JobTimeoutError
+
+
+@pytest.mark.asyncio
+async def test_async_job_poller_success(monkeypatch) -> None:
+    get_job = AsyncMock()
+    states = [
+        JobStatus(batch_id="1", state="PROCESSING", progress=10),
+        JobStatus(batch_id="1", state="COMPLETED", progress=100),
+    ]
+    get_job.side_effect = lambda s, b: states.pop(0)
+    monkeypatch.setattr(asyncio, "sleep", AsyncMock())
+
+    poller = JobPoller(get_job, True)
+    result = await poller.run_async("STUDY", "1", interval=0, timeout=5)
+    assert result.state == "COMPLETED"
+
+
+@pytest.mark.asyncio
+async def test_async_job_poller_timeout(monkeypatch) -> None:
+    get_job = AsyncMock(return_value=JobStatus(batch_id="1", state="PROCESSING"))
+    monkeypatch.setattr(asyncio, "sleep", AsyncMock())
+    tick = {"v": 0}
+
+    def monotonic() -> int:
+        tick["v"] += 1
+        return tick["v"]
+
+    monkeypatch.setattr("time.monotonic", monotonic)
+    poller = JobPoller(get_job, True)
+    with pytest.raises(JobTimeoutError):
+        await poller.run_async("S", "1", interval=0, timeout=2)
+
+
+@pytest.mark.asyncio
+async def test_async_job_poller_failed(monkeypatch) -> None:
+    states = [
+        JobStatus(batch_id="1", state="PROCESSING"),
+        JobStatus(batch_id="1", state="FAILED"),
+    ]
+    get_job = AsyncMock(side_effect=lambda s, b: states.pop(0))
+    monkeypatch.setattr(asyncio, "sleep", AsyncMock())
+    poller = JobPoller(get_job, True)
+    with pytest.raises(RuntimeError):
+        await poller.run_async("S", "1", interval=0, timeout=5)

--- a/tests/unit/test_poll_job.py
+++ b/tests/unit/test_poll_job.py
@@ -18,7 +18,7 @@ def test_poll_job_success(monkeypatch) -> None:
         JobStatus(batch_id="1", state="COMPLETED", progress=100),
     ]
 
-    monkeypatch.setattr(sdk, "get_job", lambda s, b: states.pop(0))
+    monkeypatch.setattr(sdk.jobs, "get", lambda s, b: states.pop(0))
     monkeypatch.setattr("time.sleep", lambda *a: None)
     result = sdk.poll_job("STUDY", "1", interval=0, timeout=5)
     assert result.state == "COMPLETED"
@@ -27,7 +27,7 @@ def test_poll_job_success(monkeypatch) -> None:
 def test_poll_job_timeout(monkeypatch) -> None:
     sdk = _create_sdk()
     job = JobStatus(batch_id="1", state="PROCESSING")
-    monkeypatch.setattr(sdk, "get_job", lambda s, b: job)
+    monkeypatch.setattr(sdk.jobs, "get", lambda s, b: job)
 
     t = {"v": 0}
 
@@ -47,7 +47,7 @@ def test_poll_job_failed(monkeypatch) -> None:
         JobStatus(batch_id="1", state="PROCESSING"),
         JobStatus(batch_id="1", state="FAILED"),
     ]
-    monkeypatch.setattr(sdk, "get_job", lambda s, b: states.pop(0))
+    monkeypatch.setattr(sdk.jobs, "get", lambda s, b: states.pop(0))
     monkeypatch.setattr("time.sleep", lambda *a: None)
     with pytest.raises(RuntimeError):
         sdk.poll_job("S", "1", interval=0, timeout=5)


### PR DESCRIPTION
## Summary
- implement generic JobPoller supporting sync & async polling
- update SDK methods and RecordUpdate workflow to use the new helper
- add async JobPoller tests and adjust existing polling tests
- refresh documentation and example usage
- document change in `CHANGELOG`

## Testing
- `poetry run ruff check --fix .`
- `poetry run black --check .`
- `poetry run mypy imednet`
- `poetry run pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6866abf3b264832c8bc3651abdbf7cb1