### PR TITLE
Introduce JsonModel base for parsing logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   instead of parsing connections directly.
 - Added ``with_sdk`` decorator for CLI commands to centralize SDK creation and
   error handling.
+- Introduced ``JsonModel`` base class for shared parsing logic and refactored
+  all models to inherit from it.
 
 ### Fixed
 - Fix core package missing `Context` re-export.

--- a/imednet/models/_base.py
+++ b/imednet/models/_base.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any, Union, get_args, get_origin
+
+from pydantic import BaseModel, ConfigDict, field_validator
+from typing_extensions import Self
+
+from imednet.utils.validators import (
+    parse_bool,
+    parse_datetime,
+    parse_dict_or_default,
+    parse_int_or_default,
+    parse_list_or_default,
+    parse_str_or_default,
+)
+
+
+class JsonModel(BaseModel):
+    """Base model with shared JSON parsing helpers."""
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    @classmethod
+    def from_json(cls, data: Any) -> Self:
+        """Validate data coming from JSON APIs."""
+        return cls.model_validate(data)
+
+    @field_validator("*", mode="before")
+    def _normalise(cls, v: Any, info: Any) -> Any:  # noqa: D401
+        """Normalize common primitive types before validation."""
+        field = cls.model_fields[info.field_name]
+        annotation = field.annotation
+        origin = get_origin(annotation)
+        optional = False
+        if origin is Union:
+            args = [a for a in get_args(annotation) if a is not type(None)]
+            if len(args) == 1:
+                annotation = args[0]
+                origin = get_origin(annotation)
+                optional = True
+
+        if origin is list:
+            return parse_list_or_default(v)
+        if origin is dict:
+            return parse_dict_or_default(v)
+
+        if annotation is str:
+            if optional and v is None:
+                return None
+            return parse_str_or_default(v)
+        if annotation is int:
+            if optional and v is None:
+                return None
+            return parse_int_or_default(v)
+        if annotation is bool:
+            if optional and v is None:
+                return None
+            return parse_bool(v)
+        if annotation is datetime:
+            if optional and not v:
+                return None
+            return parse_datetime(v)
+        return v

--- a/imednet/models/base.py
+++ b/imednet/models/base.py
@@ -5,30 +5,21 @@ from __future__ import annotations
 from datetime import datetime
 from typing import Any, Dict, Generic, List, Optional, TypeVar
 
-from pydantic import BaseModel, ConfigDict, Field, field_validator
+from pydantic import Field
 
-from imednet.utils.validators import (
-    parse_datetime,
-    parse_int_or_default,
-    parse_list_or_default,
-    parse_str_or_default,
-)
+from imednet.models._base import JsonModel
 
 
-class SortField(BaseModel):
+class SortField(JsonModel):
     """Sorting information for a field in a paginated response."""
 
     property: str = Field(..., description="Property to sort by")
     direction: str = Field(..., description="Sort direction (ASC or DESC)")
 
-    model_config = ConfigDict(populate_by_name=True)
-
-    @field_validator("property", "direction", mode="before")
-    def _fill_strs(cls, v):
-        return parse_str_or_default(v)
+    pass
 
 
-class Pagination(BaseModel):
+class Pagination(JsonModel):
     """Pagination information in an API response."""
 
     current_page: int = Field(0, alias="currentPage")
@@ -37,36 +28,20 @@ class Pagination(BaseModel):
     total_elements: int = Field(0, alias="totalElements")
     sort: List[SortField] = Field(default_factory=list)
 
-    model_config = ConfigDict(populate_by_name=True)
-
-    @field_validator("current_page", "size", "total_pages", "total_elements", mode="before")
-    def _fill_ints(cls, v):
-        return parse_int_or_default(v)
-
-    @field_validator("sort", mode="before")
-    def _fill_list(cls, v):
-        return parse_list_or_default(v)
+    pass
 
 
-class Error(BaseModel):
+class Error(JsonModel):
     """Error information in an API response."""
 
     code: str = Field("", description="Error code")
     message: str = Field("", description="Error message")
     details: Dict[str, Any] = Field(default_factory=dict)
 
-    model_config = ConfigDict(populate_by_name=True)
-
-    @field_validator("code", "message", mode="before")
-    def _fill_strs(cls, v):
-        return parse_str_or_default(v)
-
-    @field_validator("details", mode="before")
-    def _fill_details(cls, v):
-        return v if isinstance(v, dict) else {}
+    pass
 
 
-class Metadata(BaseModel):
+class Metadata(JsonModel):
     """Metadata information in an API response."""
 
     status: str = Field("", description="Response status")
@@ -75,25 +50,17 @@ class Metadata(BaseModel):
     timestamp: datetime
     error: Error = Field(default_factory=lambda: Error(code="", message=""))
 
-    model_config = ConfigDict(populate_by_name=True)
-
-    @field_validator("status", "method", "path", mode="before")
-    def _fill_strs(cls, v):
-        return parse_str_or_default(v)
-
-    @field_validator("timestamp", mode="before")
-    def _parse_datetime(cls, v):
-        return parse_datetime(v)
+    pass
 
 
 T = TypeVar("T")
 
 
