### PR TITLE
Create ListGetEndpointMixin

### DIFF
--- a/imednet/endpoints/_mixins.py
+++ b/imednet/endpoints/_mixins.py
@@ -1,0 +1,153 @@
+from __future__ import annotations
+
+import inspect
+import sys
+from typing import Any, Dict, List, Optional
+
+from imednet.utils.filters import build_filter_string as default_build_filter_string
+
+from .base import BaseEndpoint
+
+
+class ListGetEndpointMixin(BaseEndpoint):
+    """Shared list/get helpers for endpoints."""
+
+    BASE_PATH = "/api/v1/edc/studies"
+    PATH: str
+    MODEL: Any
+    ID_FIELD: str
+    _cache_name: str | None = None
+    _pop_study_key: bool = False
+    _requires_study_key: bool = False
+    _include_study_key_in_filter: bool = False
+    _per_study_cache: bool = True
+    _page_size: int | None = None
+    _param_map: Dict[str, str] = {}
+
+    # ------------------------------------------------------------------
+    # Helper methods
+    # ------------------------------------------------------------------
+    def _build_path(self, study_key: Optional[str], path: str) -> str:
+        segments = [self.BASE_PATH.strip("/")]
+        if study_key:
+            segments.append(str(study_key).strip("/"))
+        if path:
+            segments.append(path.strip("/"))
+        return "/" + "/".join(segments)
+
+    def _parse_item(self, data: Dict[str, Any]) -> Any:
+        if hasattr(self.MODEL, "from_json"):
+            return self.MODEL.from_json(data)
+        return self.MODEL.model_validate(data)
+
+    def _list_impl(
+        self,
+        client: Any,
+        paginator_cls: type[Any],
+        *,
+        study_key: Optional[str] = None,
+        refresh: bool = False,
+        **filters: Any,
+    ) -> Any:
+        filters = self._auto_filter(filters)
+        if study_key:
+            filters["studyKey"] = study_key
+
+        params: Dict[str, Any] = {}
+        for key, param in self._param_map.items():
+            if key in filters:
+                val = filters.pop(key)
+                if isinstance(val, bool):
+                    val = str(val).lower()
+                params[param] = val
+
+        if self._pop_study_key:
+            study = filters.pop("studyKey")
+            if not study:
+                raise ValueError("Study key must be provided or set in the context")
+        else:
+            study = filters.get("studyKey")
+            if self._requires_study_key and not study:
+                raise ValueError("Study key must be provided or set in the context")
+            if not self._include_study_key_in_filter:
+                filters.pop("studyKey", None)
+
+        cache: Any = None
+        if self._cache_name:
+            cache = getattr(
+                self,
+                self._cache_name,
+                {} if self._per_study_cache else None,
+            )
+            if not hasattr(self, self._cache_name):
+                assert self._cache_name is not None
+                setattr(self, self._cache_name, cache)
+            if not filters and not refresh:
+                if self._per_study_cache:
+                    if study in cache:  # type: ignore[operator]
+                        return cache[study]  # type: ignore[index]
+                else:
+                    if cache is not None:
+                        return cache
+
+        if filters:
+            module = sys.modules[self.__class__.__module__]
+            build_filter = getattr(module, "build_filter_string", default_build_filter_string)
+            params["filter"] = build_filter(filters)
+
+        paginator_kwargs: Dict[str, Any] = {"params": params}
+        if self._page_size is not None:
+            paginator_kwargs["page_size"] = self._page_size
+        path = self._build_path(study, self.PATH)
+        paginator = paginator_cls(client, path, **paginator_kwargs)
+
+        if hasattr(paginator, "__aiter__"):
+
+            async def _collect() -> List[Any]:
+                result = [self._parse_item(item) async for item in paginator]
+                if cache is not None and not filters:
+                    if self._per_study_cache:
+                        cache[study] = result  # type: ignore[index]
+                    else:
+                        assert self._cache_name is not None
+                        setattr(self, self._cache_name, result)
+                return result
+
+            return _collect()
+
+        result = [self._parse_item(item) for item in paginator]
+        if cache is not None and not filters:
+            if self._per_study_cache:
+                cache[study] = result  # type: ignore[index]
+            else:
+                assert self._cache_name is not None
+                setattr(self, self._cache_name, result)
+        return result
+
+    def _get_impl(
+        self,
+        client: Any,
+        paginator_cls: type[Any],
+        *,
+        study_key: str,
+        item_id: Any,
+    ) -> Any:
+        kwargs = {"study_key": study_key, **{self.ID_FIELD: item_id}}
+        if self._cache_name is not None:
+            kwargs["refresh"] = True
+
+        result = self._list_impl(client, paginator_cls, **kwargs)
+
+        if inspect.isawaitable(result):
+
+            async def _await() -> Any:
+                items = await result
+                if not items:
+                    raise ValueError(f"{self.ID_FIELD} {item_id} not found in study {study_key}")
+                return items[0]
+
+            return _await()
+
+        if not result:
+            raise ValueError(f"{self.ID_FIELD} {item_id} not found in study {study_key}")
+        return result[0]

--- a/imednet/endpoints/codings.py
+++ b/imednet/endpoints/codings.py
@@ -1,78 +1,29 @@
 """Endpoint for managing codings (medical coding) in a study."""
 
-import inspect
-from typing import Any, Dict, List, Optional
+from typing import Any, List, Optional
 
 from imednet.core.paginator import AsyncPaginator, Paginator
 from imednet.endpoints.base import BaseEndpoint
 from imednet.models.codings import Coding
-from imednet.utils.filters import build_filter_string
+from imednet.utils.filters import build_filter_string as _build_filter_string
+
+from ._mixins import ListGetEndpointMixin
+
+# expose for patching in tests
+build_filter_string = _build_filter_string
 
 
-class CodingsEndpoint(BaseEndpoint):
+class CodingsEndpoint(ListGetEndpointMixin, BaseEndpoint):
     """
     API endpoint for interacting with codings (medical coding) in an iMedNet study.
 
     Provides methods to list and retrieve individual codings.
     """
 
