### PR TITLE
Introduce ListGetEndpointMixin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Changed
+- Introduced `ListGetEndpointMixin` to unify `.list()` and `.get()` logic across all endpoints.
 - Consolidated job polling logic into a reusable ``JobPoller`` supporting sync
   and async flows.
 - Updated integration tests to patch `RequestExecutor` and allow non-strict `respx` mocking.

--- a/imednet/endpoints/_mixins.py
+++ b/imednet/endpoints/_mixins.py
@@ -1,0 +1,126 @@
+"""Endpoint mix-ins for shared functionality."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Type
+
+from pydantic import BaseModel
+
+from imednet.core.paginator import AsyncPaginator, Paginator
+from imednet.models._base import JsonModel
+from imednet.utils.filters import build_filter_string
+
+
+class ListGetEndpointMixin:
+    """Provide ``list`` and ``get`` helpers for endpoints."""
+
+    PATH: str
+    MODEL: Type[JsonModel]
+    _id_param: str
+    _cache_name: str | None = None
+    requires_study_key: bool = True
+    PAGE_SIZE: int = 100
+
+    def _parse_item(self, item: Any) -> JsonModel:  # pragma: no cover - simple wrapper
+        return self.MODEL.from_json(item)
+
+    if TYPE_CHECKING:
+
+        def _auto_filter(self, filters: Dict[str, Any]) -> Dict[str, Any]: ...
+
+        def _build_path(self, *segments: Any) -> str: ...
+
+    def _list_impl(
+        self,
+        client: Any,
+        paginator_cls: type[Paginator] | type[AsyncPaginator],
+        *,
+        study_key: Optional[str] = None,
+        refresh: bool = False,
+        **filters: Any,
+    ) -> Any:
+        filters = self._auto_filter(filters)
+        if study_key is not None:
+            filters["studyKey"] = study_key
+
+        cache = getattr(self, self._cache_name) if self._cache_name else None
+        study = None
+        if self.requires_study_key:
+            study = filters.pop("studyKey", None)
+            if not study:
+                raise ValueError("Study key must be provided or set in the context")
+            if cache is not None and not filters and not refresh and study in cache:
+                return cache[study]
+        else:
+            if cache is not None and not filters and not refresh:
+                return cache
+
+        params: Dict[str, Any] = {}
+        if filters:
+            params["filter"] = build_filter_string(filters)
+
+        if self.requires_study_key:
+            path = self._build_path(study, self.PATH)
+        else:
+            path = self._build_path(self.PATH) if self.PATH else self._build_path()
+
+        paginator = paginator_cls(client, path, params=params, page_size=self.PAGE_SIZE)
+
+        if hasattr(paginator, "__aiter__"):
+
+            async def _collect() -> List[JsonModel]:
+                items = [self._parse_item(item) async for item in paginator]
+                if self._cache_name and not filters:
+                    if self.requires_study_key:
+                        cache_dict = cache or {}
+                        cache_dict[study] = items
+                        setattr(self, self._cache_name, cache_dict)
+                    else:
+                        setattr(self, self._cache_name, items)
+                return items
+
+            return _collect()
+
+        items = [self._parse_item(item) for item in paginator]
+        if self._cache_name and not filters:
+            if self.requires_study_key:
+                cache_dict = cache or {}
+                cache_dict[study] = items
+                setattr(self, self._cache_name, cache_dict)
+            else:
+                setattr(self, self._cache_name, items)
+        return items
+
+    def _get_impl(
+        self,
+        client: Any,
+        paginator_cls: type[Paginator] | type[AsyncPaginator],
+        study_key: Optional[str] = None,
+        item_id: Any | None = None,
+    ) -> Any:
+        if item_id is None:
+            item_id = study_key
+            study_key = None
+        result = self._list_impl(
+            client,
+            paginator_cls,
+            study_key=study_key,
+            refresh=True,
+            **{self._id_param: item_id},
+        )
+
+        if hasattr(result, "__await__"):
+
+            async def _await() -> BaseModel:
+                items = await result
+                if not items:
+                    key = f" in study {study_key}" if study_key else ""
+                    raise ValueError(f"{self.MODEL.__name__} {item_id} not found{key}")
+                return items[0]
+
+            return _await()
+
+        if not result:
+            key = f" in study {study_key}" if study_key else ""
+            raise ValueError(f"{self.MODEL.__name__} {item_id} not found{key}")
+        return result[0]

--- a/imednet/endpoints/base.py
+++ b/imednet/endpoints/base.py
@@ -16,6 +16,7 @@ class BaseEndpoint:
     Handles context injection and filtering.
     """
 