-class ApiResponse(BaseModel, Generic[T]):
+class ApiResponse(JsonModel, Generic[T]):
     """Generic API response model."""
 
     metadata: Metadata
     pagination: Optional[Pagination] = None
     data: T
 
-    model_config = ConfigDict(populate_by_name=True)
+    pass

--- a/imednet/models/codings.py
+++ b/imednet/models/codings.py
@@ -1,18 +1,13 @@
 from __future__ import annotations
 
 from datetime import datetime
-from typing import Any, Dict
 
-from pydantic import BaseModel, ConfigDict, Field, field_validator
+from pydantic import Field
 
-from imednet.utils.validators import (
-    parse_datetime,
-    parse_int_or_default,
-    parse_str_or_default,
-)
+from imednet.models._base import JsonModel
 
 
-class Coding(BaseModel):
+class Coding(JsonModel):
     study_key: str = Field("", alias="studyKey")
     site_name: str = Field("", alias="siteName")
     site_id: int = Field(0, alias="siteId")
@@ -32,41 +27,3 @@ class Coding(BaseModel):
     dictionary_name: str = Field("", alias="dictionaryName")
     dictionary_version: str = Field("", alias="dictionaryVersion")
     date_coded: datetime = Field(default_factory=datetime.now, alias="dateCoded")
-
-    # allow population by field names as well as aliases
-    model_config = ConfigDict(populate_by_name=True)
-
-    @field_validator(
-        "study_key",
-        "site_name",
-        "subject_key",
-        "form_name",
-        "form_key",
-        "variable",
-        "value",
-        "code",
-        "coded_by",
-        "reason",
-        "dictionary_name",
-        "dictionary_version",
-        mode="before",
-    )
-    def _fill_strs(cls, v):
-        return parse_str_or_default(v)
-
-    @field_validator(
-        "site_id", "subject_id", "form_id", "revision", "record_id", "coding_id", mode="before"
-    )
-    def _fill_ints(cls, v):
-        return parse_int_or_default(v)
-
-    @field_validator("date_coded", mode="before")
-    def _parse_date_coded(cls, v: str | datetime) -> datetime:
-        return parse_datetime(v)
-
-    @classmethod
-    def from_json(cls, data: Dict[str, Any]) -> Coding:
-        """
-        Create a Coding instance from a JSON-like dict.
-        """
-        return cls.model_validate(data)

--- a/imednet/models/forms.py
+++ b/imednet/models/forms.py
@@ -1,19 +1,13 @@
 from __future__ import annotations
 
 from datetime import datetime
-from typing import Any, Dict
 
-from pydantic import BaseModel, ConfigDict, Field, field_validator
+from pydantic import Field
 
-from imednet.utils.validators import (
-    parse_bool,
-    parse_datetime,
-    parse_int_or_default,
-    parse_str_or_default,
-)
+from imednet.models._base import JsonModel
 
 
-class Form(BaseModel):
+class Form(JsonModel):
     study_key: str = Field("", alias="studyKey")
     form_id: int = Field(0, alias="formId")
     form_key: str = Field("", alias="formKey")
@@ -31,39 +25,3 @@ class Form(BaseModel):
     disabled: bool = Field(False, alias="disabled")
     date_created: datetime = Field(default_factory=datetime.now, alias="dateCreated")
     date_modified: datetime = Field(default_factory=datetime.now, alias="dateModified")
-
-    model_config = ConfigDict(populate_by_name=True)
-
-    @field_validator("study_key", "form_key", "form_name", "form_type", mode="before")
-    def _fill_strs(cls, v):
-        return parse_str_or_default(v)
-
-    @field_validator("form_id", "revision", mode="before")
-    def _fill_ints(cls, v):
-        return parse_int_or_default(v)
-
-    @field_validator(
-        "embedded_log",
-        "enforce_ownership",
-        "user_agreement",
-        "subject_record_report",
-        "unscheduled_visit",
-        "other_forms",
-        "epro_form",
-        "allow_copy",
-        "disabled",
-        mode="before",
-    )
-    def _parse_bools(cls, v: Any) -> bool:
-        return parse_bool(v)
-
-    @field_validator("date_created", "date_modified", mode="before")
-    def _parse_datetimes(cls, v: Any) -> datetime:
-        return parse_datetime(v)
-
-    @classmethod
-    def from_json(cls, data: Dict[str, Any]) -> Form:
-        """
-        Create a Form instance from JSON-like dict.
-        """
-        return cls.model_validate(data)

--- a/imednet/models/intervals.py
+++ b/imednet/models/intervals.py
@@ -1,44 +1,22 @@
 from __future__ import annotations
 
 from datetime import datetime
-from typing import Any, Dict, List
+from typing import List
 
-from pydantic import BaseModel, ConfigDict, Field, field_validator
+from pydantic import Field
 
