### PR TITLE
Add ListGetEndpointMixin and unify endpoint logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated integration tests to patch `RequestExecutor` and allow non-strict `respx` mocking.
 - Airflow operators now obtain ``ImednetSDK`` instances via ``ImednetHook``
   instead of parsing connections directly.
+- Introduced ``ListGetEndpointMixin`` to unify ``list`` and ``get`` logic across endpoints.
 - Added ``with_sdk`` decorator for CLI commands to centralize SDK creation and
   error handling.
 - Introduced ``JsonModel`` base class for shared parsing logic and refactored

--- a/imednet/endpoints/_mixins.py
+++ b/imednet/endpoints/_mixins.py
@@ -1,0 +1,167 @@
+from __future__ import annotations
+
+import inspect
+from typing import TYPE_CHECKING, Any, Dict, Iterable, Optional, Protocol, Type
+
+from pydantic import BaseModel
+
+from imednet.core.async_client import AsyncClient
+from imednet.core.client import Client
+from imednet.core.paginator import AsyncPaginator, Paginator
+from imednet.utils.filters import build_filter_string
+
+if TYPE_CHECKING:  # pragma: no cover - imported for type hints only
+
+    class _EndpointBase(Protocol):
+        def _auto_filter(self, filters: Dict[str, Any]) -> Dict[str, Any]: ...
+        def _build_path(self, *segments: Any) -> str: ...
+
+        PATH: str
+        MODEL: Type[BaseModel]
+        _id_param: str
+        _cache_name: Optional[str]
+        requires_study_key: bool
+        PAGE_SIZE: int
+
+        def _list_impl(
+            self,
+            client: Client | AsyncClient,
+            paginator_cls: type[Paginator] | type[AsyncPaginator],
+            *,
+            study_key: Optional[str] | None = None,
+            refresh: bool = False,
+            extra_params: Optional[Dict[str, Any]] = None,
+            **filters: Any,
+        ) -> Any: ...
+
+        def _parse_item(self, item: Any) -> BaseModel: ...
+
+
+class ListGetEndpointMixin:
+    """Mixin implementing ``list`` and ``get`` helpers."""
+
+    PATH: str
+    MODEL: Type[BaseModel]
+    _id_param: str
+    _cache_name: Optional[str] = None
+    requires_study_key: bool = True
+    PAGE_SIZE: int = 100
+    _pop_study_filter: bool = False
+    _missing_study_exception: type[Exception] = ValueError
+
+    def _parse_item(self, item: Any) -> BaseModel:
+        if hasattr(self.MODEL, "from_json"):
+            return getattr(self.MODEL, "from_json")(item)
+        return self.MODEL.model_validate(item)
+
+    def _list_impl(
+        self: Any,
+        client: Client | AsyncClient,
+        paginator_cls: type[Paginator] | type[AsyncPaginator],
+        *,
+        study_key: Optional[str] = None,
+        refresh: bool = False,
+        extra_params: Optional[Dict[str, Any]] = None,
+        **filters: Any,
+    ) -> Any:
+        filters = self._auto_filter(filters)
+        if study_key:
+            filters["studyKey"] = study_key
+        if self.requires_study_key:
+            if self._pop_study_filter:
+                try:
+                    study = filters.pop("studyKey")
+                except KeyError as exc:
+                    raise self._missing_study_exception(
+                        "Study key must be provided or set in the context"
+                    ) from exc
+            else:
+                study = filters.get("studyKey")
+                if not study:
+                    raise ValueError("Study key must be provided or set in the context")
+        else:
+            study = filters.get("studyKey")
+
+        cache = getattr(self, self._cache_name, None) if self._cache_name else None
+        other_filters = {k: v for k, v in filters.items() if k != "studyKey"}
+        if self.requires_study_key:
+            if not study:
+                raise ValueError("Study key must be provided or set in the context")
+            if cache is not None and not other_filters and not refresh and study in cache:
+                return cache[study]
+        else:
+            if cache is not None and not other_filters and not refresh and cache is not None:
+                return cache
+
+        params: Dict[str, Any] = {}
+        if filters:
+            params["filter"] = build_filter_string(filters)
+        if extra_params:
+            params.update(extra_params)
+
+        segments: Iterable[Any]
+        if self.requires_study_key:
+            segments = (study, self.PATH)
+        else:
+            segments = (self.PATH,) if self.PATH else ()
+        path = self._build_path(*segments)
+        page_size = self.PAGE_SIZE
+        paginator = paginator_cls(client, path, params=params, page_size=page_size)
+
+        if hasattr(paginator, "__aiter__"):
+
+            async def _collect() -> list[BaseModel]:
+                result = [self._parse_item(item) async for item in paginator]
+                if not other_filters:
+                    if self.requires_study_key and cache is not None:
+                        cache[study] = result
+                    elif self._cache_name:
+                        setattr(self, self._cache_name, result)
+                return result
+
+            return _collect()
+
+        result = [self._parse_item(item) for item in paginator]
+        if not other_filters:
+            if self.requires_study_key and cache is not None:
+                cache[study] = result
+            elif self._cache_name:
+                setattr(self, self._cache_name, result)
+        return result
+
+    def _get_impl(
+        self: Any,
+        client: Client | AsyncClient,
+        paginator_cls: type[Paginator] | type[AsyncPaginator],
+        *,
+        study_key: Optional[str],
+        item_id: Any,
+    ) -> Any:
+        filters = {self._id_param: item_id}
+        result = self._list_impl(
+            client,
+            paginator_cls,
+            study_key=study_key,
+            refresh=True,
+            **filters,
+        )
+
+        if inspect.isawaitable(result):
+
+            async def _await() -> BaseModel:
+                items = await result
+                if not items:
+                    if self.requires_study_key:
+                        raise ValueError(
+                            f"{self.MODEL.__name__} {item_id} not found in study {study_key}"
+                        )
+                    raise ValueError(f"{self.MODEL.__name__} {item_id} not found")
+                return items[0]
+
+            return _await()
+
+        if not result:
+            if self.requires_study_key:
+                raise ValueError(f"{self.MODEL.__name__} {item_id} not found in study {study_key}")
+            raise ValueError(f"{self.MODEL.__name__} {item_id} not found")
+        return result[0]