-    PATH = "/api/v1/edc/studies"
-
-    def _list_impl(
-        self,
-        client: Any,
-        paginator_cls: type[Any],
-        *,
-        study_key: Optional[str] = None,
-        **filters: Any,
-    ) -> Any:
-        filters = self._auto_filter(filters)
-        if study_key:
-            filters["studyKey"] = study_key
-
-        study = filters.pop("studyKey")
-        if not study:
-            raise ValueError("Study key must be provided or set in the context")
-
-        params: Dict[str, Any] = {}
-        if filters:
-            params["filter"] = build_filter_string(filters)
-
-        path = self._build_path(study, "codings")
-        paginator = paginator_cls(client, path, params=params)
-
-        if hasattr(paginator, "__aiter__"):
-
-            async def _collect() -> List[Coding]:
-                return [Coding.from_json(item) async for item in paginator]
-
-            return _collect()
-
-        return [Coding.from_json(item) for item in paginator]
-
-    def _get_impl(
-        self, client: Any, paginator_cls: type[Any], study_key: str, coding_id: str
-    ) -> Any:
-        result = self._list_impl(
-            client,
-            paginator_cls,
-            study_key=study_key,
-            codingId=coding_id,
-        )
-
-        if inspect.isawaitable(result):
-
-            async def _await() -> Coding:
-                items = await result
-                if not items:
-                    raise ValueError(f"Coding {coding_id} not found in study {study_key}")
-                return items[0]
-
-            return _await()
-
-        if not result:
-            raise ValueError(f"Coding {coding_id} not found in study {study_key}")
-        return result[0]
+    PATH = "codings"
+    MODEL = Coding
+    ID_FIELD = "codingId"
+    _pop_study_key = True
 
     def list(self, study_key: Optional[str] = None, **filters) -> List[Coding]:
         """List codings in a study with optional filtering."""
@@ -110,7 +61,12 @@ class CodingsEndpoint(BaseEndpoint):
             Coding object
         """
 
-        result = self._get_impl(self._client, Paginator, study_key, coding_id)
+        result = self._get_impl(
+            self._client,
+            Paginator,
+            study_key=study_key,
+            item_id=coding_id,
+        )
         return result  # type: ignore[return-value]
 
     async def async_get(self, study_key: str, coding_id: str) -> Coding:
@@ -120,4 +76,9 @@ class CodingsEndpoint(BaseEndpoint):
         """
         if self._async_client is None:
             raise RuntimeError("Async client not configured")
-        return await self._get_impl(self._async_client, AsyncPaginator, study_key, coding_id)
+        return await self._get_impl(
+            self._async_client,
+            AsyncPaginator,
+            study_key=study_key,
+            item_id=coding_id,
+        )

--- a/imednet/endpoints/forms.py
+++ b/imednet/endpoints/forms.py
@@ -1,98 +1,31 @@
 """Endpoint for managing forms (eCRFs) in a study."""
 
-import inspect
-from typing import Any, Dict, List, Optional
+from typing import Any, List, Optional
 
-from imednet.core.async_client import AsyncClient
-from imednet.core.client import Client
-from imednet.core.context import Context
 from imednet.core.paginator import AsyncPaginator, Paginator
 from imednet.endpoints.base import BaseEndpoint
 from imednet.models.forms import Form
-from imednet.utils.filters import build_filter_string
+from imednet.utils.filters import build_filter_string as _build_filter_string
+
+from ._mixins import ListGetEndpointMixin
+
+# expose for patching in tests
+build_filter_string = _build_filter_string
 
 
-class FormsEndpoint(BaseEndpoint):
+class FormsEndpoint(ListGetEndpointMixin, BaseEndpoint):
     """
     API endpoint for interacting with forms (eCRFs) in an iMedNet study.
 
     Provides methods to list and retrieve individual forms.
     """
 
