### PR TITLE
Fix core Context re-export

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added ``with_sdk`` decorator for CLI commands to centralize SDK creation and
   error handling.
 
+### Fixed
+- Fix core package missing `Context` re-export.
+
 ## [0.1.1] - 2025-07-02
 
 ### Features and Improvements

--- a/imednet/core/__init__.py
+++ b/imednet/core/__init__.py
@@ -5,6 +5,7 @@ Re-exports core components for easier access.
 from .async_client import AsyncClient
 from .base_client import BaseClient
 from .client import Client
+from .context import Context
 from .exceptions import (
     ApiError,
     AuthenticationError,


### PR DESCRIPTION
## Summary
- re-export `Context` through `imednet.core`
- document the fix in the changelog

## Testing
- `poetry run ruff check --fix .`
- `poetry run black --check .`
- `poetry run mypy imednet`
- `poetry run pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6866e802e140832cb97221ef1a2274e4