-from imednet.utils.validators import (
-    parse_bool,
-    parse_datetime,
-    parse_int_or_default,
-    parse_list_or_default,
-    parse_str_or_default,
-)
+from imednet.models._base import JsonModel
 
 
-class FormSummary(BaseModel):
+class FormSummary(JsonModel):
     form_id: int = Field(0, alias="formId")
     form_key: str = Field("", alias="formKey")
     form_name: str = Field("", alias="formName")
 
-    # allow instantiation via field names as well as aliases
-    model_config = ConfigDict(populate_by_name=True)
-
-    @classmethod
-    def from_json(cls, data: Dict[str, Any]) -> FormSummary:
-        """
-        Create a FormSummary instance from JSON-like dict.
-        """
-        return cls.model_validate(data)
-
-    @field_validator("form_key", "form_name", mode="before")
-    def _fill_strs(cls, v):
-        return parse_str_or_default(v)
-
-    @field_validator("form_id", mode="before")
-    def _fill_ints(cls, v):
-        return parse_int_or_default(v)
+    pass
 
 
-class Interval(BaseModel):
+class Interval(JsonModel):
     study_key: str = Field("", alias="studyKey")
     interval_id: int = Field(0, alias="intervalId")
     interval_name: str = Field("", alias="intervalName")
@@ -61,52 +39,4 @@ class Interval(BaseModel):
     epro_grace_period: int = Field(0, alias="eproGracePeriod")
     forms: List[FormSummary] = Field(default_factory=list, alias="forms")
 
-    model_config = ConfigDict(populate_by_name=True)
-
-    @field_validator(
-        "study_key",
-        "interval_name",
-        "interval_description",
-        "interval_group_name",
-        "timeline",
-        "defined_using_interval",
-        "window_calculation_form",
-        "window_calculation_date",
-        "actual_date_form",
-        "actual_date",
-        mode="before",
-    )
-    def _fill_strs(cls, v):
-        return parse_str_or_default(v)
-
-    @field_validator(
-        "interval_id",
-        "interval_sequence",
-        "interval_group_id",
-        "due_date_will_be_in",
-        "negative_slack",
-        "positive_slack",
-        "epro_grace_period",
-        mode="before",
-    )
-    def _fill_ints(cls, v):
-        return parse_int_or_default(v)
-
-    @field_validator("forms", mode="before")
-    def _fill_list(cls, v):
-        return parse_list_or_default(v)
-
-    @field_validator("date_created", "date_modified", mode="before")
-    def _parse_datetimes(cls, v: str | datetime) -> datetime:
-        return parse_datetime(v)
-
-    @field_validator("disabled", mode="before")
-    def parse_bool_field(cls, v: Any) -> bool:
-        return parse_bool(v)
-
-    @classmethod
-    def from_json(cls, data: Dict[str, Any]) -> Interval:
-        """
-        Create an Interval instance from JSON-like dict, including nested forms.
-        """
-        return cls.model_validate(data)
+    pass

--- a/imednet/models/jobs.py
+++ b/imednet/models/jobs.py
@@ -1,38 +1,20 @@
 from __future__ import annotations
 
 from datetime import datetime
-from typing import Any, Dict
+from typing import Any
 
-from pydantic import BaseModel, ConfigDict, Field, field_validator
+from pydantic import Field, field_validator
 
-from imednet.utils.validators import parse_datetime, parse_str_or_default
+from imednet.models._base import JsonModel
 
 
-class Job(BaseModel):
+class Job(JsonModel):
     job_id: str = Field("", alias="jobId")
     batch_id: str = Field("", alias="batchId")
     state: str = Field("", alias="state")
     date_created: datetime = Field(default_factory=datetime.now, alias="dateCreated")
     date_started: datetime = Field(default_factory=datetime.now, alias="dateStarted")
     date_finished: datetime = Field(default_factory=datetime.now, alias="dateFinished")
-
-    # Allow instantiation via field names or aliases
-    model_config = ConfigDict(populate_by_name=True)
-
-    @field_validator("job_id", "batch_id", "state", mode="before")
-    def _fill_strs(cls, v):
-        return parse_str_or_default(v)
-
-    @field_validator("date_created", "date_started", "date_finished", mode="before")
-    def _parse_datetimes(cls, v):
-        return parse_datetime(v)
-
-    @classmethod
-    def from_json(cls, data: Dict[str, Any]) -> Job:
-        """
-        Create a Job instance from a JSON-like dict.
-        """
-        return cls.model_validate(data)
 
 
 class JobStatus(Job):
@@ -47,8 +29,3 @@ class JobStatus(Job):
             return int(v)
         except (TypeError, ValueError):
             return 0
-
-    @classmethod
-    def from_json(cls, data: Dict[str, Any]) -> "JobStatus":
-        """Create a JobStatus instance from a JSON-like dict."""
-        return cls.model_validate(data)

--- a/imednet/models/queries.py
+++ b/imednet/models/queries.py
@@ -1,20 +1,14 @@
 from __future__ import annotations
 
 from datetime import datetime
