### PR TITLE
Introduce with_sdk decorator for CLI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated integration tests to patch `RequestExecutor` and allow non-strict `respx` mocking.
 - Airflow operators now obtain ``ImednetSDK`` instances via ``ImednetHook``
   instead of parsing connections directly.
+- Added ``with_sdk`` decorator for CLI commands to centralize SDK creation and
+  error handling.
 
 ## [0.1.1] - 2025-07-02
 

--- a/imednet/cli/__init__.py
+++ b/imednet/cli/__init__.py
@@ -17,6 +17,7 @@ from ..integrations.export import (  # noqa: F401
 from ..workflows.data_extraction import DataExtractionWorkflow  # noqa: F401
 from ..workflows.subject_data import SubjectDataWorkflow  # noqa: F401
 from .utils import get_sdk, parse_filter_args  # noqa: F401
+from .decorators import with_sdk  # noqa: F401
 
 load_dotenv()
 

--- a/imednet/cli/decorators.py
+++ b/imednet/cli/decorators.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+import inspect
+from functools import wraps
+from typing import Callable, Concatenate, ParamSpec, TypeVar
+
+import typer
+from rich import print
+
+from ..core.exceptions import ApiError
+from ..sdk import ImednetSDK
+
+P = ParamSpec("P")
+R = TypeVar("R")
+
+
+def with_sdk(func: Callable[Concatenate[ImednetSDK, P], R]) -> Callable[P, R]:
+    """Initialize the SDK and pass it to the wrapped command function."""
+
+    sig = inspect.signature(func)
+    wrapper_params = list(sig.parameters.values())[1:]
+
+    @wraps(func)
+    def wrapper(*args: P.args, **kwargs: P.kwargs) -> R:
+        from . import get_sdk  # local import so tests can monkeypatch
+
+        sdk = get_sdk()
+        try:
+            return func(sdk, *args, **kwargs)
+        except typer.Exit:  # allow commands to exit early
+            raise
+        except ApiError as exc:
+            print(f"[bold red]API Error:[/bold red] {exc}")
+            raise typer.Exit(code=1)
+        except Exception as exc:  # pragma: no cover - defensive
+            print(f"[bold red]Unexpected error:[/bold red] {exc}")
+            raise typer.Exit(code=1)
+
+    wrapper.__signature__ = sig.replace(parameters=wrapper_params)  # type: ignore[attr-defined]
+
+    return wrapper

--- a/imednet/cli/export.py
+++ b/imednet/cli/export.py
@@ -6,11 +6,16 @@ from pathlib import Path
 import typer
 from rich import print
 
+from ..sdk import ImednetSDK
+from .decorators import with_sdk
+
 app = typer.Typer(name="export", help="Export study data to various formats.")
 
 
 @app.command("parquet")
+@with_sdk
 def export_parquet(
+    sdk: ImednetSDK,
     study_key: str = typer.Argument(..., help="The key identifying the study."),
     path: Path = typer.Argument(..., help="Destination Parquet file."),
 ) -> None:
@@ -22,66 +27,54 @@ def export_parquet(
         )
         raise typer.Exit(code=1)
 
-    from . import export_to_parquet, get_sdk
+    from . import export_to_parquet
 
-    sdk = get_sdk()
-    try:
-        export_to_parquet(sdk, study_key, str(path))
-    except Exception as exc:
-        print(f"[bold red]Error:[/bold red] {exc}")
-        raise typer.Exit(code=1)
+    export_to_parquet(sdk, study_key, str(path))
 
 
 @app.command("csv")
+@with_sdk
 def export_csv(
+    sdk: ImednetSDK,
     study_key: str = typer.Argument(..., help="The key identifying the study."),
     path: Path = typer.Argument(..., help="Destination CSV file."),
 ) -> None:
     """Export study records to a CSV file."""
-    from . import export_to_csv, get_sdk
+    from . import export_to_csv
 
-    sdk = get_sdk()
-    try:
-        export_to_csv(sdk, study_key, str(path))
-    except Exception as exc:
-        print(f"[bold red]Error:[/bold red] {exc}")
-        raise typer.Exit(code=1)
+    export_to_csv(sdk, study_key, str(path))
 
 
 @app.command("excel")
+@with_sdk
 def export_excel(
+    sdk: ImednetSDK,
     study_key: str = typer.Argument(..., help="The key identifying the study."),
     path: Path = typer.Argument(..., help="Destination Excel workbook."),
 ) -> None:
     """Export study records to an Excel workbook."""
-    from . import export_to_excel, get_sdk
+    from . import export_to_excel
 
-    sdk = get_sdk()
-    try:
-        export_to_excel(sdk, study_key, str(path))
-    except Exception as exc:
-        print(f"[bold red]Error:[/bold red] {exc}")
-        raise typer.Exit(code=1)
+    export_to_excel(sdk, study_key, str(path))
 
 
 @app.command("json")
+@with_sdk
 def export_json_cmd(
+    sdk: ImednetSDK,
     study_key: str = typer.Argument(..., help="The key identifying the study."),
     path: Path = typer.Argument(..., help="Destination JSON file."),
 ) -> None:
     """Export study records to a JSON file."""
-    from . import export_to_json, get_sdk
+    from . import export_to_json
 
-    sdk = get_sdk()
-    try:
-        export_to_json(sdk, study_key, str(path))
-    except Exception as exc:
-        print(f"[bold red]Error:[/bold red] {exc}")
-        raise typer.Exit(code=1)
+    export_to_json(sdk, study_key, str(path))
 
 
 @app.command("sql")
+@with_sdk
 def export_sql(
+    sdk: ImednetSDK,
     study_key: str = typer.Argument(..., help="The key identifying the study."),
     table: str = typer.Argument(..., help="Destination table name."),
     connection_string: str = typer.Argument(..., help="Database connection string."),
@@ -101,18 +94,10 @@ def export_sql(
 
     from sqlalchemy import create_engine
 
-    from . import export_to_sql, export_to_sql_by_form, get_sdk
+    from . import export_to_sql, export_to_sql_by_form
 
-    sdk = get_sdk()
-    try:
-        engine = create_engine(connection_string)
-        if not single_table and engine.dialect.name == "sqlite":
-            export_to_sql_by_form(sdk, study_key, connection_string)
-        else:
-            export_to_sql(sdk, study_key, table, connection_string)
-    except ValueError as exc:
-        print(f"[bold red]Error:[/bold red] {exc}")
-        raise typer.Exit(code=1)
-    except Exception as exc:
-        print(f"[bold red]Error:[/bold red] {exc}")
-        raise typer.Exit(code=1)
+    engine = create_engine(connection_string)
+    if not single_table and engine.dialect.name == "sqlite":
+        export_to_sql_by_form(sdk, study_key, connection_string)
+    else:
+        export_to_sql(sdk, study_key, table, connection_string)

--- a/imednet/cli/jobs.py
+++ b/imednet/cli/jobs.py
@@ -3,40 +3,33 @@ from __future__ import annotations
 import typer
 from rich import print
 
+from ..sdk import ImednetSDK
+from .decorators import with_sdk
+
 app = typer.Typer(name="jobs", help="Manage background jobs.")
 
 
 @app.command("status")
+@with_sdk
 def job_status(
+    sdk: ImednetSDK,
     study_key: str = typer.Argument(..., help="The key identifying the study."),
     batch_id: str = typer.Argument(..., help="Job batch ID."),
 ) -> None:
     """Fetch a job's current status."""
-    from . import get_sdk
-
-    sdk = get_sdk()
-    try:
-        job = sdk.get_job(study_key, batch_id)
-        print(job.model_dump())
-    except Exception as exc:  # pragma: no cover - defensive
-        print(f"[bold red]Error:[/bold red] {exc}")
-        raise typer.Exit(code=1)
+    job = sdk.get_job(study_key, batch_id)
+    print(job.model_dump())
 
 
 @app.command("wait")
+@with_sdk
 def job_wait(
+    sdk: ImednetSDK,
     study_key: str = typer.Argument(..., help="The key identifying the study."),
     batch_id: str = typer.Argument(..., help="Job batch ID."),
     interval: int = typer.Option(5, help="Polling interval in seconds."),
     timeout: int = typer.Option(300, help="Maximum time to wait."),
 ) -> None:
     """Wait for a job to reach a terminal state."""
-    from . import get_sdk
-
-    sdk = get_sdk()
-    try:
-        job = sdk.poll_job(study_key, batch_id, interval=interval, timeout=timeout)
-        print(job.model_dump())
-    except Exception as exc:  # pragma: no cover - defensive
-        print(f"[bold red]Error:[/bold red] {exc}")
-        raise typer.Exit(code=1)
+    job = sdk.poll_job(study_key, batch_id, interval=interval, timeout=timeout)
+    print(job.model_dump())

--- a/imednet/cli/queries.py
+++ b/imednet/cli/queries.py
@@ -3,30 +3,23 @@ from __future__ import annotations
 import typer
 from rich import print
 
-from ..core.exceptions import ApiError
+from ..sdk import ImednetSDK
+from .decorators import with_sdk
 
 app = typer.Typer(name="queries", help="Manage queries within a study.")
 
 
 @app.command("list")
+@with_sdk
 def list_queries(
+    sdk: ImednetSDK,
     study_key: str = typer.Argument(..., help="The key identifying the study."),
 ) -> None:
     """List queries for a study."""
-    from . import get_sdk
-
-    sdk = get_sdk()
-    try:
-        print(f"Fetching queries for study '{study_key}'...")
-        queries = sdk.queries.list(study_key)
-        if queries:
-            print(f"Found {len(queries)} queries:")
-            print(queries)
-        else:
-            print("No queries found.")
-    except ApiError as exc:
-        print(f"[bold red]API Error:[/bold red] {exc}")
-        raise typer.Exit(code=1)
-    except Exception as exc:  # pragma: no cover - defensive
-        print(f"[bold red]An unexpected error occurred:[/bold red] {exc}")
-        raise typer.Exit(code=1)
+    print(f"Fetching queries for study '{study_key}'...")
+    queries = sdk.queries.list(study_key)
+    if queries:
+        print(f"Found {len(queries)} queries:")
+        print(queries)
+    else:
+        print("No queries found.")

--- a/imednet/cli/record_revisions.py
+++ b/imednet/cli/record_revisions.py
@@ -3,30 +3,23 @@ from __future__ import annotations
 import typer
 from rich import print
 
-from ..core.exceptions import ApiError
+from ..sdk import ImednetSDK
+from .decorators import with_sdk
 
 app = typer.Typer(name="record-revisions", help="Manage record revision history.")
 
 
 @app.command("list")
+@with_sdk
 def list_record_revisions(
+    sdk: ImednetSDK,
     study_key: str = typer.Argument(..., help="The key identifying the study."),
 ) -> None:
     """List record revisions for a study."""
-    from . import get_sdk
-
-    sdk = get_sdk()
-    try:
-        print(f"Fetching record revisions for study '{study_key}'...")
-        revisions = sdk.record_revisions.list(study_key)
-        if revisions:
-            print(f"Found {len(revisions)} record revisions:")
-            print(revisions)
-        else:
-            print("No record revisions found.")
-    except ApiError as exc:
-        print(f"[bold red]API Error:[/bold red] {exc}")
-        raise typer.Exit(code=1)
-    except Exception as exc:  # pragma: no cover - defensive
-        print(f"[bold red]An unexpected error occurred:[/bold red] {exc}")
-        raise typer.Exit(code=1)
+    print(f"Fetching record revisions for study '{study_key}'...")
+    revisions = sdk.record_revisions.list(study_key)
+    if revisions:
+        print(f"Found {len(revisions)} record revisions:")
+        print(revisions)
+    else:
+        print("No record revisions found.")

--- a/imednet/cli/records.py
+++ b/imednet/cli/records.py
@@ -7,13 +7,16 @@ import pandas as pd
 import typer
 from rich import print
 
-from ..core.exceptions import ApiError
+from ..sdk import ImednetSDK
+from .decorators import with_sdk
 
 app = typer.Typer(name="records", help="Manage records within a study.")
 
 
 @app.command("list")
+@with_sdk
 def list_records(
+    sdk: ImednetSDK,
     study_key: str = typer.Argument(..., help="The key identifying the study."),
     output: Optional[str] = typer.Option(
         None,
@@ -25,35 +28,25 @@ def list_records(
     ),
 ) -> None:
     """List records for a study."""
-    from . import get_sdk
+    if output and output.lower() not in {"json", "csv"}:
+        print("[bold red]Invalid output format. Use 'json' or 'csv'.[/bold red]")
+        raise typer.Exit(code=1)
+    print(f"Fetching records for study '{study_key}'...")
+    records = sdk.records.list(study_key)
+    rows = [r.model_dump(by_alias=True) for r in records]
+    df = pd.DataFrame(rows)
 
-    sdk = get_sdk()
-    try:
-        if output and output.lower() not in {"json", "csv"}:
-            print("[bold red]Invalid output format. Use 'json' or 'csv'.[/bold red]")
-            raise typer.Exit(code=1)
-        print(f"Fetching records for study '{study_key}'...")
-        records = sdk.records.list(study_key)
-        rows = [r.model_dump(by_alias=True) for r in records]
-        df = pd.DataFrame(rows)
-
-        if output:
-            path = Path(f"records.{output}")
-            if output == "csv":
-                df.to_csv(path, index=False)
-            else:
-                df.to_json(path, orient="records", indent=2)
-            print(f"Saved {len(df)} records to {path}")
+    if output:
+        path = Path(f"records.{output}")
+        if output == "csv":
+            df.to_csv(path, index=False)
         else:
-            if df.empty:
-                print("No records found.")
-            else:
-                print(df.head().to_string(index=False))
-                if len(df) > 5:
-                    print(f"... ({len(df)} total records)")
-    except ApiError as exc:
-        print(f"[bold red]API Error:[/bold red] {exc}")
-        raise typer.Exit(code=1)
-    except Exception as exc:  # pragma: no cover - defensive
-        print(f"[bold red]An unexpected error occurred:[/bold red] {exc}")
-        raise typer.Exit(code=1)
+            df.to_json(path, orient="records", indent=2)
+        print(f"Saved {len(df)} records to {path}")
+    else:
+        if df.empty:
+            print("No records found.")
+        else:
+            print(df.head().to_string(index=False))
+            if len(df) > 5:
+                print(f"... ({len(df)} total records)")

--- a/imednet/cli/sites.py
+++ b/imednet/cli/sites.py
@@ -3,29 +3,22 @@ from __future__ import annotations
 import typer
 from rich import print
 
-from ..core.exceptions import ApiError
+from ..sdk import ImednetSDK
+from .decorators import with_sdk
 
 app = typer.Typer(name="sites", help="Manage sites within a study.")
 
 
 @app.command("list")
+@with_sdk
 def list_sites(
+    sdk: ImednetSDK,
     study_key: str = typer.Argument(..., help="The key identifying the study."),
 ) -> None:
     """List sites for a specific study."""
-    from . import get_sdk
-
-    sdk = get_sdk()
-    try:
-        print(f"Fetching sites for study '{study_key}'...")
-        sites_list = sdk.sites.list(study_key)
-        if sites_list:
-            print(sites_list)
-        else:
-            print("No sites found for this study.")
-    except ApiError as exc:
-        print(f"[bold red]API Error:[/bold red] {exc}")
-        raise typer.Exit(code=1)
-    except Exception as exc:  # pragma: no cover - defensive
-        print(f"[bold red]An unexpected error occurred:[/bold red] {exc}")
-        raise typer.Exit(code=1)
+    print(f"Fetching sites for study '{study_key}'...")
+    sites_list = sdk.sites.list(study_key)
+    if sites_list:
+        print(sites_list)
+    else:
+        print("No sites found for this study.")

--- a/imednet/cli/studies.py
+++ b/imednet/cli/studies.py
@@ -3,27 +3,19 @@ from __future__ import annotations
 import typer
 from rich import print
 
-from ..core.exceptions import ApiError
+from ..sdk import ImednetSDK
+from .decorators import with_sdk
 
 app = typer.Typer(name="studies", help="Manage studies.")
 
 
 @app.command("list")
-def list_studies() -> None:
+@with_sdk
+def list_studies(sdk: ImednetSDK) -> None:
     """List available studies."""
-    from . import get_sdk
-
-    sdk = get_sdk()
-    try:
-        print("Fetching studies...")
-        studies_list = sdk.studies.list()
-        if studies_list:
-            print(studies_list)
-        else:
-            print("No studies found.")
-    except ApiError as exc:
-        print(f"[bold red]API Error:[/bold red] {exc}")
-        raise typer.Exit(code=1)
-    except Exception as exc:  # pragma: no cover - defensive
-        print(f"[bold red]An unexpected error occurred:[/bold red] {exc}")
-        raise typer.Exit(code=1)
+    print("Fetching studies...")
+    studies_list = sdk.studies.list()
+    if studies_list:
+        print(studies_list)
+    else:
+        print("No studies found.")

--- a/imednet/cli/subject_data.py
+++ b/imednet/cli/subject_data.py
@@ -3,25 +3,19 @@ from __future__ import annotations
 import typer
 from rich import print
 
-from ..core.exceptions import ApiError
+from ..sdk import ImednetSDK
+from .decorators import with_sdk
 
 
+@with_sdk
 def subject_data(
+    sdk: ImednetSDK,
     study_key: str = typer.Argument(..., help="The key identifying the study."),
     subject_key: str = typer.Argument(..., help="The key identifying the subject."),
 ) -> None:
     """Retrieve all data for a single subject."""
-    from . import SubjectDataWorkflow, get_sdk
+    from . import SubjectDataWorkflow
 
-    sdk = get_sdk()
     workflow = SubjectDataWorkflow(sdk)
-
-    try:
-        data = workflow.get_all_subject_data(study_key, subject_key)
-        print(data.model_dump())
-    except ApiError as exc:
-        print(f"[bold red]API Error:[/bold red] {exc}")
-        raise typer.Exit(code=1)
-    except Exception as exc:  # pragma: no cover - defensive
-        print(f"[bold red]An unexpected error occurred:[/bold red] {exc}")
-        raise typer.Exit(code=1)
+    data = workflow.get_all_subject_data(study_key, subject_key)
+    print(data.model_dump())

--- a/imednet/cli/subjects.py
+++ b/imednet/cli/subjects.py
@@ -5,14 +5,17 @@ from typing import List, Optional
 import typer
 from rich import print
 
-from ..core.exceptions import ApiError
+from ..sdk import ImednetSDK
+from .decorators import with_sdk
 from .utils import parse_filter_args
 
 app = typer.Typer(name="subjects", help="Manage subjects within a study.")
 
 
 @app.command("list")
+@with_sdk
 def list_subjects(
+    sdk: ImednetSDK,
     study_key: str = typer.Argument(..., help="The key identifying the study."),
     subject_filter: Optional[List[str]] = typer.Option(
         None,
@@ -22,22 +25,12 @@ def list_subjects(
     ),
 ) -> None:
     """List subjects for a specific study."""
-    from . import get_sdk
+    parsed_filter = parse_filter_args(subject_filter)
 
-    sdk = get_sdk()
-    try:
-        parsed_filter = parse_filter_args(subject_filter)
-
-        print(f"Fetching subjects for study '{study_key}'...")
-        subjects_list = sdk.subjects.list(study_key, **(parsed_filter or {}))
-        if subjects_list:
-            print(f"Found {len(subjects_list)} subjects:")
-            print(subjects_list)
-        else:
-            print("No subjects found matching the criteria.")
-    except ApiError as exc:
-        print(f"[bold red]API Error:[/bold red] {exc}")
-        raise typer.Exit(code=1)
-    except Exception as exc:  # pragma: no cover - defensive
-        print(f"[bold red]An unexpected error occurred:[/bold red] {exc}")
-        raise typer.Exit(code=1)
+    print(f"Fetching subjects for study '{study_key}'...")
+    subjects_list = sdk.subjects.list(study_key, **(parsed_filter or {}))
+    if subjects_list:
+        print(f"Found {len(subjects_list)} subjects:")
+        print(subjects_list)
+    else:
+        print("No subjects found matching the criteria.")

--- a/imednet/cli/variables.py
+++ b/imednet/cli/variables.py
@@ -3,30 +3,23 @@ from __future__ import annotations
 import typer
 from rich import print
 
-from ..core.exceptions import ApiError
+from ..sdk import ImednetSDK
+from .decorators import with_sdk
 
 app = typer.Typer(name="variables", help="Manage variables within a study.")
 
 
 @app.command("list")
+@with_sdk
 def list_variables(
+    sdk: ImednetSDK,
     study_key: str = typer.Argument(..., help="The key identifying the study."),
 ) -> None:
     """List variables for a study."""
-    from . import get_sdk
-
-    sdk = get_sdk()
-    try:
-        print(f"Fetching variables for study '{study_key}'...")
-        variables = sdk.variables.list(study_key)
-        if variables:
-            print(f"Found {len(variables)} variables:")
-            print(variables)
-        else:
-            print("No variables found.")
-    except ApiError as exc:
-        print(f"[bold red]API Error:[/bold red] {exc}")
-        raise typer.Exit(code=1)
-    except Exception as exc:  # pragma: no cover - defensive
-        print(f"[bold red]An unexpected error occurred:[/bold red] {exc}")
-        raise typer.Exit(code=1)
+    print(f"Fetching variables for study '{study_key}'...")
+    variables = sdk.variables.list(study_key)
+    if variables:
+        print(f"Found {len(variables)} variables:")
+        print(variables)
+    else:
+        print("No variables found.")

--- a/tests/unit/cli/test_decorators.py
+++ b/tests/unit/cli/test_decorators.py
@@ -1,0 +1,19 @@
+from unittest.mock import MagicMock
+
+import imednet.cli as cli
+import pytest
+from typer.testing import CliRunner
+
+
+def test_decorator_handles_unexpected_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    runner = CliRunner()
+    monkeypatch.setenv("IMEDNET_API_KEY", "k")
+    monkeypatch.setenv("IMEDNET_SECURITY_KEY", "s")
+    sdk = MagicMock()
+    sdk.studies.list.side_effect = RuntimeError("boom")
+    monkeypatch.setattr(cli, "get_sdk", MagicMock(return_value=sdk))
+
+    result = runner.invoke(cli.app, ["studies", "list"])
+
+    assert result.exit_code == 1
+    assert "Unexpected error" in result.stdout


### PR DESCRIPTION
## Summary
- add `with_sdk` decorator to create the SDK and capture errors
- refactor CLI commands to use the decorator
- test unexpected error handling through a new unit test
- document the decorator in the changelog

## Testing
- `poetry run ruff check --fix .`
- `poetry run black --check .`
- `poetry run mypy imednet`
- `poetry run pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6866d1552b3c832c8ad91ebbfc9b65f8