--- a/imednet/endpoints/base.py
+++ b/imednet/endpoints/base.py
@@ -16,6 +16,8 @@ class BaseEndpoint:
     Handles context injection and filtering.
     """
 
+    BASE_PATH = "/api/v1/edc/studies"
+
     PATH: str  # to be set in subclasses
 
     def __init__(
@@ -34,10 +36,15 @@ class BaseEndpoint:
             filters["studyKey"] = self._ctx.default_study_key
         return filters
 
-    def _build_path(self, *args: Any) -> str:
-        # join path segments after base path
-        segments = [self.PATH.strip("/")] + [str(a).strip("/") for a in args]
-        return "/" + "/".join(segments)
+    def _build_path(self, *segments: Any) -> str:
+        """Return an API path joined with :data:`BASE_PATH`."""
+
+        parts = [self.BASE_PATH.strip("/")]
+        for seg in segments:
+            text = str(seg).strip("/")
+            if text:
+                parts.append(text)
+        return "/" + "/".join(parts)
 
     # ------------------------------------------------------------------
     # Helper methods

--- a/imednet/endpoints/codings.py
+++ b/imednet/endpoints/codings.py
@@ -1,78 +1,25 @@
 """Endpoint for managing codings (medical coding) in a study."""
 
-import inspect
-from typing import Any, Dict, List, Optional
+from typing import Any, List, Optional
 
 from imednet.core.paginator import AsyncPaginator, Paginator
+from imednet.endpoints._mixins import ListGetEndpointMixin
 from imednet.endpoints.base import BaseEndpoint
 from imednet.models.codings import Coding
-from imednet.utils.filters import build_filter_string
 
 
-class CodingsEndpoint(BaseEndpoint):
+class CodingsEndpoint(ListGetEndpointMixin, BaseEndpoint):
     """
     API endpoint for interacting with codings (medical coding) in an iMedNet study.
 
     Provides methods to list and retrieve individual codings.
     """
 
-    PATH = "/api/v1/edc/studies"
-
-    def _list_impl(
-        self,
-        client: Any,
-        paginator_cls: type[Any],
-        *,
-        study_key: Optional[str] = None,
-        **filters: Any,
-    ) -> Any:
-        filters = self._auto_filter(filters)
-        if study_key:
-            filters["studyKey"] = study_key
-
-        study = filters.pop("studyKey")
-        if not study:
-            raise ValueError("Study key must be provided or set in the context")
-
-        params: Dict[str, Any] = {}
-        if filters:
-            params["filter"] = build_filter_string(filters)
-
-        path = self._build_path(study, "codings")
-        paginator = paginator_cls(client, path, params=params)
-
-        if hasattr(paginator, "__aiter__"):
-
-            async def _collect() -> List[Coding]:
-                return [Coding.from_json(item) async for item in paginator]
-
-            return _collect()
-
-        return [Coding.from_json(item) for item in paginator]
-
-    def _get_impl(
-        self, client: Any, paginator_cls: type[Any], study_key: str, coding_id: str
-    ) -> Any:
-        result = self._list_impl(
-            client,
-            paginator_cls,
-            study_key=study_key,
-            codingId=coding_id,
-        )
-
-        if inspect.isawaitable(result):
-
-            async def _await() -> Coding:
-                items = await result
-                if not items:
-                    raise ValueError(f"Coding {coding_id} not found in study {study_key}")
-                return items[0]
-
-            return _await()
-
-        if not result:
-            raise ValueError(f"Coding {coding_id} not found in study {study_key}")
-        return result[0]
+    PATH = "codings"
+    MODEL = Coding
+    _id_param = "codingId"
+    _pop_study_filter = True
+    _missing_study_exception = KeyError
 
     def list(self, study_key: Optional[str] = None, **filters) -> List[Coding]:
         """List codings in a study with optional filtering."""
@@ -110,7 +57,7 @@ class CodingsEndpoint(BaseEndpoint):
             Coding object
         """
 
-        result = self._get_impl(self._client, Paginator, study_key, coding_id)
+        result = self._get_impl(self._client, Paginator, study_key=study_key, item_id=coding_id)
         return result  # type: ignore[return-value]
 
     async def async_get(self, study_key: str, coding_id: str) -> Coding:
@@ -120,4 +67,6 @@ class CodingsEndpoint(BaseEndpoint):
         """
         if self._async_client is None:
             raise RuntimeError("Async client not configured")
-        return await self._get_impl(self._async_client, AsyncPaginator, study_key, coding_id)
+        return await self._get_impl(
+            self._async_client, AsyncPaginator, study_key=study_key, item_id=coding_id
+        )

--- a/imednet/endpoints/forms.py
+++ b/imednet/endpoints/forms.py
@@ -1,89 +1,30 @@
 """Endpoint for managing forms (eCRFs) in a study."""
 
-import inspect
 from typing import Any, Dict, List, Optional
 
 from imednet.core.async_client import AsyncClient
 from imednet.core.client import Client
 from imednet.core.context import Context
 from imednet.core.paginator import AsyncPaginator, Paginator
+from imednet.endpoints._mixins import ListGetEndpointMixin
 from imednet.endpoints.base import BaseEndpoint
 from imednet.models.forms import Form
-from imednet.utils.filters import build_filter_string
 
 
-class FormsEndpoint(BaseEndpoint):
+class FormsEndpoint(ListGetEndpointMixin, BaseEndpoint):
     """
     API endpoint for interacting with forms (eCRFs) in an iMedNet study.
 
     Provides methods to list and retrieve individual forms.
     """
 
-    PATH = "/api/v1/edc/studies"
-
-    def _list_impl(
-        self,
-        client: Any,
-        paginator_cls: type[Any],
-        *,
-        study_key: Optional[str] = None,
-        refresh: bool = False,
-        **filters: Any,
-    ) -> Any:
-        filters = self._auto_filter(filters)
-        if study_key:
-            filters["studyKey"] = study_key
-
-        study = filters.pop("studyKey")
-        if not study:
-            raise ValueError("Study key must be provided or set in the context")
-        if not filters and not refresh and study in self._forms_cache:
-            return self._forms_cache[study]
-
-        params: Dict[str, Any] = {}
-        if filters:
-            params["filter"] = build_filter_string(filters)
-
-        path = self._build_path(study, "forms")
-        paginator = paginator_cls(client, path, params=params, page_size=500)
-
-        if hasattr(paginator, "__aiter__"):
-
-            async def _collect() -> List[Form]:
-                result = [Form.from_json(item) async for item in paginator]
-                if not filters:
-                    self._forms_cache[study] = result
-                return result
-
-            return _collect()
-
-        result = [Form.from_json(item) for item in paginator]
-        if not filters:
-            self._forms_cache[study] = result
-        return result
-
-    def _get_impl(self, client: Any, paginator_cls: type[Any], study_key: str, form_id: int) -> Any:
-        result = self._list_impl(
-            client,
-            paginator_cls,
-            study_key=study_key,
-            refresh=True,
-            formId=form_id,
-        )
-
-        if inspect.isawaitable(result):
-
-            async def _await() -> Form:
-                items = await result
-                if not items:
-                    raise ValueError(f"Form {form_id} not found in study {study_key}")
-                return items[0]
-
-            return _await()
-
-        if not result:
-            raise ValueError(f"Form {form_id} not found in study {study_key}")
-        return result[0]
+    PATH = "forms"
+    MODEL = Form
+    _id_param = "formId"
+    _cache_name = "_forms_cache"
+    PAGE_SIZE = 500
+    _pop_study_filter = True
+    _missing_study_exception = KeyError
 
     def __init__(
         self,
@@ -142,7 +83,7 @@ class FormsEndpoint(BaseEndpoint):
         Returns:
             Form object
         """