-from typing import Any, Dict, List, Optional
+from typing import List, Optional
 
-from pydantic import BaseModel, ConfigDict, Field, field_validator
+from pydantic import Field
 
-from imednet.utils.validators import (
-    parse_bool,
-    parse_datetime,
-    parse_int_or_default,
-    parse_list_or_default,
-    parse_str_or_default,
-)
+from imednet.models._base import JsonModel
 
 
-class QueryComment(BaseModel):
+class QueryComment(JsonModel):
     sequence: int = Field(0, alias="sequence")
     annotation_status: str = Field("", alias="annotationStatus")
     user: str = Field("", alias="user")
@@ -22,34 +16,10 @@ class QueryComment(BaseModel):
     closed: bool = Field(False, alias="closed")
     date: datetime = Field(default_factory=datetime.now, alias="date")
 
-    # Allow instantiation via field names or aliases
-    model_config = ConfigDict(populate_by_name=True)
-
-    @field_validator("annotation_status", "user", "comment", mode="before")
-    def _fill_strs(cls, v):
-        return parse_str_or_default(v)
-
-    @field_validator("sequence", mode="before")
-    def _fill_ints(cls, v):
-        return parse_int_or_default(v)
-
-    @field_validator("date", mode="before")
-    def _parse_date(cls, v):
-        return parse_datetime(v)
-
-    @field_validator("closed", mode="before")
-    def parse_bool_field(cls, v):
-        return parse_bool(v)
-
-    @classmethod
-    def from_json(cls, data: Dict[str, Any]) -> QueryComment:
-        """
-        Create a QueryComment instance from a JSON-like dict.
-        """
-        return cls.model_validate(data)
+    pass
 
 
-class Query(BaseModel):
+class Query(JsonModel):
     study_key: str = Field("", alias="studyKey")
     subject_id: int = Field(0, alias="subjectId")
     subject_oid: str = Field("", alias="subjectOid")
@@ -64,35 +34,4 @@ class Query(BaseModel):
     date_modified: datetime = Field(default_factory=datetime.now, alias="dateModified")
     query_comments: List[QueryComment] = Field(default_factory=list, alias="queryComments")
 
-    model_config = ConfigDict(populate_by_name=True)
-
-    @field_validator(
-        "study_key",
-        "subject_oid",
-        "annotation_type",
-        "description",
-        "variable",
-        "subject_key",
-        mode="before",
-    )
-    def _fill_strs(cls, v):
-        return parse_str_or_default(v)
-
-    @field_validator("subject_id", "annotation_id", "record_id", mode="before")
-    def _fill_ints(cls, v):
-        return parse_int_or_default(v)
-
-    @field_validator("query_comments", mode="before")
-    def _fill_list(cls, v):
-        return parse_list_or_default(v)
-
-    @field_validator("date_created", "date_modified", mode="before")
-    def _parse_datetimes(cls, v):
-        return parse_datetime(v)
-
-    @classmethod
-    def from_json(cls, data: Dict[str, Any]) -> Query:
-        """
-        Create a Query instance from a JSON-like dict, including nested comments.
-        """
-        return cls.model_validate(data)
+    pass

--- a/imednet/models/record_revisions.py
+++ b/imednet/models/record_revisions.py
@@ -1,19 +1,13 @@
 from __future__ import annotations
 
 from datetime import datetime
-from typing import Any, Dict
 
-from pydantic import BaseModel, ConfigDict, Field, field_validator
+from pydantic import Field
 
-from imednet.utils.validators import (
-    parse_bool,
-    parse_datetime,
-    parse_int_or_default,
-    parse_str_or_default,
-)
+from imednet.models._base import JsonModel
 
 
-class RecordRevision(BaseModel):
+class RecordRevision(JsonModel):
     study_key: str = Field("", alias="studyKey")
     record_revision_id: int = Field(0, alias="recordRevisionId")
     record_id: int = Field(0, alias="recordId")
@@ -33,47 +27,4 @@ class RecordRevision(BaseModel):
     deleted: bool = Field(False, alias="deleted")
     date_created: datetime = Field(default_factory=datetime.now, alias="dateCreated")
 
-    model_config = ConfigDict(populate_by_name=True)
-
-    @field_validator(
-        "record_revision_id",
-        "record_id",
-        "record_revision",
-        "data_revision",
-        "subject_id",
-        "site_id",
-        "interval_id",
-        mode="before",
-    )
-    def _fill_ints(cls, v):
-        return parse_int_or_default(v)
-
-    @field_validator(
-        "study_key",
-        "record_oid",
-        "record_status",
-        "subject_oid",
-        "subject_key",
-        "form_key",
-        "role",
-        "user",
-        "reason_for_change",
-        mode="before",
-    )
-    def _fill_strs(cls, v):
-        return parse_str_or_default(v)
-
-    @field_validator("deleted", mode="before")
-    def _parse_deleted(cls, v):
-        return parse_bool(v)
-
-    @field_validator("date_created", mode="before")
-    def _parse_date_created(cls, v):
-        return parse_datetime(v)
-
-    @classmethod
-    def from_json(cls, data: Dict[str, Any]) -> RecordRevision:
-        """
-        Create a RecordRevision instance from JSON-like dict.
-        """
-        return cls.model_validate(data)
+    pass

