### PR TITLE
chore: bump version to 0.1.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+- Bump project version to `0.1.3` to fix PyPI upload.
 ## [0.1.3] - 2025-07-07
 
 ### Changed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "imednet"
-version = "0.1.1"
+version = "0.1.3"
 description = ""
 authors = [{name = "Frederick de Ruiter", email = "127706008+fderuiter@users.noreply.github.com"}]
 readme = "README.md"
@@ -11,7 +11,7 @@ imednet = "imednet.cli:app"
 
 [tool.poetry]
 name = "imednet"
-version = "0.1.1"
+version = "0.1.3"
 description = "Unofficial Python SDK for the iMednet clinical trials API"
 readme = "README.md"
 keywords = ["imednet", "clinical trials", "sdk", "api"]


### PR DESCRIPTION
## Summary
- bump the project version to 0.1.3
- document the version bump in CHANGELOG

## Testing
- `poetry run ruff check --fix .`
- `poetry run black --check .`
- `poetry run mypy imednet`
- `poetry run pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686be37ec514832ca824e232ec9e8347