-        result = self._get_impl(self._client, Paginator, study_key, form_id)
+        result = self._get_impl(self._client, Paginator, study_key=study_key, item_id=form_id)
         return result  # type: ignore[return-value]
 
     async def async_get(self, study_key: str, form_id: int) -> Form:
@@ -153,4 +94,6 @@ class FormsEndpoint(BaseEndpoint):
         """
         if self._async_client is None:
             raise RuntimeError("Async client not configured")
-        return await self._get_impl(self._async_client, AsyncPaginator, study_key, form_id)
+        return await self._get_impl(
+            self._async_client, AsyncPaginator, study_key=study_key, item_id=form_id
+        )

--- a/imednet/endpoints/intervals.py
+++ b/imednet/endpoints/intervals.py
@@ -1,91 +1,29 @@
 """Endpoint for managing intervals (visit definitions) in a study."""
 
-import inspect
 from typing import Any, Dict, List, Optional
 
 from imednet.core.async_client import AsyncClient
 from imednet.core.client import Client
 from imednet.core.context import Context
 from imednet.core.paginator import AsyncPaginator, Paginator
+from imednet.endpoints._mixins import ListGetEndpointMixin
 from imednet.endpoints.base import BaseEndpoint
 from imednet.models.intervals import Interval
-from imednet.utils.filters import build_filter_string
 
 
-class IntervalsEndpoint(BaseEndpoint):
+class IntervalsEndpoint(ListGetEndpointMixin, BaseEndpoint):
     """
     API endpoint for interacting with intervals (visit definitions) in an iMedNet study.
 
     Provides methods to list and retrieve individual intervals.
     """
 
-    PATH = "/api/v1/edc/studies"
-
-    def _list_impl(
-        self,
-        client: Any,
-        paginator_cls: type[Any],
-        *,
-        study_key: Optional[str] = None,
-        refresh: bool = False,
-        **filters: Any,
-    ) -> Any:
-        filters = self._auto_filter(filters)
-        if study_key:
-            filters["studyKey"] = study_key
-
-        study = filters.pop("studyKey")
-        if not study:
-            raise ValueError("Study key must be provided or set in the context")
-        if not filters and not refresh and study in self._intervals_cache:
-            return self._intervals_cache[study]
-
-        params: Dict[str, Any] = {}
-        if filters:
-            params["filter"] = build_filter_string(filters)
-
-        path = self._build_path(study, "intervals")
-        paginator = paginator_cls(client, path, params=params, page_size=500)
-
-        if hasattr(paginator, "__aiter__"):
-
-            async def _collect() -> List[Interval]:
-                result = [Interval.from_json(item) async for item in paginator]
-                if not filters:
-                    self._intervals_cache[study] = result
-                return result
-
-            return _collect()
-
-        result = [Interval.from_json(item) for item in paginator]
-        if not filters:
-            self._intervals_cache[study] = result
-        return result
-
-    def _get_impl(
-        self, client: Any, paginator_cls: type[Any], study_key: str, interval_id: int
-    ) -> Any:
-        result = self._list_impl(
-            client,
-            paginator_cls,
-            study_key=study_key,
-            refresh=True,
-            intervalId=interval_id,
-        )
-
-        if inspect.isawaitable(result):
-
-            async def _await() -> Interval:
-                items = await result
-                if not items:
-                    raise ValueError(f"Interval {interval_id} not found in study {study_key}")
-                return items[0]
-
-            return _await()
-
-        if not result:
-            raise ValueError(f"Interval {interval_id} not found in study {study_key}")
-        return result[0]
+    PATH = "intervals"
+    MODEL = Interval
+    _id_param = "intervalId"
+    _cache_name = "_intervals_cache"
+    PAGE_SIZE = 500
+    _pop_study_filter = True
 
     def __init__(
         self,
@@ -138,7 +76,7 @@ class IntervalsEndpoint(BaseEndpoint):
         Returns:
             Interval object
         """
-        result = self._get_impl(self._client, Paginator, study_key, interval_id)
+        result = self._get_impl(self._client, Paginator, study_key=study_key, item_id=interval_id)
         return result  # type: ignore[return-value]
 
     async def async_get(self, study_key: str, interval_id: int) -> Interval:
@@ -149,4 +87,6 @@ class IntervalsEndpoint(BaseEndpoint):
         """
         if self._async_client is None:
             raise RuntimeError("Async client not configured")
-        return await self._get_impl(self._async_client, AsyncPaginator, study_key, interval_id)
+        return await self._get_impl(
+            self._async_client, AsyncPaginator, study_key=study_key, item_id=interval_id
+        )

--- a/imednet/endpoints/queries.py
+++ b/imednet/endpoints/queries.py
@@ -1,74 +1,23 @@
 """Endpoint for managing queries (dialogue/questions) in a study."""
 
-import inspect
-from typing import Any, Dict, List, Optional
+from typing import Any, List, Optional
 
 from imednet.core.paginator import AsyncPaginator, Paginator
+from imednet.endpoints._mixins import ListGetEndpointMixin
 from imednet.endpoints.base import BaseEndpoint
 from imednet.models.queries import Query
-from imednet.utils.filters import build_filter_string
 
 
-class QueriesEndpoint(BaseEndpoint):
+class QueriesEndpoint(ListGetEndpointMixin, BaseEndpoint):
     """
     API endpoint for interacting with queries (dialogue/questions) in an iMedNet study.
 
     Provides methods to list and retrieve queries.
     """
 
-    PATH = "/api/v1/edc/studies"
-
-    def _list_impl(
-        self,
-        client: Any,
-        paginator_cls: type[Any],
-        *,
-        study_key: Optional[str] = None,
-        **filters: Any,
-    ) -> Any:
-        filters = self._auto_filter(filters)
-        if study_key:
-            filters["studyKey"] = study_key
-
-        params: Dict[str, Any] = {}
-        if filters:
-            params["filter"] = build_filter_string(filters)
-
-        path = self._build_path(filters.get("studyKey", ""), "queries")
-        paginator = paginator_cls(client, path, params=params)
-
-        if hasattr(paginator, "__aiter__"):
-
-            async def _collect() -> List[Query]:
-                return [Query.from_json(item) async for item in paginator]
-
-            return _collect()
-
-        return [Query.from_json(item) for item in paginator]
-
-    def _get_impl(
-        self, client: Any, paginator_cls: type[Any], study_key: str, annotation_id: int
-    ) -> Any:
-        result = self._list_impl(
-            client,
-            paginator_cls,
-            study_key=study_key,
-            annotationId=annotation_id,
-        )
-
-        if inspect.isawaitable(result):
-
-            async def _await() -> Query:
-                items = await result
-                if not items:
-                    raise ValueError(f"Query {annotation_id} not found in study {study_key}")
-                return items[0]
-
-            return _await()
-
-        if not result:
-            raise ValueError(f"Query {annotation_id} not found in study {study_key}")
-        return result[0]
+    PATH = "queries"
+    MODEL = Query
+    _id_param = "annotationId"
 
     def list(self, study_key: Optional[str] = None, **filters) -> List[Query]:
         """List queries in a study with optional filtering."""
@@ -105,7 +54,7 @@ class QueriesEndpoint(BaseEndpoint):
         Returns:
             Query object
         """