--- a/imednet/models/records.py
+++ b/imednet/models/records.py
@@ -3,43 +3,21 @@ from __future__ import annotations
 from datetime import datetime
 from typing import Any, Dict, List
 
-from pydantic import BaseModel, ConfigDict, Field, RootModel, field_validator
+from pydantic import Field, RootModel
 
-from imednet.utils.validators import (
-    parse_bool,
-    parse_datetime,
-    parse_int_or_default,
-    parse_list_or_default,
-    parse_str_or_default,
-)
+from imednet.models._base import JsonModel
 
 
-class Keyword(BaseModel):
+class Keyword(JsonModel):
     keyword_name: str = Field("", alias="keywordName")
     keyword_key: str = Field("", alias="keywordKey")
     keyword_id: int = Field(0, alias="keywordId")
     date_added: datetime = Field(default_factory=datetime.now, alias="dateAdded")
 
-    model_config = ConfigDict(populate_by_name=True)
-
-    @field_validator("keyword_name", "keyword_key", mode="before")
-    def _fill_strs(cls, v):
-        return parse_str_or_default(v)
-
-    @field_validator("keyword_id", mode="before")
-    def _fill_ints(cls, v):
-        return parse_int_or_default(v)
-
-    @field_validator("date_added", mode="before")
-    def _parse_date_added(cls, v):
-        return parse_datetime(v)
-
-    @classmethod
-    def from_json(cls, data: Dict[str, Any]) -> Keyword:
-        return cls.model_validate(data)
+    pass
 
 
-class Record(BaseModel):
+class Record(JsonModel):
     study_key: str = Field("", alias="studyKey")
     interval_id: int = Field(0, alias="intervalId")
     form_id: int = Field(0, alias="formId")
@@ -60,102 +38,42 @@ class Record(BaseModel):
     keywords: List[Keyword] = Field(default_factory=list, alias="keywords")
     record_data: Dict[str, Any] = Field(default_factory=dict, alias="recordData")
 
-    model_config = ConfigDict(populate_by_name=True)
-
-    @field_validator(
-        "interval_id",
-        "form_id",
-        "site_id",
-        "record_id",
-        "subject_id",
-        "visit_id",
-        "parent_record_id",
-        mode="before",
-    )
-    def _fill_ints(cls, v):
-        return parse_int_or_default(v)
-
-    @field_validator(
-        "study_key",
-        "form_key",
-        "record_oid",
-        "record_type",
-        "record_status",
-        "subject_oid",
-        "subject_key",
-        mode="before",
-    )
-    def _fill_strs(cls, v):
-        return parse_str_or_default(v)
-
-    @field_validator("keywords", mode="before")
-    def _fill_list(cls, v):
-        return parse_list_or_default(v)
-
-    @field_validator("deleted", mode="before")
-    def parse_bool_field(cls, v):
-        return parse_bool(v)
-
-    @field_validator("date_created", "date_modified", mode="before")
-    def _parse_datetimes(cls, v):
-        return parse_datetime(v)
-
-    @classmethod
-    def from_json(cls, data: Dict[str, Any]) -> Record:
-        return cls.model_validate(data)
+    pass
 
 
-class RecordJobResponse(BaseModel):
+class RecordJobResponse(JsonModel):
     job_id: str = Field("", alias="jobId")
     batch_id: str = Field("", alias="batchId")
     state: str = Field("", alias="state")
 
-    model_config = ConfigDict(populate_by_name=True)
-
-    @field_validator("job_id", "batch_id", "state", mode="before")
-    def _fill_strs(cls, v):
-        return parse_str_or_default(v)
-
-    @classmethod
-    def from_json(cls, data: Dict[str, Any]) -> RecordJobResponse:
-        return cls.model_validate(data)
+    pass
 
 
 class RecordData(RootModel[Dict[str, Any]]):
     pass
 
 
-class BaseRecordRequest(BaseModel):
+class BaseRecordRequest(JsonModel):
     form_key: str = Field("", alias="formKey")
     data: RecordData = Field(default_factory=lambda: RecordData({}), alias="data")
 
-    model_config = ConfigDict(populate_by_name=True)
-
-    @field_validator("form_key", mode="before")
-    def _fill_strs(cls, v):
-        return parse_str_or_default(v)
+    pass
 
 
 class RegisterSubjectRequest(BaseRecordRequest):
     site_name: str = Field("", alias="siteName")
 
-    @field_validator("site_name", mode="before")
-    def _fill_strs(cls, v):
-        return parse_str_or_default(v)
+    pass
 
 
 class UpdateScheduledRecordRequest(BaseRecordRequest):
     subject_key: str = Field("", alias="subjectKey")
     interval_name: str = Field("", alias="intervalName")
 