-    PATH = "/api/v1/edc/studies"
-
-    def _list_impl(
-        self,
-        client: Any,
-        paginator_cls: type[Any],
-        *,
-        study_key: Optional[str] = None,
-        refresh: bool = False,
-        **filters: Any,
-    ) -> Any:
-        filters = self._auto_filter(filters)
-        if study_key:
-            filters["studyKey"] = study_key
-
-        study = filters.pop("studyKey")
-        if not study:
-            raise ValueError("Study key must be provided or set in the context")
-        if not filters and not refresh and study in self._forms_cache:
-            return self._forms_cache[study]
-
-        params: Dict[str, Any] = {}
-        if filters:
-            params["filter"] = build_filter_string(filters)
-
-        path = self._build_path(study, "forms")
-        paginator = paginator_cls(client, path, params=params, page_size=500)
-
-        if hasattr(paginator, "__aiter__"):
-
-            async def _collect() -> List[Form]:
-                result = [Form.from_json(item) async for item in paginator]
-                if not filters:
-                    self._forms_cache[study] = result
-                return result
-
-            return _collect()
-
-        result = [Form.from_json(item) for item in paginator]
-        if not filters:
-            self._forms_cache[study] = result
-        return result
-
-    def _get_impl(self, client: Any, paginator_cls: type[Any], study_key: str, form_id: int) -> Any:
-        result = self._list_impl(
-            client,
-            paginator_cls,
-            study_key=study_key,
-            refresh=True,
-            formId=form_id,
-        )
-
-        if inspect.isawaitable(result):
-
-            async def _await() -> Form:
-                items = await result
-                if not items:
-                    raise ValueError(f"Form {form_id} not found in study {study_key}")
-                return items[0]
-
-            return _await()
-
-        if not result:
-            raise ValueError(f"Form {form_id} not found in study {study_key}")
-        return result[0]
-
-    def __init__(
-        self,
-        client: Client,
-        ctx: Context,
-        async_client: AsyncClient | None = None,
-    ) -> None:
-        super().__init__(client, ctx, async_client)
-        self._forms_cache: Dict[str, List[Form]] = {}
+    PATH = "forms"
+    MODEL = Form
+    ID_FIELD = "formId"
+    _cache_name = "_forms_cache"
+    _pop_study_key = True
+    _page_size = 500
 
     def list(
         self,
@@ -142,7 +75,12 @@ class FormsEndpoint(BaseEndpoint):
         Returns:
             Form object
         """
-        result = self._get_impl(self._client, Paginator, study_key, form_id)
+        result = self._get_impl(
+            self._client,
+            Paginator,
+            study_key=study_key,
+            item_id=form_id,
+        )
         return result  # type: ignore[return-value]
 
     async def async_get(self, study_key: str, form_id: int) -> Form:
@@ -153,4 +91,9 @@ class FormsEndpoint(BaseEndpoint):
         """
         if self._async_client is None:
             raise RuntimeError("Async client not configured")
-        return await self._get_impl(self._async_client, AsyncPaginator, study_key, form_id)
+        return await self._get_impl(
+            self._async_client,
+            AsyncPaginator,
+            study_key=study_key,
+            item_id=form_id,
+        )

--- a/imednet/endpoints/intervals.py
+++ b/imednet/endpoints/intervals.py
@@ -1,100 +1,31 @@
 """Endpoint for managing intervals (visit definitions) in a study."""
 
-import inspect
-from typing import Any, Dict, List, Optional
+from typing import Any, List, Optional
 
-from imednet.core.async_client import AsyncClient
-from imednet.core.client import Client
-from imednet.core.context import Context
 from imednet.core.paginator import AsyncPaginator, Paginator
 from imednet.endpoints.base import BaseEndpoint
 from imednet.models.intervals import Interval
-from imednet.utils.filters import build_filter_string
+from imednet.utils.filters import build_filter_string as _build_filter_string
+
+from ._mixins import ListGetEndpointMixin
+
+# expose for patching in tests
+build_filter_string = _build_filter_string
 
 
-class IntervalsEndpoint(BaseEndpoint):
+class IntervalsEndpoint(ListGetEndpointMixin, BaseEndpoint):
     """
     API endpoint for interacting with intervals (visit definitions) in an iMedNet study.
 
     Provides methods to list and retrieve individual intervals.
     """
 
-    PATH = "/api/v1/edc/studies"
-
-    def _list_impl(
-        self,
-        client: Any,
-        paginator_cls: type[Any],
-        *,
-        study_key: Optional[str] = None,
-        refresh: bool = False,
-        **filters: Any,
-    ) -> Any:
-        filters = self._auto_filter(filters)
-        if study_key:
-            filters["studyKey"] = study_key
-
-        study = filters.pop("studyKey")
-        if not study:
-            raise ValueError("Study key must be provided or set in the context")
-        if not filters and not refresh and study in self._intervals_cache:
-            return self._intervals_cache[study]
-
-        params: Dict[str, Any] = {}
-        if filters:
-            params["filter"] = build_filter_string(filters)
-
-        path = self._build_path(study, "intervals")
-        paginator = paginator_cls(client, path, params=params, page_size=500)
-
-        if hasattr(paginator, "__aiter__"):
-
-            async def _collect() -> List[Interval]:
-                result = [Interval.from_json(item) async for item in paginator]
-                if not filters:
-                    self._intervals_cache[study] = result
-                return result
-
-            return _collect()
-
-        result = [Interval.from_json(item) for item in paginator]
-        if not filters:
-            self._intervals_cache[study] = result
-        return result
-
-    def _get_impl(
-        self, client: Any, paginator_cls: type[Any], study_key: str, interval_id: int
-    ) -> Any:
-        result = self._list_impl(
-            client,
-            paginator_cls,
-            study_key=study_key,
-            refresh=True,
-            intervalId=interval_id,
-        )
-
-        if inspect.isawaitable(result):
-
-            async def _await() -> Interval:
-                items = await result
-                if not items:
-                    raise ValueError(f"Interval {interval_id} not found in study {study_key}")
-                return items[0]
-
-            return _await()
-
-        if not result:
-            raise ValueError(f"Interval {interval_id} not found in study {study_key}")
-        return result[0]
-
-    def __init__(
-        self,
-        client: Client,
-        ctx: Context,
-        async_client: AsyncClient | None = None,
-    ) -> None:
-        super().__init__(client, ctx, async_client)
-        self._intervals_cache: Dict[str, List[Interval]] = {}
+    PATH = "intervals"
+    MODEL = Interval
+    ID_FIELD = "intervalId"
+    _cache_name = "_intervals_cache"
+    _pop_study_key = True
+    _page_size = 500
 
     def list(
         self, study_key: Optional[str] = None, refresh: bool = False, **filters: Any
@@ -138,7 +69,12 @@ class IntervalsEndpoint(BaseEndpoint):
         Returns:
             Interval object
         """
-        result = self._get_impl(self._client, Paginator, study_key, interval_id)
+        result = self._get_impl(
+            self._client,
+            Paginator,
+            study_key=study_key,
+            item_id=interval_id,
+        )
         return result  # type: ignore[return-value]
 
     async def async_get(self, study_key: str, interval_id: int) -> Interval:
@@ -149,4 +85,9 @@ class IntervalsEndpoint(BaseEndpoint):
         """
         if self._async_client is None:
             raise RuntimeError("Async client not configured")
-        return await self._get_impl(self._async_client, AsyncPaginator, study_key, interval_id)
+        return await self._get_impl(
+            self._async_client,
+            AsyncPaginator,
+            study_key=study_key,
+            item_id=interval_id,
+        )

--- a/imednet/endpoints/queries.py
+++ b/imednet/endpoints/queries.py
@@ -1,74 +1,29 @@
 """Endpoint for managing queries (dialogue/questions) in a study."""
 
-import inspect
-from typing import Any, Dict, List, Optional
+from typing import Any, List, Optional
 
 from imednet.core.paginator import AsyncPaginator, Paginator
 from imednet.endpoints.base import BaseEndpoint
 from imednet.models.queries import Query
-from imednet.utils.filters import build_filter_string
+from imednet.utils.filters import build_filter_string as _build_filter_string
+
+from ._mixins import ListGetEndpointMixin
+
+# expose for patching in tests
+build_filter_string = _build_filter_string
 
 
-class QueriesEndpoint(BaseEndpoint):
+class QueriesEndpoint(ListGetEndpointMixin, BaseEndpoint):
     """
     API endpoint for interacting with queries (dialogue/questions) in an iMedNet study.
 
     Provides methods to list and retrieve queries.
     """
 
-    PATH = "/api/v1/edc/studies"
-
-    def _list_impl(
-        self,
-        client: Any,
-        paginator_cls: type[Any],
-        *,
-        study_key: Optional[str] = None,
-        **filters: Any,
-    ) -> Any:
-        filters = self._auto_filter(filters)
-        if study_key:
-            filters["studyKey"] = study_key
-
-        params: Dict[str, Any] = {}
-        if filters:
-            params["filter"] = build_filter_string(filters)
-
-        path = self._build_path(filters.get("studyKey", ""), "queries")
-        paginator = paginator_cls(client, path, params=params)
-
-        if hasattr(paginator, "__aiter__"):
-
-            async def _collect() -> List[Query]:
-                return [Query.from_json(item) async for item in paginator]
-
-            return _collect()
-
-        return [Query.from_json(item) for item in paginator]
-
-    def _get_impl(
-        self, client: Any, paginator_cls: type[Any], study_key: str, annotation_id: int
-    ) -> Any:
-        result = self._list_impl(
-            client,
-            paginator_cls,
-            study_key=study_key,
-            annotationId=annotation_id,
-        )
-
-        if inspect.isawaitable(result):
-
-            async def _await() -> Query:
-                items = await result
-                if not items:
-                    raise ValueError(f"Query {annotation_id} not found in study {study_key}")
-                return items[0]
-
-            return _await()
-
-        if not result:
-            raise ValueError(f"Query {annotation_id} not found in study {study_key}")
-        return result[0]
+    PATH = "queries"
+    MODEL = Query
+    ID_FIELD = "annotationId"
+    _include_study_key_in_filter = True
 
     def list(self, study_key: Optional[str] = None, **filters) -> List[Query]:
         """List queries in a study with optional filtering."""
@@ -105,7 +60,12 @@ class QueriesEndpoint(BaseEndpoint):
         Returns:
             Query object
         """
-        result = self._get_impl(self._client, Paginator, study_key, annotation_id)
+        result = self._get_impl(
+            self._client,
+            Paginator,
+            study_key=study_key,
+            item_id=annotation_id,
+        )
         return result  # type: ignore[return-value]
 
     async def async_get(self, study_key: str, annotation_id: int) -> Query:
@@ -115,4 +75,9 @@ class QueriesEndpoint(BaseEndpoint):
         """
         if self._async_client is None:
             raise RuntimeError("Async client not configured")
-        return await self._get_impl(self._async_client, AsyncPaginator, study_key, annotation_id)
+        return await self._get_impl(
+            self._async_client,
+            AsyncPaginator,
+            study_key=study_key,
+            item_id=annotation_id,
+        )

--- a/imednet/endpoints/record_revisions.py
+++ b/imednet/endpoints/record_revisions.py
@@ -1,76 +1,29 @@
 """Endpoint for retrieving record revision history in a study."""
 
-import inspect
-from typing import Any, Dict, List, Optional
+from typing import Any, List, Optional
 
 from imednet.core.paginator import AsyncPaginator, Paginator
 from imednet.endpoints.base import BaseEndpoint
 from imednet.models.record_revisions import RecordRevision
-from imednet.utils.filters import build_filter_string
+from imednet.utils.filters import build_filter_string as _build_filter_string
+
+from ._mixins import ListGetEndpointMixin
+
+# expose for patching in tests
+build_filter_string = _build_filter_string
 
 
-class RecordRevisionsEndpoint(BaseEndpoint):
+class RecordRevisionsEndpoint(ListGetEndpointMixin, BaseEndpoint):
     """
     API endpoint for accessing record revision history in an iMedNet study.
 
     Provides methods to list and retrieve record revisions.
     """
 
-    PATH = "/api/v1/edc/studies"
-
-    def _list_impl(
-        self,
-        client: Any,
-        paginator_cls: type[Any],
-        *,
-        study_key: Optional[str] = None,
-        **filters: Any,
-    ) -> Any:
-        filters = self._auto_filter(filters)
-        if study_key:
-            filters["studyKey"] = study_key
-
-        params: Dict[str, Any] = {}
-        if filters:
-            params["filter"] = build_filter_string(filters)
-
-        path = self._build_path(filters.get("studyKey", ""), "recordRevisions")
-        paginator = paginator_cls(client, path, params=params)
-
-        if hasattr(paginator, "__aiter__"):
-
-            async def _collect() -> List[RecordRevision]:
-                return [RecordRevision.from_json(item) async for item in paginator]
-
-            return _collect()
-
-        return [RecordRevision.from_json(item) for item in paginator]
-
-    def _get_impl(
-        self, client: Any, paginator_cls: type[Any], study_key: str, record_revision_id: int
-    ) -> Any:
-        result = self._list_impl(
-            client,
-            paginator_cls,
-            study_key=study_key,
-            recordRevisionId=record_revision_id,
-        )
-
-        if inspect.isawaitable(result):
-
-            async def _await() -> RecordRevision:
-                items = await result
-                if not items:
-                    raise ValueError(
-                        f"Record revision {record_revision_id} not found in study {study_key}"
-                    )
-                return items[0]
-
-            return _await()
-
-        if not result:
-            raise ValueError(f"Record revision {record_revision_id} not found in study {study_key}")
-        return result[0]
+    PATH = "recordRevisions"
+    MODEL = RecordRevision
+    ID_FIELD = "recordRevisionId"
+    _include_study_key_in_filter = True
 
     def list(self, study_key: Optional[str] = None, **filters) -> List[RecordRevision]:
         """List record revisions in a study with optional filtering."""
@@ -109,7 +62,12 @@ class RecordRevisionsEndpoint(BaseEndpoint):
         Returns:
             RecordRevision object
         """
-        result = self._get_impl(self._client, Paginator, study_key, record_revision_id)
+        result = self._get_impl(
+            self._client,
+            Paginator,
+            study_key=study_key,
+            item_id=record_revision_id,
+        )
         return result  # type: ignore[return-value]
 
     async def async_get(self, study_key: str, record_revision_id: int) -> RecordRevision:
@@ -120,5 +78,8 @@ class RecordRevisionsEndpoint(BaseEndpoint):
         if self._async_client is None:
             raise RuntimeError("Async client not configured")
         return await self._get_impl(
-            self._async_client, AsyncPaginator, study_key, record_revision_id
+            self._async_client,
+            AsyncPaginator,
+            study_key=study_key,
+            item_id=record_revision_id,
         )

--- a/imednet/endpoints/records.py
+++ b/imednet/endpoints/records.py
@@ -7,73 +7,27 @@ from imednet.core.paginator import AsyncPaginator, Paginator
 from imednet.endpoints.base import BaseEndpoint
 from imednet.models.jobs import Job
 from imednet.models.records import Record
-from imednet.utils.filters import build_filter_string
+from imednet.utils.filters import build_filter_string as _build_filter_string
 from imednet.validation.schema import SchemaCache, validate_record_data
 
+from ._mixins import ListGetEndpointMixin
 
-class RecordsEndpoint(BaseEndpoint):
+# expose for patching in tests
+build_filter_string = _build_filter_string
+
+
+class RecordsEndpoint(ListGetEndpointMixin, BaseEndpoint):
     """
     API endpoint for interacting with records (eCRF instances) in an iMedNet study.
 
     Provides methods to list, retrieve, and create records.
     """
 
-    PATH = "/api/v1/edc/studies"
-
-    def _list_impl(
-        self,
-        client: Any,
-        paginator_cls: type[Any],
-        *,
-        study_key: Optional[str] = None,
-        record_data_filter: Optional[str] = None,
-        **filters: Any,
-    ) -> Any:
-        filters = self._auto_filter(filters)
-        if study_key:
-            filters["studyKey"] = study_key
-
-        params: Dict[str, Any] = {}
-        if filters:
-            params["filter"] = build_filter_string(filters)
-        if record_data_filter:
-            params["recordDataFilter"] = record_data_filter
-
-        path = self._build_path(filters.get("studyKey", ""), "records")
-        paginator = paginator_cls(client, path, params=params)
-
-        if hasattr(paginator, "__aiter__"):
-
-            async def _collect() -> List[Record]:
-                return [Record.from_json(item) async for item in paginator]
-
-            return _collect()
-
-        return [Record.from_json(item) for item in paginator]
-
-    def _get_impl(
-        self, client: Any, paginator_cls: type[Any], study_key: str, record_id: Union[str, int]
-    ) -> Any:
-        result = self._list_impl(
-            client,
-            paginator_cls,
-            study_key=study_key,
-            recordId=record_id,
-        )
-
-        if inspect.isawaitable(result):
-
-            async def _await() -> Record:
-                items = await result
-                if not items:
-                    raise ValueError(f"Record {record_id} not found in study {study_key}")
-                return items[0]
-
-            return _await()
-
-        if not result:
-            raise ValueError(f"Record {record_id} not found in study {study_key}")
-        return result[0]
+    PATH = "records"
+    MODEL = Record
+    ID_FIELD = "recordId"
+    _param_map = {"record_data_filter": "recordDataFilter"}
+    _include_study_key_in_filter = True
 
     def _create_impl(
         self,
@@ -146,7 +100,12 @@ class RecordsEndpoint(BaseEndpoint):
         Returns:
             Record object
         """
-        result = self._get_impl(self._client, Paginator, study_key, record_id)
+        result = self._get_impl(
+            self._client,
+            Paginator,
+            study_key=study_key,
+            item_id=record_id,
+        )
         return result  # type: ignore[return-value]
 
     async def async_get(self, study_key: str, record_id: Union[str, int]) -> Record:
@@ -156,7 +115,12 @@ class RecordsEndpoint(BaseEndpoint):
         """
         if self._async_client is None:
             raise RuntimeError("Async client not configured")
-        return await self._get_impl(self._async_client, AsyncPaginator, study_key, record_id)
+        return await self._get_impl(
+            self._async_client,
+            AsyncPaginator,
+            study_key=study_key,
+            item_id=record_id,
+        )
 
     def create(
         self,

--- a/imednet/endpoints/sites.py
+++ b/imednet/endpoints/sites.py
@@ -1,76 +1,29 @@
 """Endpoint for managing sites (study locations) in a study."""
 
-import inspect
-from typing import Any, Dict, List, Optional
+from typing import Any, List, Optional
 
 from imednet.core.paginator import AsyncPaginator, Paginator
 from imednet.endpoints.base import BaseEndpoint
 from imednet.models.sites import Site
-from imednet.utils.filters import build_filter_string
+from imednet.utils.filters import build_filter_string as _build_filter_string
+
+from ._mixins import ListGetEndpointMixin
+
+# expose for patching in tests
+build_filter_string = _build_filter_string
 
 
-class SitesEndpoint(BaseEndpoint):
+class SitesEndpoint(ListGetEndpointMixin, BaseEndpoint):
     """
     API endpoint for interacting with sites (study locations) in an iMedNet study.
 
     Provides methods to list and retrieve individual sites.
     """
 
-    PATH = "/api/v1/edc/studies"
-
-    def _list_impl(
-        self,
-        client: Any,
-        paginator_cls: type[Any],
-        *,
-        study_key: Optional[str] = None,
-        **filters: Any,
-    ) -> Any:
-        filters = self._auto_filter(filters)
-        if study_key:
-            filters["studyKey"] = study_key
-
-        study = filters.pop("studyKey")
-        if not study:
-            raise ValueError("Study key must be provided or set in the context")
-
-        params: Dict[str, Any] = {}
-        if filters:
-            params["filter"] = build_filter_string(filters)
-
-        path = self._build_path(study, "sites")
-        paginator = paginator_cls(client, path, params=params)
-
-        if hasattr(paginator, "__aiter__"):
-
-            async def _collect() -> List[Site]:
-                return [Site.from_json(item) async for item in paginator]
-
-            return _collect()
-
-        return [Site.from_json(item) for item in paginator]
-
-    def _get_impl(self, client: Any, paginator_cls: type[Any], study_key: str, site_id: int) -> Any:
-        result = self._list_impl(
-            client,
-            paginator_cls,
-            study_key=study_key,
-            siteId=site_id,
-        )
-
-        if inspect.isawaitable(result):
-
-            async def _await() -> Site:
-                items = await result
-                if not items:
-                    raise ValueError(f"Site {site_id} not found in study {study_key}")
-                return items[0]
-
-            return _await()
-
-        if not result:
-            raise ValueError(f"Site {site_id} not found in study {study_key}")
-        return result[0]
+    PATH = "sites"
+    MODEL = Site
+    ID_FIELD = "siteId"
+    _pop_study_key = True
 
     def list(self, study_key: Optional[str] = None, **filters) -> List[Site]:
         """List sites in a study with optional filtering."""
@@ -107,7 +60,12 @@ class SitesEndpoint(BaseEndpoint):
         Returns:
             Site object
         """
-        result = self._get_impl(self._client, Paginator, study_key, site_id)
+        result = self._get_impl(
+            self._client,
+            Paginator,
+            study_key=study_key,
+            item_id=site_id,
+        )
         return result  # type: ignore[return-value]
 
     async def async_get(self, study_key: str, site_id: int) -> Site:
@@ -117,4 +75,9 @@ class SitesEndpoint(BaseEndpoint):
         """
         if self._async_client is None:
             raise RuntimeError("Async client not configured")
-        return await self._get_impl(self._async_client, AsyncPaginator, study_key, site_id)
+        return await self._get_impl(
+            self._async_client,
+            AsyncPaginator,
+            study_key=study_key,
+            item_id=site_id,
+        )

--- a/imednet/endpoints/subjects.py
+++ b/imednet/endpoints/subjects.py
@@ -1,74 +1,29 @@
 """Endpoint for managing subjects in a study."""
 
-import inspect
-from typing import Any, Dict, List, Optional
+from typing import Any, List, Optional
 
 from imednet.core.paginator import AsyncPaginator, Paginator
 from imednet.endpoints.base import BaseEndpoint
 from imednet.models.subjects import Subject
-from imednet.utils.filters import build_filter_string
+from imednet.utils.filters import build_filter_string as _build_filter_string
+
+from ._mixins import ListGetEndpointMixin
+
+# expose for patching in tests
+build_filter_string = _build_filter_string
 
 
-class SubjectsEndpoint(BaseEndpoint):
+class SubjectsEndpoint(ListGetEndpointMixin, BaseEndpoint):
     """
     API endpoint for interacting with subjects in an iMedNet study.
 
     Provides methods to list and retrieve individual subjects.
     """
 
-    PATH = "/api/v1/edc/studies"
-
-    def _list_impl(
-        self,
-        client: Any,
-        paginator_cls: type[Any],
-        *,
-        study_key: Optional[str] = None,
-        **filters: Any,
-    ) -> Any:
-        filters = self._auto_filter(filters)
-        if study_key:
-            filters["studyKey"] = study_key
-
-        params: Dict[str, Any] = {}
-        if filters:
-            params["filter"] = build_filter_string(filters)
-
-        path = self._build_path(filters.get("studyKey", ""), "subjects")
-        paginator = paginator_cls(client, path, params=params)
-
-        if hasattr(paginator, "__aiter__"):
-
-            async def _collect() -> List[Subject]:
-                return [Subject.from_json(item) async for item in paginator]
-
-            return _collect()
-
-        return [Subject.from_json(item) for item in paginator]
-
-    def _get_impl(
-        self, client: Any, paginator_cls: type[Any], study_key: str, subject_key: str
-    ) -> Any:
-        result = self._list_impl(
-            client,
-            paginator_cls,
-            study_key=study_key,
-            subjectKey=subject_key,
-        )
-
-        if inspect.isawaitable(result):
-
-            async def _await() -> Subject:
-                items = await result
-                if not items:
-                    raise ValueError(f"Subject {subject_key} not found in study {study_key}")
-                return items[0]
-
-            return _await()
-
-        if not result:
-            raise ValueError(f"Subject {subject_key} not found in study {study_key}")
-        return result[0]
+    PATH = "subjects"
+    MODEL = Subject
+    ID_FIELD = "subjectKey"
+    _include_study_key_in_filter = True
 
     def list(self, study_key: Optional[str] = None, **filters) -> List[Subject]:
         """List subjects in a study with optional filtering."""
@@ -105,7 +60,12 @@ class SubjectsEndpoint(BaseEndpoint):
         Returns:
             Subject object
         """
-        result = self._get_impl(self._client, Paginator, study_key, subject_key)
+        result = self._get_impl(
+            self._client,
+            Paginator,
+            study_key=study_key,
+            item_id=subject_key,
+        )
         return result  # type: ignore[return-value]
 
     async def async_get(self, study_key: str, subject_key: str) -> Subject:
@@ -118,6 +78,6 @@ class SubjectsEndpoint(BaseEndpoint):
         return await self._get_impl(
             self._async_client,
             AsyncPaginator,
-            study_key,
-            subject_key,
+            study_key=study_key,
+            item_id=subject_key,
         )

--- a/imednet/endpoints/users.py
+++ b/imednet/endpoints/users.py
@@ -1,75 +1,30 @@
 """Endpoint for managing users in a study."""
 
-import inspect
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, List, Optional, Union
 
 from imednet.core.paginator import AsyncPaginator, Paginator
 from imednet.endpoints.base import BaseEndpoint
 from imednet.models.users import User
-from imednet.utils.filters import build_filter_string
+from imednet.utils.filters import build_filter_string as _build_filter_string
+
+from ._mixins import ListGetEndpointMixin
+
+# expose for patching in tests
+build_filter_string = _build_filter_string
 
 
-class UsersEndpoint(BaseEndpoint):
+class UsersEndpoint(ListGetEndpointMixin, BaseEndpoint):
     """
     API endpoint for interacting with users in an iMedNet study.
 
     Provides methods to list and retrieve user information.
     """
 
-    PATH = "/api/v1/edc/studies"
-
-    def _list_impl(
-        self,
-        client: Any,
-        paginator_cls: type[Any],
-        *,
-        study_key: Optional[str] = None,
-        include_inactive: bool = False,
-        **filters: Any,
-    ) -> Any:
-        study_key = study_key or self._ctx.default_study_key
-        if not study_key:
-            raise ValueError("Study key must be provided or set in the context")
-
-        params: Dict[str, Any] = {"includeInactive": str(include_inactive).lower()}
-        if filters:
-            params["filter"] = build_filter_string(filters)
-
-        path = self._build_path(study_key, "users")
-        paginator = paginator_cls(client, path, params=params)
-
-        if hasattr(paginator, "__aiter__"):
-
-            async def _collect() -> List[User]:
-                return [User.from_json(item) async for item in paginator]
-
-            return _collect()
-
-        return [User.from_json(item) for item in paginator]
-
-    def _get_impl(
-        self, client: Any, paginator_cls: type[Any], study_key: str, user_id: Union[str, int]
-    ) -> Any:
-        result = self._list_impl(
-            client,
-            paginator_cls,
-            study_key=study_key,
-            userId=user_id,
-        )
-
-        if inspect.isawaitable(result):
-
-            async def _await() -> User:
-                items = await result
-                if not items:
-                    raise ValueError(f"User {user_id} not found in study {study_key}")
-                return items[0]
-
-            return _await()
-
-        if not result:
-            raise ValueError(f"User {user_id} not found in study {study_key}")
-        return result[0]
+    PATH = "users"
+    MODEL = User
+    ID_FIELD = "userId"
+    _param_map = {"include_inactive": "includeInactive"}
+    _requires_study_key = True
 
     def list(
         self, study_key: Optional[str] = None, include_inactive: bool = False, **filters: Any
@@ -113,11 +68,21 @@ class UsersEndpoint(BaseEndpoint):
         Returns:
             User object
         """
-        result = self._get_impl(self._client, Paginator, study_key, user_id)
+        result = self._get_impl(
+            self._client,
+            Paginator,
+            study_key=study_key,
+            item_id=user_id,
+        )
         return result  # type: ignore[return-value]
 
     async def async_get(self, study_key: str, user_id: Union[str, int]) -> User:
         """Asynchronous version of :meth:`get`."""
         if self._async_client is None:
             raise RuntimeError("Async client not configured")
-        return await self._get_impl(self._async_client, AsyncPaginator, study_key, user_id)
+        return await self._get_impl(
+            self._async_client,
+            AsyncPaginator,
+            study_key=study_key,
+            item_id=user_id,
+        )

--- a/imednet/endpoints/variables.py
+++ b/imednet/endpoints/variables.py
@@ -1,100 +1,31 @@
 """Endpoint for managing variables (data points on eCRFs) in a study."""
 
-import inspect
-from typing import Any, Dict, List, Optional
+from typing import Any, List, Optional
 
-from imednet.core.async_client import AsyncClient
-from imednet.core.client import Client
-from imednet.core.context import Context
 from imednet.core.paginator import AsyncPaginator, Paginator
 from imednet.endpoints.base import BaseEndpoint
 from imednet.models.variables import Variable
-from imednet.utils.filters import build_filter_string
+from imednet.utils.filters import build_filter_string as _build_filter_string
+
+from ._mixins import ListGetEndpointMixin
+
+# expose for patching in tests
+build_filter_string = _build_filter_string
 
 
-class VariablesEndpoint(BaseEndpoint):
+class VariablesEndpoint(ListGetEndpointMixin, BaseEndpoint):
     """
     API endpoint for interacting with variables (data points on eCRFs) in an iMedNet study.
 
     Provides methods to list and retrieve individual variables.
     """
 
-    PATH = "/api/v1/edc/studies"
-
-    def _list_impl(
-        self,
-        client: Any,
-        paginator_cls: type[Any],
-        *,
-        study_key: Optional[str] = None,
-        refresh: bool = False,
-        **filters: Any,
-    ) -> Any:
-        filters = self._auto_filter(filters)
-        if study_key:
-            filters["studyKey"] = study_key
-
-        study = filters.pop("studyKey")
-        if not study:
-            raise ValueError("Study key must be provided or set in the context")
-        if not filters and not refresh and study in self._variables_cache:
-            return self._variables_cache[study]
-
-        params: Dict[str, Any] = {}
-        if filters:
-            params["filter"] = build_filter_string(filters)
-
-        path = self._build_path(study, "variables")
-        paginator = paginator_cls(client, path, params=params, page_size=500)
-
-        if hasattr(paginator, "__aiter__"):
-
-            async def _collect() -> List[Variable]:
-                result = [Variable.from_json(item) async for item in paginator]
-                if not filters:
-                    self._variables_cache[study] = result
-                return result
-
-            return _collect()
-
-        result = [Variable.from_json(item) for item in paginator]
-        if not filters:
-            self._variables_cache[study] = result
-        return result
-
-    def _get_impl(
-        self, client: Any, paginator_cls: type[Any], study_key: str, variable_id: int
-    ) -> Any:
-        result = self._list_impl(
-            client,
-            paginator_cls,
-            study_key=study_key,
-            refresh=True,
-            variableId=variable_id,
-        )
-
-        if inspect.isawaitable(result):
-
-            async def _await() -> Variable:
-                items = await result
-                if not items:
-                    raise ValueError(f"Variable {variable_id} not found in study {study_key}")
-                return items[0]
-
-            return _await()
-
-        if not result:
-            raise ValueError(f"Variable {variable_id} not found in study {study_key}")
-        return result[0]
-
-    def __init__(
-        self,
-        client: Client,
-        ctx: Context,
-        async_client: AsyncClient | None = None,
-    ) -> None:
-        super().__init__(client, ctx, async_client)
-        self._variables_cache: Dict[str, List[Variable]] = {}
+    PATH = "variables"
+    MODEL = Variable
+    ID_FIELD = "variableId"
+    _cache_name = "_variables_cache"
+    _pop_study_key = True
+    _page_size = 500
 
     def list(
         self, study_key: Optional[str] = None, refresh: bool = False, **filters
@@ -138,7 +69,12 @@ class VariablesEndpoint(BaseEndpoint):
         Returns:
             Variable object
         """
-        result = self._get_impl(self._client, Paginator, study_key, variable_id)
+        result = self._get_impl(
+            self._client,
+            Paginator,
+            study_key=study_key,
+            item_id=variable_id,
+        )
         return result  # type: ignore[return-value]
 
     async def async_get(self, study_key: str, variable_id: int) -> Variable:
@@ -149,4 +85,9 @@ class VariablesEndpoint(BaseEndpoint):
         """
         if self._async_client is None:
             raise RuntimeError("Async client not configured")
-        return await self._get_impl(self._async_client, AsyncPaginator, study_key, variable_id)
+        return await self._get_impl(
+            self._async_client,
+            AsyncPaginator,
+            study_key=study_key,
+            item_id=variable_id,
+        )

--- a/imednet/endpoints/visits.py
+++ b/imednet/endpoints/visits.py
@@ -1,74 +1,29 @@
 """Endpoint for managing visits (interval instances) in a study."""
 
-import inspect
-from typing import Any, Dict, List, Optional
+from typing import Any, List, Optional
 
 from imednet.core.paginator import AsyncPaginator, Paginator
 from imednet.endpoints.base import BaseEndpoint
 from imednet.models.visits import Visit
-from imednet.utils.filters import build_filter_string
+from imednet.utils.filters import build_filter_string as _build_filter_string
+
+from ._mixins import ListGetEndpointMixin
+
+# expose for patching in tests
+build_filter_string = _build_filter_string
 
 
-class VisitsEndpoint(BaseEndpoint):
+class VisitsEndpoint(ListGetEndpointMixin, BaseEndpoint):
     """
     API endpoint for interacting with visits (interval instances) in an iMedNet study.
 
     Provides methods to list and retrieve individual visits.
     """
 
-    PATH = "/api/v1/edc/studies"
-
-    def _list_impl(
-        self,
-        client: Any,
-        paginator_cls: type[Any],
-        *,
-        study_key: Optional[str] = None,
-        **filters: Any,
-    ) -> Any:
-        filters = self._auto_filter(filters)
-        if study_key:
-            filters["studyKey"] = study_key
-
-        params: Dict[str, Any] = {}
-        if filters:
-            params["filter"] = build_filter_string(filters)
-
-        path = self._build_path(filters.get("studyKey", ""), "visits")
-        paginator = paginator_cls(client, path, params=params)
-
-        if hasattr(paginator, "__aiter__"):
-
-            async def _collect() -> List[Visit]:
-                return [Visit.from_json(item) async for item in paginator]
-
-            return _collect()
-
-        return [Visit.from_json(item) for item in paginator]
-
-    def _get_impl(
-        self, client: Any, paginator_cls: type[Any], study_key: str, visit_id: int
-    ) -> Any:
-        result = self._list_impl(
-            client,
-            paginator_cls,
-            study_key=study_key,
-            visitId=visit_id,
-        )
-
-        if inspect.isawaitable(result):
-
-            async def _await() -> Visit:
-                items = await result
-                if not items:
-                    raise ValueError(f"Visit {visit_id} not found in study {study_key}")
-                return items[0]
-
-            return _await()
-
-        if not result:
-            raise ValueError(f"Visit {visit_id} not found in study {study_key}")
-        return result[0]
+    PATH = "visits"
+    MODEL = Visit
+    ID_FIELD = "visitId"
+    _include_study_key_in_filter = True
 
     def list(self, study_key: Optional[str] = None, **filters) -> List[Visit]:
         """List visits in a study with optional filtering."""
@@ -105,7 +60,12 @@ class VisitsEndpoint(BaseEndpoint):
         Returns:
             Visit object
         """
-        result = self._get_impl(self._client, Paginator, study_key, visit_id)
+        result = self._get_impl(
+            self._client,
+            Paginator,
+            study_key=study_key,
+            item_id=visit_id,
+        )
         return result  # type: ignore[return-value]
 
     async def async_get(self, study_key: str, visit_id: int) -> Visit:
@@ -115,4 +75,9 @@ class VisitsEndpoint(BaseEndpoint):
         """
         if self._async_client is None:
             raise RuntimeError("Async client not configured")
-        return await self._get_impl(self._async_client, AsyncPaginator, study_key, visit_id)
+        return await self._get_impl(
+            self._async_client,
+            AsyncPaginator,
+            study_key=study_key,
+            item_id=visit_id,
+        )

--- a/tests/endpoints/test_list_get.py
+++ b/tests/endpoints/test_list_get.py
@@ -1,0 +1,65 @@
+import imednet.endpoints.codings as codings
+import imednet.endpoints.forms as forms
+import imednet.endpoints.intervals as intervals
+import imednet.endpoints.queries as queries
+import imednet.endpoints.record_revisions as record_revisions
+import imednet.endpoints.records as records
+import imednet.endpoints.sites as sites
+import imednet.endpoints.subjects as subjects
+import imednet.endpoints.users as users
+import imednet.endpoints.variables as variables
+import imednet.endpoints.visits as visits
+import pytest
+
+ENDPOINTS = [
+    (codings.CodingsEndpoint, "codingId"),
+    (forms.FormsEndpoint, "formId"),
+    (intervals.IntervalsEndpoint, "intervalId"),
+    (queries.QueriesEndpoint, "annotationId"),
+    (record_revisions.RecordRevisionsEndpoint, "recordRevisionId"),
+    (records.RecordsEndpoint, "recordId"),
+    (sites.SitesEndpoint, "siteId"),
+    (subjects.SubjectsEndpoint, "subjectKey"),
+    (users.UsersEndpoint, "userId"),
+    (variables.VariablesEndpoint, "variableId"),
+    (visits.VisitsEndpoint, "visitId"),
+]
+
+
+@pytest.mark.parametrize("cls,field", ENDPOINTS)
+def test_get_delegates_to_list(monkeypatch, dummy_client, context, cls, field):
+    ep = cls(dummy_client, context)
+    called = {}
+
+    def fake_list_impl(self, client, paginator, *, study_key=None, refresh=False, **filters):
+        called["study_key"] = study_key
+        called["refresh"] = refresh
+        called["filters"] = filters
+        return [1]
+
+    monkeypatch.setattr(cls, "_list_impl", fake_list_impl)
+
+    res = ep.get("S1", 1)
+    assert called["study_key"] == "S1"
+    assert called["filters"] == {field: 1}
+    assert res == 1
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("cls,field", ENDPOINTS)
+async def test_async_get_delegates_to_list(monkeypatch, dummy_client, context, cls, field) -> None:
+    ep = cls(dummy_client, context, async_client=dummy_client)
+    called = {}
+
+    async def fake_list_impl(self, client, paginator, *, study_key=None, refresh=False, **filters):
+        called["study_key"] = study_key
+        called["refresh"] = refresh
+        called["filters"] = filters
+        return [1]
+
+    monkeypatch.setattr(cls, "_list_impl", fake_list_impl)
+
+    res = await ep.async_get("S1", 1)
+    assert called["study_key"] == "S1"
+    assert called["filters"] == {field: 1}
+    assert res == 1


### PR DESCRIPTION
## Summary
- add ListGetEndpointMixin for shared list/get logic
- patch endpoints to use the mixin and re-expose build_filter_string for tests
- centralise study key handling via `_include_study_key_in_filter`
- update `_get_impl` to only pass refresh when needed
- add async list/get delegation test

## Testing
- `poetry run ruff check --fix .`
- `poetry run black --check .`
- `poetry run mypy imednet`
- `poetry run pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6866a95f2ec8832cb4ce88ae26b42a01