### PR TITLE
Fix mermaid diagram syntax

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Fix core package missing `Context` re-export.
+- Fix Mermaid diagram syntax errors and add validation test to prevent regressions.
 
 ## [0.1.1] - 2025-07-02
 

--- a/docs/job_polling.rst
+++ b/docs/job_polling.rst
@@ -8,7 +8,7 @@ a timeout occurs.
 .. mermaid::
 
    graph TD
-       A[start run()] --> B[get job status]
+       A["start run()"] --> B[get job status]
        B --> C{terminal state?}
        C -- Yes --> D[return status]
        C -- No --> E{timeout exceeded?}

--- a/docs/record_mapping.rst
+++ b/docs/record_mapping.rst
@@ -8,7 +8,7 @@ model, parses the records, and assembles the final table.
 .. mermaid::
 
    graph TD
-       A[dataframe()] --> B[_fetch_variable_metadata]
+       A["dataframe()"] --> B[_fetch_variable_metadata]
        B --> C[variables.list]
        C --> D[variable keys / labels]
        A --> E[_build_record_model]

--- a/docs/schema_validation.rst
+++ b/docs/schema_validation.rst
@@ -23,7 +23,7 @@ The diagram below outlines the main steps.
        B --> C{formKey or formId}
        C -->|Resolve formKey| D[SchemaCache]
        D --> E{variables cached?}
-       E -- No --> F[refresh(study_key)]
+       E -- No --> F["refresh(study_key)"]
        F --> G[sdk.variables.list]
        G --> D
        E -- Yes --> H[validate_record_data]

--- a/tests/test_mermaid_diagrams.py
+++ b/tests/test_mermaid_diagrams.py
@@ -1,0 +1,37 @@
+import re
+from pathlib import Path
+
+
+def get_mermaid_lines(path: Path):
+    lines = []
+    inside = False
+    skip_blank = False
+    with path.open() as f:
+        for i, line in enumerate(f, 1):
+            if line.strip() == ".. mermaid::":
+                inside = True
+                skip_blank = True
+                continue
+            if inside:
+                if skip_blank and line.strip() == "":
+                    continue
+                skip_blank = False
+                if line.strip() == "" or not line.startswith("   "):
+                    inside = False
+                    continue
+                lines.append((i, line.lstrip()))
+    return lines
+
+
+PATTERN = re.compile(r"\[[^\]]*\([^\)]*\)\]")
+
+
+def test_no_unquoted_parentheses_in_mermaid_blocks():
+    errors = []
+    for path in Path("docs").rglob("*.rst"):
+        if "_build" in path.parts:
+            continue
+        for lineno, text in get_mermaid_lines(path):
+            if PATTERN.search(text):
+                errors.append(f"{path}:{lineno}: {text.rstrip()}")
+    assert not errors, "Unquoted parentheses in mermaid labels:\n" + "\n".join(errors)


### PR DESCRIPTION
## Summary
- quote labels with parentheses in mermaid diagrams
- add a regression test that scans docs for unquoted parentheses
- document the mermaid fix in the changelog

## Testing
- `poetry run ruff check --fix .`
- `poetry run black --check .`
- `poetry run mypy imednet`
- `poetry run pytest -q`
- `poetry run pytest tests/test_mermaid_diagrams.py -q`


------
https://chatgpt.com/codex/tasks/task_e_6866f10f6344832c98ab3e65a9b19c25