-    @field_validator("subject_key", "interval_name", mode="before")
-    def _fill_strs(cls, v):
-        return parse_str_or_default(v)
+    pass
 
 
 class CreateNewRecordRequest(BaseRecordRequest):
     subject_key: str = Field("", alias="subjectKey")
 
-    @field_validator("subject_key", mode="before")
-    def _fill_strs(cls, v):
-        return parse_str_or_default(v)
+    pass

--- a/imednet/models/sites.py
+++ b/imednet/models/sites.py
@@ -1,18 +1,13 @@
 from __future__ import annotations
 
 from datetime import datetime
-from typing import Any, Dict
 
-from pydantic import BaseModel, ConfigDict, Field, field_validator
+from pydantic import Field
 
-from imednet.utils.validators import (
-    parse_datetime,
-    parse_int_or_default,
-    parse_str_or_default,
-)
+from imednet.models._base import JsonModel
 
 
-class Site(BaseModel):
+class Site(JsonModel):
     study_key: str = Field("", alias="studyKey")
     site_id: int = Field(0, alias="siteId")
     site_name: str = Field("", alias="siteName")
@@ -20,24 +15,4 @@ class Site(BaseModel):
     date_created: datetime = Field(default_factory=datetime.now, alias="dateCreated")
     date_modified: datetime = Field(default_factory=datetime.now, alias="dateModified")
 
-    # allow population by field names as well as aliases
-    model_config = ConfigDict(populate_by_name=True)
-
-    @field_validator("study_key", "site_name", "site_enrollment_status", mode="before")
-    def _fill_strs(cls, v):
-        return parse_str_or_default(v)
-
-    @field_validator("site_id", mode="before")
-    def _fill_ints(cls, v):
-        return parse_int_or_default(v)
-
-    @field_validator("date_created", "date_modified", mode="before")
-    def _parse_datetimes(cls, v):
-        return parse_datetime(v)
-
-    @classmethod
-    def from_json(cls, data: Dict[str, Any]) -> Site:
-        """
-        Create a Site instance from JSON-like dict.
-        """
-        return cls.model_validate(data)
+    pass

--- a/imednet/models/studies.py
+++ b/imednet/models/studies.py
@@ -2,16 +2,12 @@ from __future__ import annotations
 
 from datetime import datetime
 
-from pydantic import BaseModel, ConfigDict, Field, field_validator
+from pydantic import Field
 
-from imednet.utils.validators import (
-    parse_datetime,
-    parse_int_or_default,
-    parse_str_or_default,
-)
+from imednet.models._base import JsonModel
 
 
-class Study(BaseModel):
+class Study(JsonModel):
     sponsor_key: str = Field("", alias="sponsorKey")
     study_key: str = Field("", alias="studyKey")
     study_id: int = Field(0, alias="studyId")
@@ -21,18 +17,4 @@ class Study(BaseModel):
     date_created: datetime = Field(default_factory=datetime.now, alias="dateCreated")
     date_modified: datetime = Field(default_factory=datetime.now, alias="dateModified")
 
-    model_config = ConfigDict(populate_by_name=True)
-
-    @field_validator(
-        "sponsor_key", "study_key", "study_name", "study_description", "study_type", mode="before"
-    )
-    def _fill_strs(cls, v):
-        return parse_str_or_default(v)
-
-    @field_validator("study_id", mode="before")
-    def _fill_ints(cls, v):
-        return parse_int_or_default(v)
-
-    @field_validator("date_created", "date_modified", mode="before")
-    def _parse_dates(cls, v):
-        return parse_datetime(v)
+    pass

--- a/imednet/models/subjects.py
+++ b/imednet/models/subjects.py
@@ -1,45 +1,23 @@
 from __future__ import annotations
 
 from datetime import datetime
-from typing import Any, Dict, List
+from typing import List
 
-from pydantic import BaseModel, ConfigDict, Field, field_validator
+from pydantic import Field
 
-from imednet.utils.validators import (
-    parse_bool,
-    parse_datetime,
-    parse_int_or_default,
-    parse_list_or_default,
-    parse_str_or_default,
-)
+from imednet.models._base import JsonModel
 
 
-class SubjectKeyword(BaseModel):
+class SubjectKeyword(JsonModel):
     keyword_name: str = Field("", alias="keywordName")
     keyword_key: str = Field("", alias="keywordKey")
     keyword_id: int = Field(0, alias="keywordId")
     date_added: datetime = Field(default_factory=datetime.now, alias="dateAdded")
 
-    model_config = ConfigDict(populate_by_name=True)
-
-    @field_validator("keyword_name", "keyword_key", mode="before")
-    def _fill_strs(cls, v):
-        return parse_str_or_default(v)
-
-    @field_validator("keyword_id", mode="before")
-    def _fill_ints(cls, v):
-        return parse_int_or_default(v)
-
-    @field_validator("date_added", mode="before")
-    def _parse_date_added(cls, v):
-        return parse_datetime(v)
-
-    @classmethod
-    def from_json(cls, data: Dict[str, Any]) -> SubjectKeyword:
-        return cls.model_validate(data)
+    pass
 
 
-class Subject(BaseModel):
+class Subject(JsonModel):
     study_key: str = Field("", alias="studyKey")
     subject_id: int = Field(0, alias="subjectId")
     subject_oid: str = Field("", alias="subjectOid")