-        result = self._get_impl(self._client, Paginator, study_key, annotation_id)
+        result = self._get_impl(self._client, Paginator, study_key=study_key, item_id=annotation_id)
         return result  # type: ignore[return-value]
 
     async def async_get(self, study_key: str, annotation_id: int) -> Query:
@@ -115,4 +64,6 @@ class QueriesEndpoint(BaseEndpoint):
         """
         if self._async_client is None:
             raise RuntimeError("Async client not configured")
-        return await self._get_impl(self._async_client, AsyncPaginator, study_key, annotation_id)
+        return await self._get_impl(
+            self._async_client, AsyncPaginator, study_key=study_key, item_id=annotation_id
+        )

--- a/imednet/endpoints/record_revisions.py
+++ b/imednet/endpoints/record_revisions.py
@@ -1,76 +1,23 @@
 """Endpoint for retrieving record revision history in a study."""
 
-import inspect
-from typing import Any, Dict, List, Optional
+from typing import Any, List, Optional
 
 from imednet.core.paginator import AsyncPaginator, Paginator
+from imednet.endpoints._mixins import ListGetEndpointMixin
 from imednet.endpoints.base import BaseEndpoint
 from imednet.models.record_revisions import RecordRevision
-from imednet.utils.filters import build_filter_string
 
 
-class RecordRevisionsEndpoint(BaseEndpoint):
+class RecordRevisionsEndpoint(ListGetEndpointMixin, BaseEndpoint):
     """
     API endpoint for accessing record revision history in an iMedNet study.
 
     Provides methods to list and retrieve record revisions.
     """
 
-    PATH = "/api/v1/edc/studies"
-
-    def _list_impl(
-        self,
-        client: Any,
-        paginator_cls: type[Any],
-        *,
-        study_key: Optional[str] = None,
-        **filters: Any,
-    ) -> Any:
-        filters = self._auto_filter(filters)
-        if study_key:
-            filters["studyKey"] = study_key
-
-        params: Dict[str, Any] = {}
-        if filters:
-            params["filter"] = build_filter_string(filters)
-
-        path = self._build_path(filters.get("studyKey", ""), "recordRevisions")
-        paginator = paginator_cls(client, path, params=params)
-
-        if hasattr(paginator, "__aiter__"):
-
-            async def _collect() -> List[RecordRevision]:
-                return [RecordRevision.from_json(item) async for item in paginator]
-
-            return _collect()
-
-        return [RecordRevision.from_json(item) for item in paginator]
-
-    def _get_impl(
-        self, client: Any, paginator_cls: type[Any], study_key: str, record_revision_id: int
-    ) -> Any:
-        result = self._list_impl(
-            client,
-            paginator_cls,
-            study_key=study_key,
-            recordRevisionId=record_revision_id,
-        )
-
-        if inspect.isawaitable(result):
-
-            async def _await() -> RecordRevision:
-                items = await result
-                if not items:
-                    raise ValueError(
-                        f"Record revision {record_revision_id} not found in study {study_key}"
-                    )
-                return items[0]
-
-            return _await()
-
-        if not result:
-            raise ValueError(f"Record revision {record_revision_id} not found in study {study_key}")
-        return result[0]
+    PATH = "recordRevisions"
+    MODEL = RecordRevision
+    _id_param = "recordRevisionId"
 
     def list(self, study_key: Optional[str] = None, **filters) -> List[RecordRevision]:
         """List record revisions in a study with optional filtering."""
@@ -109,7 +56,9 @@ class RecordRevisionsEndpoint(BaseEndpoint):
         Returns:
             RecordRevision object
         """
-        result = self._get_impl(self._client, Paginator, study_key, record_revision_id)
+        result = self._get_impl(
+            self._client, Paginator, study_key=study_key, item_id=record_revision_id
+        )
         return result  # type: ignore[return-value]
 
     async def async_get(self, study_key: str, record_revision_id: int) -> RecordRevision:
@@ -120,5 +69,8 @@ class RecordRevisionsEndpoint(BaseEndpoint):
         if self._async_client is None:
             raise RuntimeError("Async client not configured")
         return await self._get_impl(
-            self._async_client, AsyncPaginator, study_key, record_revision_id
+            self._async_client,
+            AsyncPaginator,
+            study_key=study_key,
+            item_id=record_revision_id,
         )

--- a/imednet/endpoints/records.py
+++ b/imednet/endpoints/records.py
@@ -4,76 +4,24 @@ import inspect
 from typing import Any, Dict, List, Optional, Union
 
 from imednet.core.paginator import AsyncPaginator, Paginator
+from imednet.endpoints._mixins import ListGetEndpointMixin
 from imednet.endpoints.base import BaseEndpoint
 from imednet.models.jobs import Job
 from imednet.models.records import Record
-from imednet.utils.filters import build_filter_string
 from imednet.validation.cache import SchemaCache, validate_record_data
 
 
-class RecordsEndpoint(BaseEndpoint):
+class RecordsEndpoint(ListGetEndpointMixin, BaseEndpoint):
     """
     API endpoint for interacting with records (eCRF instances) in an iMedNet study.
 
     Provides methods to list, retrieve, and create records.
     """
 
-    PATH = "/api/v1/edc/studies"
-
-    def _list_impl(
-        self,
-        client: Any,
-        paginator_cls: type[Any],
-        *,
-        study_key: Optional[str] = None,
-        record_data_filter: Optional[str] = None,
-        **filters: Any,
-    ) -> Any:
-        filters = self._auto_filter(filters)
-        if study_key:
-            filters["studyKey"] = study_key
-
-        params: Dict[str, Any] = {}
-        if filters:
-            params["filter"] = build_filter_string(filters)
-        if record_data_filter:
-            params["recordDataFilter"] = record_data_filter
-
-        path = self._build_path(filters.get("studyKey", ""), "records")
-        paginator = paginator_cls(client, path, params=params)
-
-        if hasattr(paginator, "__aiter__"):
-
-            async def _collect() -> List[Record]:
-                return [Record.from_json(item) async for item in paginator]
-
-            return _collect()
-
-        return [Record.from_json(item) for item in paginator]
-
-    def _get_impl(
-        self, client: Any, paginator_cls: type[Any], study_key: str, record_id: Union[str, int]
-    ) -> Any:
-        result = self._list_impl(
-            client,
-            paginator_cls,
-            study_key=study_key,
-            recordId=record_id,
-        )
-
-        if inspect.isawaitable(result):
-
-            async def _await() -> Record:
-                items = await result
-                if not items:
-                    raise ValueError(f"Record {record_id} not found in study {study_key}")
-                return items[0]
-
-            return _await()
-
-        if not result:
-            raise ValueError(f"Record {record_id} not found in study {study_key}")
-        return result[0]
+    PATH = "records"
+    MODEL = Record
+    _id_param = "recordId"
+    _pop_study_filter = False
 
     def _create_impl(
         self,
@@ -83,7 +31,7 @@ class RecordsEndpoint(BaseEndpoint):
         records_data: List[Dict[str, Any]],
         email_notify: Union[bool, str, None] = None,
     ) -> Any:
-        path = self._build_path(study_key, "records")
+        path = self._build_path(study_key, self.PATH)
         headers = {}
         if email_notify is not None:
             if isinstance(email_notify, str):
@@ -134,20 +82,18 @@ class RecordsEndpoint(BaseEndpoint):
         return result
 
     def get(self, study_key: str, record_id: Union[str, int]) -> Record:
-        """
-        Get a specific record by ID.
-
-        ``record_id`` is provided to :meth:`list` as a filter value.
-
-        Args:
-            study_key: Study identifier
-            record_id: Record identifier (can be string or integer)
-
-        Returns:
-            Record object
-        """
-        result = self._get_impl(self._client, Paginator, study_key, record_id)
-        return result  # type: ignore[return-value]
+        """Get a specific record by ID."""
+        result = self._list_impl(
+            self._client,
+            Paginator,
+            study_key=study_key,
+            recordId=record_id,
+        )
+        if inspect.isawaitable(result):
+            raise RuntimeError("Unexpected awaitable result")
+        if not result:
+            raise ValueError(f"Record {record_id} not found in study {study_key}")
+        return result[0]
 
     async def async_get(self, study_key: str, record_id: Union[str, int]) -> Record:
         """Asynchronous version of :meth:`get`.
@@ -156,7 +102,15 @@ class RecordsEndpoint(BaseEndpoint):
         """
         if self._async_client is None:
             raise RuntimeError("Async client not configured")
-        return await self._get_impl(self._async_client, AsyncPaginator, study_key, record_id)
+        result = await self._list_impl(
+            self._async_client,
+            AsyncPaginator,
+            study_key=study_key,
+            recordId=record_id,
+        )
+        if not result:
+            raise ValueError(f"Record {record_id} not found in study {study_key}")
+        return result[0]
 
     def create(
         self,
@@ -216,4 +170,22 @@ class RecordsEndpoint(BaseEndpoint):
             study_key=study_key,
             records_data=records_data,
             email_notify=email_notify,
+        )
+
+    def _list_impl(
+        self,
+        client: Any,
+        paginator_cls: type[Any],
+        *,
+        study_key: Optional[str] = None,
+        record_data_filter: Optional[str] = None,
+        **filters: Any,
+    ) -> Any:
+        extra = {"recordDataFilter": record_data_filter} if record_data_filter else None
+        return super()._list_impl(
+            client,
+            paginator_cls,
+            study_key=study_key,
+            extra_params=extra,
+            **filters,
         )

--- a/imednet/endpoints/sites.py
+++ b/imednet/endpoints/sites.py
@@ -1,76 +1,25 @@
 """Endpoint for managing sites (study locations) in a study."""
 
-import inspect
-from typing import Any, Dict, List, Optional
+from typing import Any, List, Optional
 
 from imednet.core.paginator import AsyncPaginator, Paginator
+from imednet.endpoints._mixins import ListGetEndpointMixin
 from imednet.endpoints.base import BaseEndpoint
 from imednet.models.sites import Site
-from imednet.utils.filters import build_filter_string
 
 
-class SitesEndpoint(BaseEndpoint):
+class SitesEndpoint(ListGetEndpointMixin, BaseEndpoint):
     """
     API endpoint for interacting with sites (study locations) in an iMedNet study.
 
     Provides methods to list and retrieve individual sites.
     """
 
-    PATH = "/api/v1/edc/studies"
-
-    def _list_impl(
-        self,
-        client: Any,
-        paginator_cls: type[Any],
-        *,
-        study_key: Optional[str] = None,
-        **filters: Any,
-    ) -> Any:
-        filters = self._auto_filter(filters)
-        if study_key:
-            filters["studyKey"] = study_key
-
-        study = filters.pop("studyKey")
-        if not study:
-            raise ValueError("Study key must be provided or set in the context")
-
-        params: Dict[str, Any] = {}
-        if filters:
-            params["filter"] = build_filter_string(filters)
-
-        path = self._build_path(study, "sites")
-        paginator = paginator_cls(client, path, params=params)
-
-        if hasattr(paginator, "__aiter__"):
-
-            async def _collect() -> List[Site]:
-                return [Site.from_json(item) async for item in paginator]
-
-            return _collect()
-
-        return [Site.from_json(item) for item in paginator]
-
-    def _get_impl(self, client: Any, paginator_cls: type[Any], study_key: str, site_id: int) -> Any:
-        result = self._list_impl(
-            client,
-            paginator_cls,
-            study_key=study_key,
-            siteId=site_id,
-        )
-
-        if inspect.isawaitable(result):
-
-            async def _await() -> Site:
-                items = await result
-                if not items:
-                    raise ValueError(f"Site {site_id} not found in study {study_key}")
-                return items[0]
-
-            return _await()
-
-        if not result:
-            raise ValueError(f"Site {site_id} not found in study {study_key}")
-        return result[0]
+    PATH = "sites"
+    MODEL = Site
+    _id_param = "siteId"
+    _pop_study_filter = True
+    _missing_study_exception = KeyError
 
     def list(self, study_key: Optional[str] = None, **filters) -> List[Site]:
         """List sites in a study with optional filtering."""
@@ -107,7 +56,7 @@ class SitesEndpoint(BaseEndpoint):
         Returns:
             Site object
         """
-        result = self._get_impl(self._client, Paginator, study_key, site_id)
+        result = self._get_impl(self._client, Paginator, study_key=study_key, item_id=site_id)
         return result  # type: ignore[return-value]
 
     async def async_get(self, study_key: str, site_id: int) -> Site:
@@ -117,4 +66,6 @@ class SitesEndpoint(BaseEndpoint):
         """
         if self._async_client is None:
             raise RuntimeError("Async client not configured")
-        return await self._get_impl(self._async_client, AsyncPaginator, study_key, site_id)
+        return await self._get_impl(
+            self._async_client, AsyncPaginator, study_key=study_key, item_id=site_id
+        )

--- a/imednet/endpoints/studies.py
+++ b/imednet/endpoints/studies.py
@@ -1,80 +1,29 @@
 """Endpoint for managing studies in the iMedNet system."""
 
-import inspect
-from typing import Any, Dict, List, Optional
+from typing import Any, List, Optional
 
 from imednet.core.async_client import AsyncClient
 from imednet.core.client import Client
 from imednet.core.context import Context
 from imednet.core.paginator import AsyncPaginator, Paginator
+from imednet.endpoints._mixins import ListGetEndpointMixin
 from imednet.endpoints.base import BaseEndpoint
 from imednet.models.studies import Study
-from imednet.utils.filters import build_filter_string
 
 
-class StudiesEndpoint(BaseEndpoint):
+class StudiesEndpoint(ListGetEndpointMixin, BaseEndpoint):
     """
     API endpoint for interacting with studies in the iMedNet system.
 
     Provides methods to list available studies and retrieve specific studies.
     """
 