+    BASE_PATH = "/api/v1/edc/studies"
     PATH: str  # to be set in subclasses
 
     def __init__(
@@ -35,8 +36,12 @@ class BaseEndpoint:
         return filters
 
     def _build_path(self, *args: Any) -> str:
-        # join path segments after base path
-        segments = [self.PATH.strip("/")] + [str(a).strip("/") for a in args]
+        """Join ``BASE_PATH`` with additional path segments."""
+
+        segments = [self.BASE_PATH.strip("/")]
+        for part in args:
+            if part:
+                segments.append(str(part).strip("/"))
         return "/" + "/".join(segments)
 
     # ------------------------------------------------------------------

--- a/imednet/endpoints/codings.py
+++ b/imednet/endpoints/codings.py
@@ -1,78 +1,23 @@
 """Endpoint for managing codings (medical coding) in a study."""
 
-import inspect
-from typing import Any, Dict, List, Optional
+from typing import Any, List, Optional
 
 from imednet.core.paginator import AsyncPaginator, Paginator
+from imednet.endpoints._mixins import ListGetEndpointMixin
 from imednet.endpoints.base import BaseEndpoint
 from imednet.models.codings import Coding
-from imednet.utils.filters import build_filter_string
 
 
-class CodingsEndpoint(BaseEndpoint):
+class CodingsEndpoint(ListGetEndpointMixin, BaseEndpoint):
     """
     API endpoint for interacting with codings (medical coding) in an iMedNet study.
 
     Provides methods to list and retrieve individual codings.
     """
 
-    PATH = "/api/v1/edc/studies"
-
-    def _list_impl(
-        self,
-        client: Any,
-        paginator_cls: type[Any],
-        *,
-        study_key: Optional[str] = None,
-        **filters: Any,
-    ) -> Any:
-        filters = self._auto_filter(filters)
-        if study_key:
-            filters["studyKey"] = study_key
-
-        study = filters.pop("studyKey")
-        if not study:
-            raise ValueError("Study key must be provided or set in the context")
-
-        params: Dict[str, Any] = {}
-        if filters:
-            params["filter"] = build_filter_string(filters)
-
-        path = self._build_path(study, "codings")
-        paginator = paginator_cls(client, path, params=params)
-
-        if hasattr(paginator, "__aiter__"):
-
-            async def _collect() -> List[Coding]:
-                return [Coding.from_json(item) async for item in paginator]
-
-            return _collect()
-
-        return [Coding.from_json(item) for item in paginator]
-
-    def _get_impl(
-        self, client: Any, paginator_cls: type[Any], study_key: str, coding_id: str
-    ) -> Any:
-        result = self._list_impl(
-            client,
-            paginator_cls,
-            study_key=study_key,
-            codingId=coding_id,
-        )
-
-        if inspect.isawaitable(result):
-
-            async def _await() -> Coding:
-                items = await result
-                if not items:
-                    raise ValueError(f"Coding {coding_id} not found in study {study_key}")
-                return items[0]
-
-            return _await()
-
-        if not result:
-            raise ValueError(f"Coding {coding_id} not found in study {study_key}")
-        return result[0]
+    PATH = "codings"
+    MODEL = Coding
+    _id_param = "codingId"
 
     def list(self, study_key: Optional[str] = None, **filters) -> List[Coding]:
         """List codings in a study with optional filtering."""

--- a/imednet/endpoints/forms.py
+++ b/imednet/endpoints/forms.py
@@ -1,89 +1,28 @@
 """Endpoint for managing forms (eCRFs) in a study."""
 
-import inspect
 from typing import Any, Dict, List, Optional
 
 from imednet.core.async_client import AsyncClient
 from imednet.core.client import Client
 from imednet.core.context import Context
 from imednet.core.paginator import AsyncPaginator, Paginator
+from imednet.endpoints._mixins import ListGetEndpointMixin
 from imednet.endpoints.base import BaseEndpoint
 from imednet.models.forms import Form
-from imednet.utils.filters import build_filter_string
 
 
-class FormsEndpoint(BaseEndpoint):
+class FormsEndpoint(ListGetEndpointMixin, BaseEndpoint):
     """
     API endpoint for interacting with forms (eCRFs) in an iMedNet study.
 
     Provides methods to list and retrieve individual forms.
     """
 
-    PATH = "/api/v1/edc/studies"
-
-    def _list_impl(
-        self,
-        client: Any,
-        paginator_cls: type[Any],
-        *,
-        study_key: Optional[str] = None,
-        refresh: bool = False,
-        **filters: Any,
-    ) -> Any:
-        filters = self._auto_filter(filters)
-        if study_key:
-            filters["studyKey"] = study_key
-
-        study = filters.pop("studyKey")
-        if not study:
-            raise ValueError("Study key must be provided or set in the context")
-        if not filters and not refresh and study in self._forms_cache:
-            return self._forms_cache[study]
-
-        params: Dict[str, Any] = {}
-        if filters:
-            params["filter"] = build_filter_string(filters)
-
-        path = self._build_path(study, "forms")
-        paginator = paginator_cls(client, path, params=params, page_size=500)
-
-        if hasattr(paginator, "__aiter__"):
-
-            async def _collect() -> List[Form]:
-                result = [Form.from_json(item) async for item in paginator]
-                if not filters:
-                    self._forms_cache[study] = result
-                return result
-
-            return _collect()
-
-        result = [Form.from_json(item) for item in paginator]
-        if not filters:
-            self._forms_cache[study] = result
-        return result
-
-    def _get_impl(self, client: Any, paginator_cls: type[Any], study_key: str, form_id: int) -> Any:
-        result = self._list_impl(
-            client,
-            paginator_cls,
-            study_key=study_key,
-            refresh=True,
-            formId=form_id,
-        )
-
-        if inspect.isawaitable(result):
-
-            async def _await() -> Form:
-                items = await result
-                if not items:
-                    raise ValueError(f"Form {form_id} not found in study {study_key}")
-                return items[0]
-
-            return _await()
-
-        if not result:
-            raise ValueError(f"Form {form_id} not found in study {study_key}")
-        return result[0]
+    PATH = "forms"
+    MODEL = Form
+    _id_param = "formId"
+    _cache_name = "_forms_cache"
+    PAGE_SIZE = 500
 
     def __init__(
         self,

--- a/imednet/endpoints/intervals.py
+++ b/imednet/endpoints/intervals.py
@@ -1,91 +1,28 @@
 """Endpoint for managing intervals (visit definitions) in a study."""
 
-import inspect
 from typing import Any, Dict, List, Optional
 
 from imednet.core.async_client import AsyncClient
 from imednet.core.client import Client
 from imednet.core.context import Context
 from imednet.core.paginator import AsyncPaginator, Paginator
+from imednet.endpoints._mixins import ListGetEndpointMixin
 from imednet.endpoints.base import BaseEndpoint
 from imednet.models.intervals import Interval
-from imednet.utils.filters import build_filter_string
 
 
-class IntervalsEndpoint(BaseEndpoint):
+class IntervalsEndpoint(ListGetEndpointMixin, BaseEndpoint):
     """
     API endpoint for interacting with intervals (visit definitions) in an iMedNet study.
 
     Provides methods to list and retrieve individual intervals.
     """
 
-    PATH = "/api/v1/edc/studies"
-
-    def _list_impl(
-        self,
-        client: Any,
-        paginator_cls: type[Any],
-        *,
-        study_key: Optional[str] = None,
-        refresh: bool = False,
-        **filters: Any,
-    ) -> Any:
-        filters = self._auto_filter(filters)
-        if study_key:
-            filters["studyKey"] = study_key
-
-        study = filters.pop("studyKey")
-        if not study:
-            raise ValueError("Study key must be provided or set in the context")
-        if not filters and not refresh and study in self._intervals_cache:
-            return self._intervals_cache[study]
-
-        params: Dict[str, Any] = {}
-        if filters:
-            params["filter"] = build_filter_string(filters)
-
-        path = self._build_path(study, "intervals")
-        paginator = paginator_cls(client, path, params=params, page_size=500)
-
-        if hasattr(paginator, "__aiter__"):
-
-            async def _collect() -> List[Interval]:
-                result = [Interval.from_json(item) async for item in paginator]
-                if not filters:
-                    self._intervals_cache[study] = result
-                return result
-
-            return _collect()
-
-        result = [Interval.from_json(item) for item in paginator]
-        if not filters:
-            self._intervals_cache[study] = result
-        return result
-
-    def _get_impl(
-        self, client: Any, paginator_cls: type[Any], study_key: str, interval_id: int
-    ) -> Any:
-        result = self._list_impl(
-            client,
-            paginator_cls,
-            study_key=study_key,
-            refresh=True,
-            intervalId=interval_id,
-        )
-
-        if inspect.isawaitable(result):
-
-            async def _await() -> Interval:
-                items = await result
-                if not items:
-                    raise ValueError(f"Interval {interval_id} not found in study {study_key}")
-                return items[0]
-
-            return _await()
-
-        if not result:
-            raise ValueError(f"Interval {interval_id} not found in study {study_key}")
-        return result[0]
+    PATH = "intervals"
+    MODEL = Interval
+    _id_param = "intervalId"
+    _cache_name = "_intervals_cache"
+    PAGE_SIZE = 500
 
     def __init__(
         self,

--- a/imednet/endpoints/jobs.py
+++ b/imednet/endpoints/jobs.py
@@ -14,7 +14,7 @@ class JobsEndpoint(BaseEndpoint):
     Provides a method to fetch a job by its batch ID.
     """
 
-    PATH = "/api/v1/edc/studies"
+    PATH = ""
 
     def _get_impl(self, client: Any, study_key: str, batch_id: str) -> Any:
         endpoint = self._build_path(study_key, "jobs", batch_id)

--- a/imednet/endpoints/queries.py
+++ b/imednet/endpoints/queries.py
@@ -1,74 +1,23 @@
 """Endpoint for managing queries (dialogue/questions) in a study."""
 
-import inspect
-from typing import Any, Dict, List, Optional
+from typing import Any, List, Optional
 
 from imednet.core.paginator import AsyncPaginator, Paginator
+from imednet.endpoints._mixins import ListGetEndpointMixin
 from imednet.endpoints.base import BaseEndpoint
 from imednet.models.queries import Query
-from imednet.utils.filters import build_filter_string
 
 
-class QueriesEndpoint(BaseEndpoint):
+class QueriesEndpoint(ListGetEndpointMixin, BaseEndpoint):
     """
     API endpoint for interacting with queries (dialogue/questions) in an iMedNet study.
 
     Provides methods to list and retrieve queries.
     """
 
-    PATH = "/api/v1/edc/studies"
-
-    def _list_impl(
-        self,
-        client: Any,
-        paginator_cls: type[Any],
-        *,
-        study_key: Optional[str] = None,
-        **filters: Any,
-    ) -> Any:
-        filters = self._auto_filter(filters)
-        if study_key:
-            filters["studyKey"] = study_key
-
-        params: Dict[str, Any] = {}
-        if filters:
-            params["filter"] = build_filter_string(filters)
-
-        path = self._build_path(filters.get("studyKey", ""), "queries")
-        paginator = paginator_cls(client, path, params=params)
-
-        if hasattr(paginator, "__aiter__"):
-
-            async def _collect() -> List[Query]:
-                return [Query.from_json(item) async for item in paginator]
-
-            return _collect()
-
-        return [Query.from_json(item) for item in paginator]
-
-    def _get_impl(
-        self, client: Any, paginator_cls: type[Any], study_key: str, annotation_id: int
-    ) -> Any:
-        result = self._list_impl(
-            client,
-            paginator_cls,
-            study_key=study_key,
-            annotationId=annotation_id,
-        )
-
-        if inspect.isawaitable(result):
-
-            async def _await() -> Query:
-                items = await result
-                if not items:
-                    raise ValueError(f"Query {annotation_id} not found in study {study_key}")
-                return items[0]
-
-            return _await()
-
-        if not result:
-            raise ValueError(f"Query {annotation_id} not found in study {study_key}")
-        return result[0]
+    PATH = "queries"
+    MODEL = Query
+    _id_param = "annotationId"
 
     def list(self, study_key: Optional[str] = None, **filters) -> List[Query]:
         """List queries in a study with optional filtering."""

--- a/imednet/endpoints/record_revisions.py
+++ b/imednet/endpoints/record_revisions.py
@@ -1,76 +1,23 @@
 """Endpoint for retrieving record revision history in a study."""
 
-import inspect
-from typing import Any, Dict, List, Optional
+from typing import Any, List, Optional
 
 from imednet.core.paginator import AsyncPaginator, Paginator
+from imednet.endpoints._mixins import ListGetEndpointMixin
 from imednet.endpoints.base import BaseEndpoint
 from imednet.models.record_revisions import RecordRevision
-from imednet.utils.filters import build_filter_string
 
 
-class RecordRevisionsEndpoint(BaseEndpoint):
+class RecordRevisionsEndpoint(ListGetEndpointMixin, BaseEndpoint):
     """
     API endpoint for accessing record revision history in an iMedNet study.
 
     Provides methods to list and retrieve record revisions.
     """
 
-    PATH = "/api/v1/edc/studies"
-
-    def _list_impl(
-        self,
-        client: Any,
-        paginator_cls: type[Any],
-        *,
-        study_key: Optional[str] = None,
-        **filters: Any,
-    ) -> Any:
-        filters = self._auto_filter(filters)
-        if study_key:
-            filters["studyKey"] = study_key
-
-        params: Dict[str, Any] = {}
-        if filters:
-            params["filter"] = build_filter_string(filters)
-
-        path = self._build_path(filters.get("studyKey", ""), "recordRevisions")
-        paginator = paginator_cls(client, path, params=params)
-
-        if hasattr(paginator, "__aiter__"):
-
-            async def _collect() -> List[RecordRevision]:
-                return [RecordRevision.from_json(item) async for item in paginator]
-
-            return _collect()
-
-        return [RecordRevision.from_json(item) for item in paginator]
-
-    def _get_impl(
-        self, client: Any, paginator_cls: type[Any], study_key: str, record_revision_id: int
-    ) -> Any:
-        result = self._list_impl(
-            client,
-            paginator_cls,
-            study_key=study_key,
-            recordRevisionId=record_revision_id,
-        )
-
-        if inspect.isawaitable(result):
-
-            async def _await() -> RecordRevision:
-                items = await result
-                if not items:
-                    raise ValueError(
-                        f"Record revision {record_revision_id} not found in study {study_key}"
-                    )
-                return items[0]
-
-            return _await()
-
-        if not result:
-            raise ValueError(f"Record revision {record_revision_id} not found in study {study_key}")
-        return result[0]
+    PATH = "recordRevisions"
+    MODEL = RecordRevision
+    _id_param = "recordRevisionId"
 
     def list(self, study_key: Optional[str] = None, **filters) -> List[RecordRevision]:
         """List record revisions in a study with optional filtering."""

--- a/imednet/endpoints/sites.py
+++ b/imednet/endpoints/sites.py
@@ -1,76 +1,23 @@
 """Endpoint for managing sites (study locations) in a study."""
 
-import inspect
-from typing import Any, Dict, List, Optional
+from typing import Any, List, Optional
 
 from imednet.core.paginator import AsyncPaginator, Paginator
+from imednet.endpoints._mixins import ListGetEndpointMixin
 from imednet.endpoints.base import BaseEndpoint
 from imednet.models.sites import Site
-from imednet.utils.filters import build_filter_string
 
 
-class SitesEndpoint(BaseEndpoint):
+class SitesEndpoint(ListGetEndpointMixin, BaseEndpoint):
     """
     API endpoint for interacting with sites (study locations) in an iMedNet study.
 
     Provides methods to list and retrieve individual sites.
     """
 
-    PATH = "/api/v1/edc/studies"
-
-    def _list_impl(
-        self,
-        client: Any,
-        paginator_cls: type[Any],
-        *,
-        study_key: Optional[str] = None,
-        **filters: Any,
-    ) -> Any:
-        filters = self._auto_filter(filters)
-        if study_key:
-            filters["studyKey"] = study_key
-
-        study = filters.pop("studyKey")
-        if not study:
-            raise ValueError("Study key must be provided or set in the context")
-
-        params: Dict[str, Any] = {}
-        if filters:
-            params["filter"] = build_filter_string(filters)
-
-        path = self._build_path(study, "sites")
-        paginator = paginator_cls(client, path, params=params)
-
-        if hasattr(paginator, "__aiter__"):
-
-            async def _collect() -> List[Site]:
-                return [Site.from_json(item) async for item in paginator]
-
-            return _collect()
-
-        return [Site.from_json(item) for item in paginator]
-
-    def _get_impl(self, client: Any, paginator_cls: type[Any], study_key: str, site_id: int) -> Any:
-        result = self._list_impl(
-            client,
-            paginator_cls,
-            study_key=study_key,
-            siteId=site_id,
-        )
-
-        if inspect.isawaitable(result):
-
-            async def _await() -> Site:
-                items = await result
-                if not items:
-                    raise ValueError(f"Site {site_id} not found in study {study_key}")
-                return items[0]
-
-            return _await()
-
-        if not result:
-            raise ValueError(f"Site {site_id} not found in study {study_key}")
-        return result[0]
+    PATH = "sites"
+    MODEL = Site
+    _id_param = "siteId"
 
     def list(self, study_key: Optional[str] = None, **filters) -> List[Site]:
         """List sites in a study with optional filtering."""

--- a/imednet/endpoints/studies.py
+++ b/imednet/endpoints/studies.py
@@ -1,80 +1,33 @@
 """Endpoint for managing studies in the iMedNet system."""
 
-import inspect
-from typing import Any, Dict, List, Optional
+from typing import Any, List, Optional
 
 from imednet.core.async_client import AsyncClient
 from imednet.core.client import Client
 from imednet.core.context import Context
 from imednet.core.paginator import AsyncPaginator, Paginator
+from imednet.endpoints._mixins import ListGetEndpointMixin
 from imednet.endpoints.base import BaseEndpoint
 from imednet.models.studies import Study
-from imednet.utils.filters import build_filter_string
 
 
-class StudiesEndpoint(BaseEndpoint):
+class StudiesEndpoint(ListGetEndpointMixin, BaseEndpoint):
     """
     API endpoint for interacting with studies in the iMedNet system.
 
     Provides methods to list available studies and retrieve specific studies.
     """
 
-    PATH = "/api/v1/edc/studies"
+    PATH = ""
+    MODEL = Study
+    _id_param = "studyKey"
+    _cache_name = "_studies_cache"
+    requires_study_key = False
     _studies_cache: Optional[List[Study]]
 
-    def _list_impl(
-        self,
-        client: Any,
-        paginator_cls: type[Any],
-        *,
-        refresh: bool = False,
-        **filters: Any,
-    ) -> Any:
-        filters = self._auto_filter(filters)
-        if not filters and not refresh and self._studies_cache is not None:
-            return self._studies_cache
-
-        params: Dict[str, Any] = {}
-        if filters:
-            params["filter"] = build_filter_string(filters)
-        paginator = paginator_cls(client, self.PATH, params=params)
-
-        if hasattr(paginator, "__aiter__"):
-
-            async def _collect() -> List[Study]:
-                result = [Study.model_validate(item) async for item in paginator]
-                if not filters:
-                    self._studies_cache = result
-                return result
-
-            return _collect()
-
-        result = [Study.model_validate(item) for item in paginator]
-        if not filters:
-            self._studies_cache = result
-        return result
-
-    def _get_impl(self, client: Any, paginator_cls: type[Any], study_key: str) -> Any:
-        result = self._list_impl(
-            client,
-            paginator_cls,
-            refresh=True,
-            studyKey=study_key,
-        )
-
-        if inspect.isawaitable(result):
-
-            async def _await() -> Study:
-                items = await result
-                if not items:
-                    raise ValueError(f"Study {study_key} not found")
-                return items[0]
-
-            return _await()
-
-        if not result:
-            raise ValueError(f"Study {study_key} not found")
-        return result[0]
+    def _parse_item(self, item: Any) -> Study:  # noqa: D401
+        """Parse a Study item using ``model_validate``."""
+        return Study.model_validate(item)
 
     def __init__(
         self,

--- a/imednet/endpoints/subjects.py
+++ b/imednet/endpoints/subjects.py
@@ -1,74 +1,23 @@
 """Endpoint for managing subjects in a study."""
 
-import inspect
-from typing import Any, Dict, List, Optional
+from typing import Any, List, Optional
 
 from imednet.core.paginator import AsyncPaginator, Paginator
+from imednet.endpoints._mixins import ListGetEndpointMixin
 from imednet.endpoints.base import BaseEndpoint
 from imednet.models.subjects import Subject
-from imednet.utils.filters import build_filter_string
 
 
-class SubjectsEndpoint(BaseEndpoint):
+class SubjectsEndpoint(ListGetEndpointMixin, BaseEndpoint):
     """
     API endpoint for interacting with subjects in an iMedNet study.
 
     Provides methods to list and retrieve individual subjects.
     """
 
-    PATH = "/api/v1/edc/studies"
-
-    def _list_impl(
-        self,
-        client: Any,
-        paginator_cls: type[Any],
-        *,
-        study_key: Optional[str] = None,
-        **filters: Any,
-    ) -> Any:
-        filters = self._auto_filter(filters)
-        if study_key:
-            filters["studyKey"] = study_key
-
-        params: Dict[str, Any] = {}
-        if filters:
-            params["filter"] = build_filter_string(filters)
-
-        path = self._build_path(filters.get("studyKey", ""), "subjects")
-        paginator = paginator_cls(client, path, params=params)
-
-        if hasattr(paginator, "__aiter__"):
-
-            async def _collect() -> List[Subject]:
-                return [Subject.from_json(item) async for item in paginator]
-
-            return _collect()
-
-        return [Subject.from_json(item) for item in paginator]
-
-    def _get_impl(
-        self, client: Any, paginator_cls: type[Any], study_key: str, subject_key: str
-    ) -> Any:
-        result = self._list_impl(
-            client,
-            paginator_cls,
-            study_key=study_key,
-            subjectKey=subject_key,
-        )
-
-        if inspect.isawaitable(result):
-
-            async def _await() -> Subject:
-                items = await result
-                if not items:
-                    raise ValueError(f"Subject {subject_key} not found in study {study_key}")
-                return items[0]
-
-            return _await()
-
-        if not result:
-            raise ValueError(f"Subject {subject_key} not found in study {study_key}")
-        return result[0]
+    PATH = "subjects"
+    MODEL = Subject
+    _id_param = "subjectKey"
 
     def list(self, study_key: Optional[str] = None, **filters) -> List[Subject]:
         """List subjects in a study with optional filtering."""

--- a/imednet/endpoints/visits.py
+++ b/imednet/endpoints/visits.py
@@ -1,74 +1,23 @@
 """Endpoint for managing visits (interval instances) in a study."""
 
-import inspect
-from typing import Any, Dict, List, Optional
+from typing import Any, List, Optional
 
 from imednet.core.paginator import AsyncPaginator, Paginator
+from imednet.endpoints._mixins import ListGetEndpointMixin
 from imednet.endpoints.base import BaseEndpoint
 from imednet.models.visits import Visit
-from imednet.utils.filters import build_filter_string
 
 
-class VisitsEndpoint(BaseEndpoint):
+class VisitsEndpoint(ListGetEndpointMixin, BaseEndpoint):
     """
     API endpoint for interacting with visits (interval instances) in an iMedNet study.
 
     Provides methods to list and retrieve individual visits.
     """
 
-    PATH = "/api/v1/edc/studies"
-
-    def _list_impl(
-        self,
-        client: Any,
-        paginator_cls: type[Any],
-        *,
-        study_key: Optional[str] = None,
-        **filters: Any,
-    ) -> Any:
-        filters = self._auto_filter(filters)
-        if study_key:
-            filters["studyKey"] = study_key
-
-        params: Dict[str, Any] = {}
-        if filters:
-            params["filter"] = build_filter_string(filters)
-
-        path = self._build_path(filters.get("studyKey", ""), "visits")
-        paginator = paginator_cls(client, path, params=params)
-
-        if hasattr(paginator, "__aiter__"):
-
-            async def _collect() -> List[Visit]:
-                return [Visit.from_json(item) async for item in paginator]
-
-            return _collect()
-
-        return [Visit.from_json(item) for item in paginator]
-
-    def _get_impl(
-        self, client: Any, paginator_cls: type[Any], study_key: str, visit_id: int
-    ) -> Any:
-        result = self._list_impl(
-            client,
-            paginator_cls,
-            study_key=study_key,
-            visitId=visit_id,
-        )
-
-        if inspect.isawaitable(result):
-
-            async def _await() -> Visit:
-                items = await result
-                if not items:
-                    raise ValueError(f"Visit {visit_id} not found in study {study_key}")
-                return items[0]
-
-            return _await()
-
-        if not result:
-            raise ValueError(f"Visit {visit_id} not found in study {study_key}")
-        return result[0]
+    PATH = "visits"
+    MODEL = Visit
+    _id_param = "visitId"
 
     def list(self, study_key: Optional[str] = None, **filters) -> List[Visit]:
         """List visits in a study with optional filtering."""

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -89,7 +89,14 @@ def patch_build_filter(monkeypatch):
             captured["filters"] = filters
             return "FILTERED"
 
-        monkeypatch.setattr(module, "build_filter_string", fake)
+        target = f"{module.__name__}.build_filter_string"
+        if hasattr(module, "build_filter_string"):
+            monkeypatch.setattr(target, fake)
+        monkeypatch.setattr(
+            "imednet.endpoints._mixins.build_filter_string",
+            fake,
+            raising=False,
+        )
         return captured
 
     return patch

--- a/tests/unit/endpoints/test_codings_endpoint.py
+++ b/tests/unit/endpoints/test_codings_endpoint.py
@@ -8,7 +8,7 @@ def test_list_requires_study_key(dummy_client, context, paginator_factory, patch
     capture = paginator_factory(codings, [{"codingId": 1}])
     patch = patch_build_filter(codings)
 
-    with pytest.raises(KeyError):
+    with pytest.raises(ValueError):
         ep.list()
 
     result = ep.list(study_key="S1", status="y")

--- a/tests/unit/endpoints/test_endpoints_async.py
+++ b/tests/unit/endpoints/test_endpoints_async.py
@@ -160,8 +160,9 @@ async def test_async_get_record(monkeypatch, dummy_client, context, response_fac
     ep = records.RecordsEndpoint(dummy_client, context, async_client=dummy_client)
     called = {}
 
-    async def fake_impl(self, client, paginator, *, study_key=None, **filters):
+    async def fake_impl(self, client, paginator, *, study_key=None, refresh=False, **filters):
         called["study_key"] = study_key
+        called["refresh"] = refresh
         called["filters"] = filters
         return [Record(record_id=1)]
 
@@ -169,7 +170,7 @@ async def test_async_get_record(monkeypatch, dummy_client, context, response_fac
 
     rec = await ep.async_get("S1", 1)
 
-    assert called == {"study_key": "S1", "filters": {"recordId": 1}}
+    assert called == {"study_key": "S1", "refresh": True, "filters": {"recordId": 1}}
     assert isinstance(rec, Record)
 
 

--- a/tests/unit/endpoints/test_forms_endpoint.py
+++ b/tests/unit/endpoints/test_forms_endpoint.py
@@ -10,7 +10,7 @@ def test_list_requires_study_key_and_page_size(
     captured = paginator_factory(forms, [{"formId": 1}])
     filter_capture = patch_build_filter(forms)
 
-    with pytest.raises(KeyError):
+    with pytest.raises(ValueError):
         ep.list()
 
     context.set_default_study_key("S1")

--- a/tests/unit/endpoints/test_list_get.py
+++ b/tests/unit/endpoints/test_list_get.py
@@ -1,0 +1,80 @@
+import imednet.endpoints.codings as codings
+import imednet.endpoints.forms as forms
+import imednet.endpoints.intervals as intervals
+import imednet.endpoints.queries as queries
+import imednet.endpoints.record_revisions as record_revisions
+import imednet.endpoints.records as records
+import imednet.endpoints.sites as sites
+import imednet.endpoints.studies as studies
+import imednet.endpoints.subjects as subjects
+import imednet.endpoints.users as users
+import imednet.endpoints.variables as variables
+import imednet.endpoints.visits as visits
+import pytest
+from imednet.models.codings import Coding
+from imednet.models.forms import Form
+from imednet.models.intervals import Interval
+from imednet.models.queries import Query
+from imednet.models.record_revisions import RecordRevision
+from imednet.models.records import Record
+from imednet.models.sites import Site
+from imednet.models.studies import Study
+from imednet.models.subjects import Subject
+from imednet.models.users import User
+from imednet.models.variables import Variable
+from imednet.models.visits import Visit
+
+ENDPOINTS = [
+    (forms.FormsEndpoint, forms, Form, 1),
+    (codings.CodingsEndpoint, codings, Coding, "1"),
+    (intervals.IntervalsEndpoint, intervals, Interval, 1),
+    (queries.QueriesEndpoint, queries, Query, 1),
+    (record_revisions.RecordRevisionsEndpoint, record_revisions, RecordRevision, 1),
+    (records.RecordsEndpoint, records, Record, 1),
+    (sites.SitesEndpoint, sites, Site, 1),
+    (studies.StudiesEndpoint, studies, Study, "S1"),
+    (subjects.SubjectsEndpoint, subjects, Subject, "X"),
+    (users.UsersEndpoint, users, User, 1),
+    (variables.VariablesEndpoint, variables, Variable, 1),
+    (visits.VisitsEndpoint, visits, Visit, 1),
+]
+
+
+@pytest.mark.parametrize("cls,module,model,item_id", ENDPOINTS)
+def test_list_and_get(
+    cls, module, model, item_id, dummy_client, context, paginator_factory, monkeypatch
+):
+    ep = cls(dummy_client, context)
+    capture = paginator_factory(module, [{cls._id_param: item_id}])
+
+    list_kwargs = {"study_key": "S1"} if getattr(cls, "requires_study_key", True) else {}
+    if cls is users.UsersEndpoint:
+        list_kwargs["include_inactive"] = True
+    result = ep.list(**list_kwargs)
+
+    expected = (
+        ep._build_path("S1", cls.PATH)
+        if getattr(cls, "requires_study_key", True)
+        else ep._build_path(cls.PATH)
+    )
+    assert capture["path"] == expected
+    assert isinstance(result[0], model)
+
+    called = {}
+
+    def fake_list(self, client, paginator_cls, *, study_key=None, refresh=False, **filters):
+        called["study_key"] = study_key
+        called["refresh"] = refresh
+        called["filters"] = filters
+        return [model()]
+
+    monkeypatch.setattr(cls, "_list_impl", fake_list)
+
+    if getattr(cls, "requires_study_key", True):
+        res = ep.get("S1", item_id)
+    else:
+        res = ep.get(item_id)
+
+    assert called["refresh"] is True
+    assert called["filters"] == {cls._id_param: item_id}
+    assert isinstance(res, model)

--- a/tests/unit/endpoints/test_queries_endpoint.py
+++ b/tests/unit/endpoints/test_queries_endpoint.py
@@ -13,7 +13,7 @@ def test_list_builds_path_and_filters(dummy_client, context, paginator_factory, 
 
     assert capture["path"] == "/api/v1/edc/studies/S1/queries"
     assert capture["params"] == {"filter": "FILTERED"}
-    assert patch["filters"] == {"status": "new", "studyKey": "S1"}
+    assert patch["filters"] == {"status": "new"}
     assert isinstance(result[0], Query)
 
 

--- a/tests/unit/endpoints/test_record_revisions_endpoint.py
+++ b/tests/unit/endpoints/test_record_revisions_endpoint.py
@@ -13,7 +13,7 @@ def test_list_uses_filters(dummy_client, context, paginator_factory, patch_build
 
     assert capture["path"] == "/api/v1/edc/studies/S1/recordRevisions"
     assert capture["params"] == {"filter": "FILTERED"}
-    assert patch["filters"] == {"status": "closed", "studyKey": "S1"}
+    assert patch["filters"] == {"status": "closed"}
     assert isinstance(result[0], RecordRevision)
 
 

--- a/tests/unit/endpoints/test_records_endpoint.py
+++ b/tests/unit/endpoints/test_records_endpoint.py
@@ -29,8 +29,9 @@ def test_get_success(monkeypatch, dummy_client, context):
     ep = records.RecordsEndpoint(dummy_client, context)
     called = {}
 
-    def fake_impl(self, client, paginator, *, study_key=None, **filters):
+    def fake_impl(self, client, paginator, *, study_key=None, refresh=False, **filters):
         called["study_key"] = study_key
+        called["refresh"] = refresh
         called["filters"] = filters
         return [Record(record_id=1)]
 
@@ -38,7 +39,7 @@ def test_get_success(monkeypatch, dummy_client, context):
 
     res = ep.get("S1", 1)
 
-    assert called == {"study_key": "S1", "filters": {"recordId": 1}}
+    assert called == {"study_key": "S1", "refresh": True, "filters": {"recordId": 1}}
     assert isinstance(res, Record)
 
 

--- a/tests/unit/endpoints/test_sites_endpoint.py
+++ b/tests/unit/endpoints/test_sites_endpoint.py
@@ -8,7 +8,7 @@ def test_list_requires_study_key(dummy_client, context, paginator_factory, patch
     paginator_capture = paginator_factory(sites, [{"siteId": 1}])
     patch = patch_build_filter(sites)
 
-    with pytest.raises(KeyError):
+    with pytest.raises(ValueError):
         ep.list()
 
     result = ep.list(study_key="S1", status="ok")

--- a/tests/unit/endpoints/test_subjects_endpoint.py
+++ b/tests/unit/endpoints/test_subjects_endpoint.py
@@ -14,8 +14,8 @@ def test_list_builds_path_with_default(
     result = ep.list()
 
     assert capture["path"] == "/api/v1/edc/studies/S1/subjects"
-    assert capture["params"] == {"filter": "FILTERED"}
-    assert patch["filters"] == {"studyKey": "S1"}
+    assert capture["params"] == {}
+    assert patch == {}
     assert isinstance(result[0], Subject)
 
 

--- a/tests/unit/endpoints/test_variables_endpoint.py
+++ b/tests/unit/endpoints/test_variables_endpoint.py
@@ -10,7 +10,7 @@ def test_list_requires_study_key_page_size(
     capture = paginator_factory(variables, [{"variableId": 1}])
     patch = patch_build_filter(variables)
 
-    with pytest.raises(KeyError):
+    with pytest.raises(ValueError):
         ep.list()
 
     result = ep.list(study_key="S1", name="x")

--- a/tests/unit/endpoints/test_visits_endpoint.py
+++ b/tests/unit/endpoints/test_visits_endpoint.py
@@ -13,7 +13,7 @@ def test_list_filters_and_path(dummy_client, context, paginator_factory, patch_b
 
     assert capture["path"] == "/api/v1/edc/studies/S1/visits"
     assert capture["params"] == {"filter": "FILTERED"}
-    assert patch["filters"] == {"status": "x", "studyKey": "S1"}
+    assert patch["filters"] == {"status": "x"}
     assert isinstance(result[0], Visit)
 
 


### PR DESCRIPTION
## Summary
- implement ListGetEndpointMixin for shared list/get behavior
- refactor endpoints to use the mixin and update tests
- override listing logic for records and users endpoints
- adjust subject and visit tests for new filter handling

## Testing
- `poetry run ruff check --fix .`
- `poetry run black --check .`
- `poetry run mypy imednet`
- `poetry run pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6866fa3f9d8c832cb0969ef35b7e2080