@@ -55,30 +33,4 @@ class Subject(BaseModel):
     date_modified: datetime = Field(default_factory=datetime.now, alias="dateModified")
     keywords: List[SubjectKeyword] = Field(default_factory=list, alias="keywords")
 
-    model_config = ConfigDict(populate_by_name=True)
-
-    @field_validator("subject_id", "site_id", mode="before")
-    def _fill_ints(cls, v):
-        return parse_int_or_default(v)
-
-    @field_validator(
-        "study_key", "subject_oid", "subject_key", "subject_status", "site_name", mode="before"
-    )
-    def _fill_strs(cls, v):
-        return parse_str_or_default(v)
-
-    @field_validator("keywords", mode="before")
-    def _fill_list(cls, v):
-        return parse_list_or_default(v)
-
-    @field_validator("deleted", mode="before")
-    def parse_bool_field(cls, v):
-        return parse_bool(v)
-
-    @field_validator("enrollment_start_date", "date_created", "date_modified", mode="before")
-    def _parse_datetimes(cls, v):
-        return parse_datetime(v)
-
-    @classmethod
-    def from_json(cls, data: Dict[str, Any]) -> Subject:
-        return cls.model_validate(data)
+    pass

--- a/imednet/models/users.py
+++ b/imednet/models/users.py
@@ -1,20 +1,14 @@
 from __future__ import annotations
 
 from datetime import datetime
-from typing import Any, Dict, List
+from typing import List
 
-from pydantic import BaseModel, ConfigDict, Field, computed_field, field_validator
+from pydantic import Field, computed_field
 
-from imednet.utils.validators import (
-    parse_bool,
-    parse_datetime,
-    parse_int_or_default,
-    parse_list_or_default,
-    parse_str_or_default,
-)
+from imednet.models._base import JsonModel
 
 
-class Role(BaseModel):
+class Role(JsonModel):
     date_created: datetime = Field(default_factory=datetime.now, alias="dateCreated")
     date_modified: datetime = Field(default_factory=datetime.now, alias="dateModified")
     role_id: str = Field("", alias="roleId")
@@ -25,32 +19,10 @@ class Role(BaseModel):
     type: str = Field("", alias="type")
     inactive: bool = Field(False, alias="inactive")
 
-    model_config = ConfigDict(populate_by_name=True)
-
-    # —— Parse or default datetimes
-    @field_validator("date_created", "date_modified", mode="before")
-    def _parse_datetimes(cls, v):
-        return parse_datetime(v)
-
-    @field_validator("community_id", "level", mode="before")
-    def _fill_ints(cls, v):
-        return parse_int_or_default(v)
-
-    @field_validator("role_id", "name", "description", "type", mode="before")
-    def _fill_strs(cls, v):
-        return parse_str_or_default(v)
-
-    @field_validator("inactive", mode="before")
-    def parse_bool_field(cls, v):
-        return parse_bool(v)
-
-    @classmethod
-    def from_json(cls, data: Dict[str, Any]) -> Role:
-        """Create a Role from JSON-like dict."""
-        return cls.model_validate(data)
+    pass
 
 
-class User(BaseModel):
+class User(JsonModel):
     user_id: str = Field("", alias="userId")
     login: str = Field("", alias="login")
     first_name: str = Field("", alias="firstName")
@@ -59,27 +31,7 @@ class User(BaseModel):
     user_active_in_study: bool = Field(False, alias="userActiveInStudy")
     roles: List[Role] = Field(default_factory=list, alias="roles")
 
-    model_config = ConfigDict(populate_by_name=True)
-
-    # —— Coerce None → default strings
-    @field_validator("user_id", "login", "first_name", "last_name", "email", mode="before")
-    def _fill_strs(cls, v):
-        return parse_str_or_default(v)
-
-    # —— Coerce None → default bool
-    @field_validator("user_active_in_study", mode="before")
-    def _parse_active_flag(cls, v):
-        return parse_bool(v)
-
-    # —— Coerce None → empty list for roles
-    @field_validator("roles", mode="before")
-    def _fill_roles(cls, v):
-        return parse_list_or_default(v)
-
-    @classmethod
-    def from_json(cls, data: Dict[str, Any]) -> User:
-        """Create a User from JSON-like dict, with nested Role parsing."""
-        return cls.model_validate(data)
+    pass
 
     @computed_field
     def name(self) -> str:

--- a/imednet/models/variables.py
+++ b/imednet/models/variables.py
@@ -1,19 +1,14 @@
 from __future__ import annotations
 
 from datetime import datetime
-from typing import Any, Dict, Optional
+from typing import Optional
 
-from pydantic import BaseModel, ConfigDict, Field, field_validator
+from pydantic import Field
 