-    PATH = "/api/v1/edc/studies"
+    PATH = ""
+    MODEL = Study
+    _id_param = "studyKey"
+    _cache_name = "_studies_cache"
+    requires_study_key = False
     _studies_cache: Optional[List[Study]]
-
-    def _list_impl(
-        self,
-        client: Any,
-        paginator_cls: type[Any],
-        *,
-        refresh: bool = False,
-        **filters: Any,
-    ) -> Any:
-        filters = self._auto_filter(filters)
-        if not filters and not refresh and self._studies_cache is not None:
-            return self._studies_cache
-
-        params: Dict[str, Any] = {}
-        if filters:
-            params["filter"] = build_filter_string(filters)
-        paginator = paginator_cls(client, self.PATH, params=params)
-
-        if hasattr(paginator, "__aiter__"):
-
-            async def _collect() -> List[Study]:
-                result = [Study.model_validate(item) async for item in paginator]
-                if not filters:
-                    self._studies_cache = result
-                return result
-
-            return _collect()
-
-        result = [Study.model_validate(item) for item in paginator]
-        if not filters:
-            self._studies_cache = result
-        return result
-
-    def _get_impl(self, client: Any, paginator_cls: type[Any], study_key: str) -> Any:
-        result = self._list_impl(
-            client,
-            paginator_cls,
-            refresh=True,
-            studyKey=study_key,
-        )
-
-        if inspect.isawaitable(result):
-
-            async def _await() -> Study:
-                items = await result
-                if not items:
-                    raise ValueError(f"Study {study_key} not found")
-                return items[0]
-
-            return _await()
-
-        if not result:
-            raise ValueError(f"Study {study_key} not found")
-        return result[0]
 
     def __init__(
         self,
@@ -120,7 +69,7 @@ class StudiesEndpoint(BaseEndpoint):
         Returns:
             Study object
         """
-        result = self._get_impl(self._client, Paginator, study_key)
+        result = self._get_impl(self._client, Paginator, study_key=None, item_id=study_key)
         return result  # type: ignore[return-value]
 
     async def async_get(self, study_key: str) -> Study:
@@ -131,4 +80,6 @@ class StudiesEndpoint(BaseEndpoint):
         """
         if self._async_client is None:
             raise RuntimeError("Async client not configured")
-        return await self._get_impl(self._async_client, AsyncPaginator, study_key)
+        return await self._get_impl(
+            self._async_client, AsyncPaginator, study_key=None, item_id=study_key
+        )

--- a/imednet/endpoints/subjects.py
+++ b/imednet/endpoints/subjects.py
@@ -1,74 +1,23 @@
 """Endpoint for managing subjects in a study."""
 
-import inspect
-from typing import Any, Dict, List, Optional
+from typing import Any, List, Optional
 
 from imednet.core.paginator import AsyncPaginator, Paginator
+from imednet.endpoints._mixins import ListGetEndpointMixin
 from imednet.endpoints.base import BaseEndpoint
 from imednet.models.subjects import Subject
-from imednet.utils.filters import build_filter_string
 
 
-class SubjectsEndpoint(BaseEndpoint):
+class SubjectsEndpoint(ListGetEndpointMixin, BaseEndpoint):
     """
     API endpoint for interacting with subjects in an iMedNet study.
 
     Provides methods to list and retrieve individual subjects.
     """
 
-    PATH = "/api/v1/edc/studies"
-
-    def _list_impl(
-        self,
-        client: Any,
-        paginator_cls: type[Any],
-        *,
-        study_key: Optional[str] = None,
-        **filters: Any,
-    ) -> Any:
-        filters = self._auto_filter(filters)
-        if study_key:
-            filters["studyKey"] = study_key
-
-        params: Dict[str, Any] = {}
-        if filters:
-            params["filter"] = build_filter_string(filters)
-
-        path = self._build_path(filters.get("studyKey", ""), "subjects")
-        paginator = paginator_cls(client, path, params=params)
-
-        if hasattr(paginator, "__aiter__"):
-
-            async def _collect() -> List[Subject]:
-                return [Subject.from_json(item) async for item in paginator]
-
-            return _collect()
-
-        return [Subject.from_json(item) for item in paginator]
-
-    def _get_impl(
-        self, client: Any, paginator_cls: type[Any], study_key: str, subject_key: str
-    ) -> Any:
-        result = self._list_impl(
-            client,
-            paginator_cls,
-            study_key=study_key,
-            subjectKey=subject_key,
-        )
-
-        if inspect.isawaitable(result):
-
-            async def _await() -> Subject:
-                items = await result
-                if not items:
-                    raise ValueError(f"Subject {subject_key} not found in study {study_key}")
-                return items[0]
-
-            return _await()
-
-        if not result:
-            raise ValueError(f"Subject {subject_key} not found in study {study_key}")
-        return result[0]
+    PATH = "subjects"
+    MODEL = Subject
+    _id_param = "subjectKey"
 
     def list(self, study_key: Optional[str] = None, **filters) -> List[Subject]:
         """List subjects in a study with optional filtering."""
@@ -105,7 +54,7 @@ class SubjectsEndpoint(BaseEndpoint):
         Returns:
             Subject object
         """
-        result = self._get_impl(self._client, Paginator, study_key, subject_key)
+        result = self._get_impl(self._client, Paginator, study_key=study_key, item_id=subject_key)
         return result  # type: ignore[return-value]
 
     async def async_get(self, study_key: str, subject_key: str) -> Subject:
@@ -118,6 +67,6 @@ class SubjectsEndpoint(BaseEndpoint):
         return await self._get_impl(
             self._async_client,
             AsyncPaginator,
-            study_key,
-            subject_key,
+            study_key=study_key,
+            item_id=subject_key,
         )

--- a/imednet/endpoints/users.py
+++ b/imednet/endpoints/users.py
@@ -1,22 +1,24 @@
 """Endpoint for managing users in a study."""
 
-import inspect
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, List, Optional, Union
 
 from imednet.core.paginator import AsyncPaginator, Paginator
+from imednet.endpoints._mixins import ListGetEndpointMixin
 from imednet.endpoints.base import BaseEndpoint
 from imednet.models.users import User
-from imednet.utils.filters import build_filter_string
 
 
-class UsersEndpoint(BaseEndpoint):
+class UsersEndpoint(ListGetEndpointMixin, BaseEndpoint):
     """
     API endpoint for interacting with users in an iMedNet study.
 
     Provides methods to list and retrieve user information.
     """
 
-    PATH = "/api/v1/edc/studies"
+    PATH = "users"
+    MODEL = User
+    _id_param = "userId"
+    _pop_study_filter = True
 
     def _list_impl(
         self,
@@ -27,49 +29,14 @@ class UsersEndpoint(BaseEndpoint):
         include_inactive: bool = False,
         **filters: Any,
     ) -> Any:
-        study_key = study_key or self._ctx.default_study_key
-        if not study_key:
-            raise ValueError("Study key must be provided or set in the context")
-
-        params: Dict[str, Any] = {"includeInactive": str(include_inactive).lower()}
-        if filters:
-            params["filter"] = build_filter_string(filters)
-
-        path = self._build_path(study_key, "users")
-        paginator = paginator_cls(client, path, params=params)
-
-        if hasattr(paginator, "__aiter__"):
-
-            async def _collect() -> List[User]:
-                return [User.from_json(item) async for item in paginator]
-
-            return _collect()
-
-        return [User.from_json(item) for item in paginator]
-
-    def _get_impl(
-        self, client: Any, paginator_cls: type[Any], study_key: str, user_id: Union[str, int]
-    ) -> Any:
-        result = self._list_impl(
+        params = {"includeInactive": str(include_inactive).lower()}
+        return super()._list_impl(
             client,
             paginator_cls,
             study_key=study_key,
-            userId=user_id,
+            extra_params=params,
+            **filters,
         )
-
-        if inspect.isawaitable(result):
-
-            async def _await() -> User:
-                items = await result
-                if not items:
-                    raise ValueError(f"User {user_id} not found in study {study_key}")
-                return items[0]
-
-            return _await()
-
-        if not result:
-            raise ValueError(f"User {user_id} not found in study {study_key}")
-        return result[0]
 
     def list(
         self, study_key: Optional[str] = None, include_inactive: bool = False, **filters: Any
@@ -113,11 +80,13 @@ class UsersEndpoint(BaseEndpoint):
         Returns:
             User object
         """
-        result = self._get_impl(self._client, Paginator, study_key, user_id)
+        result = self._get_impl(self._client, Paginator, study_key=study_key, item_id=user_id)
         return result  # type: ignore[return-value]
 
     async def async_get(self, study_key: str, user_id: Union[str, int]) -> User:
         """Asynchronous version of :meth:`get`."""
         if self._async_client is None:
             raise RuntimeError("Async client not configured")
-        return await self._get_impl(self._async_client, AsyncPaginator, study_key, user_id)
+        return await self._get_impl(
+            self._async_client, AsyncPaginator, study_key=study_key, item_id=user_id
+        )

--- a/imednet/endpoints/variables.py
+++ b/imednet/endpoints/variables.py
@@ -1,91 +1,30 @@
 """Endpoint for managing variables (data points on eCRFs) in a study."""
 
-import inspect
 from typing import Any, Dict, List, Optional
 
 from imednet.core.async_client import AsyncClient
 from imednet.core.client import Client
 from imednet.core.context import Context
 from imednet.core.paginator import AsyncPaginator, Paginator
+from imednet.endpoints._mixins import ListGetEndpointMixin
 from imednet.endpoints.base import BaseEndpoint
 from imednet.models.variables import Variable
-from imednet.utils.filters import build_filter_string
 
 
-class VariablesEndpoint(BaseEndpoint):
+class VariablesEndpoint(ListGetEndpointMixin, BaseEndpoint):
     """
     API endpoint for interacting with variables (data points on eCRFs) in an iMedNet study.
 
     Provides methods to list and retrieve individual variables.
     """
 
-    PATH = "/api/v1/edc/studies"
-
-    def _list_impl(
-        self,
-        client: Any,
-        paginator_cls: type[Any],
-        *,
-        study_key: Optional[str] = None,
-        refresh: bool = False,
-        **filters: Any,
-    ) -> Any:
-        filters = self._auto_filter(filters)
-        if study_key:
-            filters["studyKey"] = study_key
-
-        study = filters.pop("studyKey")
-        if not study:
-            raise ValueError("Study key must be provided or set in the context")
-        if not filters and not refresh and study in self._variables_cache:
-            return self._variables_cache[study]
-
-        params: Dict[str, Any] = {}
-        if filters:
-            params["filter"] = build_filter_string(filters)
-
-        path = self._build_path(study, "variables")
-        paginator = paginator_cls(client, path, params=params, page_size=500)
-
-        if hasattr(paginator, "__aiter__"):
-
-            async def _collect() -> List[Variable]:
-                result = [Variable.from_json(item) async for item in paginator]
-                if not filters:
-                    self._variables_cache[study] = result
-                return result
-
-            return _collect()
-
-        result = [Variable.from_json(item) for item in paginator]
-        if not filters:
-            self._variables_cache[study] = result
-        return result
-
-    def _get_impl(
-        self, client: Any, paginator_cls: type[Any], study_key: str, variable_id: int
-    ) -> Any:
-        result = self._list_impl(
-            client,
-            paginator_cls,
-            study_key=study_key,
-            refresh=True,
-            variableId=variable_id,
-        )
-
-        if inspect.isawaitable(result):
-
-            async def _await() -> Variable:
-                items = await result
-                if not items:
-                    raise ValueError(f"Variable {variable_id} not found in study {study_key}")
-                return items[0]
-
-            return _await()
-
-        if not result:
-            raise ValueError(f"Variable {variable_id} not found in study {study_key}")
-        return result[0]
+    PATH = "variables"
+    MODEL = Variable
+    _id_param = "variableId"
+    _cache_name = "_variables_cache"
+    PAGE_SIZE = 500
+    _pop_study_filter = True
+    _missing_study_exception = KeyError
 
     def __init__(
         self,
@@ -138,7 +77,7 @@ class VariablesEndpoint(BaseEndpoint):
         Returns:
             Variable object
         """
-        result = self._get_impl(self._client, Paginator, study_key, variable_id)
+        result = self._get_impl(self._client, Paginator, study_key=study_key, item_id=variable_id)
         return result  # type: ignore[return-value]
 
     async def async_get(self, study_key: str, variable_id: int) -> Variable:
@@ -149,4 +88,6 @@ class VariablesEndpoint(BaseEndpoint):
         """
         if self._async_client is None:
             raise RuntimeError("Async client not configured")
-        return await self._get_impl(self._async_client, AsyncPaginator, study_key, variable_id)
+        return await self._get_impl(
+            self._async_client, AsyncPaginator, study_key=study_key, item_id=variable_id
+        )

--- a/imednet/endpoints/visits.py
+++ b/imednet/endpoints/visits.py
@@ -1,74 +1,23 @@
 """Endpoint for managing visits (interval instances) in a study."""
 
-import inspect
-from typing import Any, Dict, List, Optional
+from typing import Any, List, Optional
 
 from imednet.core.paginator import AsyncPaginator, Paginator
+from imednet.endpoints._mixins import ListGetEndpointMixin
 from imednet.endpoints.base import BaseEndpoint
 from imednet.models.visits import Visit
-from imednet.utils.filters import build_filter_string
 
 
-class VisitsEndpoint(BaseEndpoint):
+class VisitsEndpoint(ListGetEndpointMixin, BaseEndpoint):
     """
     API endpoint for interacting with visits (interval instances) in an iMedNet study.
 
     Provides methods to list and retrieve individual visits.
     """
 
-    PATH = "/api/v1/edc/studies"
-
-    def _list_impl(
-        self,
-        client: Any,
-        paginator_cls: type[Any],
-        *,
-        study_key: Optional[str] = None,
-        **filters: Any,
-    ) -> Any:
-        filters = self._auto_filter(filters)
-        if study_key:
-            filters["studyKey"] = study_key
-
-        params: Dict[str, Any] = {}
-        if filters:
-            params["filter"] = build_filter_string(filters)
-
-        path = self._build_path(filters.get("studyKey", ""), "visits")
-        paginator = paginator_cls(client, path, params=params)
-
-        if hasattr(paginator, "__aiter__"):
-
-            async def _collect() -> List[Visit]:
-                return [Visit.from_json(item) async for item in paginator]
-
-            return _collect()
-
-        return [Visit.from_json(item) for item in paginator]
-
-    def _get_impl(
-        self, client: Any, paginator_cls: type[Any], study_key: str, visit_id: int
-    ) -> Any:
-        result = self._list_impl(
-            client,
-            paginator_cls,
-            study_key=study_key,
-            visitId=visit_id,
-        )
-
-        if inspect.isawaitable(result):
-
-            async def _await() -> Visit:
-                items = await result
-                if not items:
-                    raise ValueError(f"Visit {visit_id} not found in study {study_key}")
-                return items[0]
-
-            return _await()
-
-        if not result:
-            raise ValueError(f"Visit {visit_id} not found in study {study_key}")
-        return result[0]
+    PATH = "visits"
+    MODEL = Visit
+    _id_param = "visitId"
 
     def list(self, study_key: Optional[str] = None, **filters) -> List[Visit]:
         """List visits in a study with optional filtering."""
@@ -105,7 +54,7 @@ class VisitsEndpoint(BaseEndpoint):
         Returns:
             Visit object
         """
-        result = self._get_impl(self._client, Paginator, study_key, visit_id)
+        result = self._get_impl(self._client, Paginator, study_key=study_key, item_id=visit_id)
         return result  # type: ignore[return-value]
 
     async def async_get(self, study_key: str, visit_id: int) -> Visit:
@@ -115,4 +64,6 @@ class VisitsEndpoint(BaseEndpoint):
         """
         if self._async_client is None:
             raise RuntimeError("Async client not configured")
-        return await self._get_impl(self._async_client, AsyncPaginator, study_key, visit_id)
+        return await self._get_impl(
+            self._async_client, AsyncPaginator, study_key=study_key, item_id=visit_id
+        )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -89,7 +89,12 @@ def patch_build_filter(monkeypatch):
             captured["filters"] = filters
             return "FILTERED"
 
-        monkeypatch.setattr(module, "build_filter_string", fake)
+        if hasattr(module, "build_filter_string"):
+            monkeypatch.setattr(module, "build_filter_string", fake)
+        else:
+            import imednet.endpoints._mixins as mixins
+
+            monkeypatch.setattr(mixins, "build_filter_string", fake)
         return captured
 
     return patch

--- a/tests/unit/endpoints/test_list_get.py
+++ b/tests/unit/endpoints/test_list_get.py
@@ -1,0 +1,91 @@
+import imednet.endpoints.codings as codings
+import imednet.endpoints.forms as forms
+import imednet.endpoints.intervals as intervals
+import imednet.endpoints.queries as queries
+import imednet.endpoints.record_revisions as record_revisions
+import imednet.endpoints.records as records
+import imednet.endpoints.sites as sites
+import imednet.endpoints.studies as studies
+import imednet.endpoints.subjects as subjects
+import imednet.endpoints.users as users
+import imednet.endpoints.variables as variables
+import imednet.endpoints.visits as visits
+import pytest
+from imednet.models.codings import Coding
+from imednet.models.forms import Form
+from imednet.models.intervals import Interval
+from imednet.models.queries import Query
+from imednet.models.record_revisions import RecordRevision
+from imednet.models.records import Record
+from imednet.models.sites import Site
+from imednet.models.studies import Study
+from imednet.models.subjects import Subject
+from imednet.models.users import User
+from imednet.models.variables import Variable
+from imednet.models.visits import Visit
+
+CASES = [
+    (codings.CodingsEndpoint, codings, Coding, "C1"),
+    (forms.FormsEndpoint, forms, Form, 1),
+    (intervals.IntervalsEndpoint, intervals, Interval, 1),
+    (queries.QueriesEndpoint, queries, Query, 1),
+    (record_revisions.RecordRevisionsEndpoint, record_revisions, RecordRevision, 1),
+    (records.RecordsEndpoint, records, Record, 1),
+    (sites.SitesEndpoint, sites, Site, 1),
+    (studies.StudiesEndpoint, studies, Study, "S1"),
+    (subjects.SubjectsEndpoint, subjects, Subject, "SUB"),
+    (users.UsersEndpoint, users, User, 1),
+    (variables.VariablesEndpoint, variables, Variable, 1),
+    (visits.VisitsEndpoint, visits, Visit, 1),
+]
+
+
+@pytest.mark.parametrize("cls,module,model,item_id", CASES)
+def test_list_and_get(dummy_client, context, paginator_factory, cls, module, model, item_id):
+    ep = cls(dummy_client, context)
+    capture = paginator_factory(module, [{cls._id_param: item_id}])
+
+    list_kwargs = {"study_key": "S1"} if getattr(cls, "requires_study_key", True) else {}
+    result = ep.list(**list_kwargs)
+
+    expected_path = "/api/v1/edc/studies"
+    if getattr(cls, "requires_study_key", True):
+        expected_path += f"/S1/{cls.PATH}"
+    elif cls.PATH:
+        expected_path += f"/{cls.PATH}"
+    assert capture["path"] == expected_path
+    assert isinstance(result[0], model)
+
+    get_args = ("S1", item_id) if getattr(cls, "requires_study_key", True) else (item_id,)
+    got = ep.get(*get_args)
+    assert isinstance(got, model)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("cls,module,model,item_id", CASES)
+async def test_async_list_and_get(
+    dummy_client,
+    context,
+    async_paginator_factory,
+    cls,
+    module,
+    model,
+    item_id,
+):
+    ep = cls(dummy_client, context, async_client=dummy_client)
+    capture = async_paginator_factory(module, [{cls._id_param: item_id}])
+
+    list_kwargs = {"study_key": "S1"} if getattr(cls, "requires_study_key", True) else {}
+    result = await ep.async_list(**list_kwargs)
+
+    expected_path = "/api/v1/edc/studies"
+    if getattr(cls, "requires_study_key", True):
+        expected_path += f"/S1/{cls.PATH}"
+    elif cls.PATH:
+        expected_path += f"/{cls.PATH}"
+    assert capture["path"] == expected_path
+    assert isinstance(result[0], model)
+
+    get_args = ("S1", item_id) if getattr(cls, "requires_study_key", True) else (item_id,)
+    got = await ep.async_get(*get_args)
+    assert isinstance(got, model)


### PR DESCRIPTION
## Summary
- refactor endpoints to share common list and get behavior via `ListGetEndpointMixin`
- customize missing study handling and caching for each endpoint
- adjust tests to patch mixin utilities

## Testing
- `poetry run ruff check --fix .`
- `poetry run black --check .`
- `poetry run mypy imednet`
- `poetry run pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6867023c12d4832cacf85166bfa5374b