### PR TITLE
Clarify SDK status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   instead of parsing connections directly.
 - Added ``with_sdk`` decorator for CLI commands to centralize SDK creation and
   error handling.
+- Updated package description to clarify this is an unofficial SDK.
 
 ### Fixed
 - Fix core package missing `Context` re-export.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ imednet = "imednet.cli:app"
 [tool.poetry]
 name = "imednet"
 version = "0.1.1"
-description = "Official Python client for the iMednet clinical trials API"
+description = "Unofficial Python SDK for the iMednet clinical trials API"
 readme = "README.md"
 keywords = ["imednet", "clinical trials", "sdk", "api"]
 classifiers = [


### PR DESCRIPTION
## Summary
- clarify in pyproject description that this SDK is unofficial
- note change in changelog

## Testing
- `poetry run ruff check --fix .`
- `poetry run black --check .`
- `poetry run mypy imednet`
- `poetry run pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6866ec1bfc90832cb97a03fae8d490ab