-from imednet.utils.validators import (
-    parse_bool,
-    parse_datetime,
-    parse_int_or_default,
-    parse_str_or_default,
-)
+from imednet.models._base import JsonModel
 
 
-class Variable(BaseModel):
+class Variable(JsonModel):
     study_key: str = Field("", alias="studyKey")
     variable_id: int = Field(0, alias="variableId")
     variable_type: str = Field("", alias="variableType")
@@ -31,37 +26,4 @@ class Variable(BaseModel):
     label: str = Field("", alias="label")
     blinded: bool = Field(False, alias="blinded")
 
-    # allow population by field names as well as aliases
-    model_config = ConfigDict(populate_by_name=True)
-
-    @field_validator(
-        "study_key",
-        "variable_type",
-        "variable_name",
-        "form_key",
-        "form_name",
-        "label",
-        mode="before",
-    )
-    def _fill_strs(cls, v):
-        return parse_str_or_default(v)
-
-    @field_validator("variable_id", "sequence", "revision", "form_id", mode="before")
-    def _fill_ints(cls, v):
-        return parse_int_or_default(v)
-
-    @field_validator("date_created", "date_modified", mode="before")
-    def _parse_datetimes(cls, v):
-        return parse_datetime(v)
-
-    @field_validator("disabled", "deleted", "blinded", mode="before")
-    def parse_bool_field(cls, v):
-        return parse_bool(v)
-
-    @classmethod
-    def from_json(cls, data: Dict[str, Any]) -> Variable:
-        """
-        Create a Variable instance from a JSON-like dict,
-        honoring the same parsing logic as the original.
-        """
-        return cls.model_validate(data)
+    pass

--- a/imednet/models/visits.py
+++ b/imednet/models/visits.py
@@ -1,19 +1,14 @@
 from __future__ import annotations
 
 from datetime import datetime
-from typing import Any, Dict, Optional
+from typing import Optional
 
-from pydantic import BaseModel, ConfigDict, Field, field_validator
+from pydantic import Field, field_validator
 
-from imednet.utils.validators import (
-    parse_bool,
-    parse_datetime,
-    parse_int_or_default,
-    parse_str_or_default,
-)
+from imednet.models._base import JsonModel
 
 
-class Visit(BaseModel):
+class Visit(JsonModel):
     visit_id: int = Field(0, alias="visitId")
     study_key: str = Field("", alias="studyKey")
     interval_id: int = Field(0, alias="intervalId")
@@ -30,41 +25,16 @@ class Visit(BaseModel):
     date_created: datetime = Field(default_factory=datetime.now, alias="dateCreated")
     date_modified: datetime = Field(default_factory=datetime.now, alias="dateModified")
 
-    model_config = ConfigDict(populate_by_name=True)
-
     @field_validator(
-        "study_key",
-        "interval_name",
-        "subject_key",
-        "visit_date_form",
-        "visit_date_question",
+        "start_date",
+        "end_date",
+        "due_date",
+        "visit_date",
         mode="before",
     )
-    def _fill_strs(cls, v):
-        return parse_str_or_default(v)
-
-    @field_validator("visit_id", "interval_id", "subject_id", mode="before")
-    def _fill_ints(cls, v):
-        return parse_int_or_default(v)
-
-    @field_validator("start_date", "end_date", "due_date", "visit_date", mode="before")
     def _clean_empty_dates(cls, v):
         if not v:
             return None
         return v
 
-    @field_validator("deleted", mode="before")
-    def parse_bool_field(cls, v):
-        return parse_bool(v)
-
-    @field_validator("date_created", "date_modified", mode="before")
-    def _parse_datetimes(cls, v):
-        return parse_datetime(v)
-
-    @classmethod
-    def from_json(cls, data: Dict[str, Any]) -> Visit:
-        """
-        Create a Visit instance from a JSON-like dict, honoring all the same parsing rules
-        as the original dataclass.from_json.
-        """
-        return cls.model_validate(data)
+    pass

--- a/tests/unit/test_json_roundtrip.py
+++ b/tests/unit/test_json_roundtrip.py
@@ -1,0 +1,18 @@
+import pytest
+from imednet.models import Form, Job, Subject
+from imednet.testing import fake_data
+
+
+@pytest.mark.parametrize(
+    "cls,payload_func",
+    [
+        (Subject, fake_data.fake_subject),
+        (Form, fake_data.fake_form),
+        (Job, fake_data.fake_job),
+    ],
+)
+def test_json_roundtrip(cls, payload_func):
+    payload = payload_func()
+    model = cls.from_json(payload)
+    dumped = model.model_dump(by_alias=True)
+    assert cls.from_json(dumped) == model


### PR DESCRIPTION
## Summary
- add JsonModel with shared validators
- refactor all models to use the shared base
- ensure round-trip JSON serialization works via tests

## Testing
- `poetry run ruff check --fix .`
- `poetry run black --check .`
- `poetry run mypy imednet`
- `poetry run pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6866eb517b4c832cbd5e25ac6f022f07