### PR TITLE
Add Python 3.8+ compatibility

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,12 +4,14 @@ repos:
     hooks:
       - id: black
         args: ["--line-length=100", "--skip-string-normalization"]
+        language_version: python3
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.4.2
     hooks:
       - id: ruff
         args: ["--ignore=E501,F401"]
+        language_version: python3
 
   - repo: https://github.com/pre-commit/mirrors-mypy
     rev: v1.10.0
@@ -17,3 +19,4 @@ repos:
       - id: mypy
         additional_dependencies: ["pandas-stubs", "types-requests", "pydantic"]
         args: ["--ignore-missing-imports", "--no-strict-optional"]
+        language_version: python3

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ print(sdk.studies.list())
 
 ## Tech Stack
 
-- Python 3.10–3.12
+- Python 3.8–3.13
 - requests, httpx, pydantic, typer, tenacity, python-dotenv
 
 ## Project Structure

--- a/imednet/cli/decorators.py
+++ b/imednet/cli/decorators.py
@@ -2,10 +2,11 @@ from __future__ import annotations
 
 import inspect
 from functools import wraps
-from typing import Callable, Concatenate, ParamSpec, TypeVar
+from typing import Callable, TypeVar
 
 import typer
 from rich import print
+from typing_extensions import Concatenate, ParamSpec
 
 from ..core.exceptions import ApiError
 from ..sdk import ImednetSDK

--- a/imednet/core/paginator.py
+++ b/imednet/core/paginator.py
@@ -1,6 +1,6 @@
 """Pagination helpers for iterating through API responses."""
 
-from typing import Any, AsyncIterator, Dict, Iterator, Optional
+from typing import Any, AsyncIterator, Dict, Iterator, List, Optional
 
 import httpx
 
@@ -34,7 +34,7 @@ class BasePaginator:
         query[self.size_param] = self.page_size
         return query
 
-    def _extract_items(self, payload: Dict[str, Any]) -> list[Any]:
+    def _extract_items(self, payload: Dict[str, Any]) -> List[Any]:
         return payload.get(self.data_key, []) or []
 
     def _next_page(self, payload: Dict[str, Any], page: int) -> Optional[int]:

--- a/imednet/endpoints/__init__.py
+++ b/imednet/endpoints/__init__.py
@@ -4,6 +4,8 @@ Endpoints package for the iMedNet SDK.
 This package contains all API endpoint implementations for accessing iMedNet resources.
 """
 
+from typing import List
+
 from imednet.endpoints.codings import CodingsEndpoint
 from imednet.endpoints.forms import FormsEndpoint
 from imednet.endpoints.intervals import IntervalsEndpoint
@@ -18,7 +20,7 @@ from imednet.endpoints.users import UsersEndpoint
 from imednet.endpoints.variables import VariablesEndpoint
 from imednet.endpoints.visits import VisitsEndpoint
 
-__all__: list[str] = [
+__all__: List[str] = [
     "CodingsEndpoint",
     "FormsEndpoint",
     "IntervalsEndpoint",

--- a/imednet/endpoints/_mixins.py
+++ b/imednet/endpoints/_mixins.py
@@ -1,7 +1,17 @@
 from __future__ import annotations
 
 import inspect
-from typing import TYPE_CHECKING, Any, Dict, Iterable, Optional, Protocol, Type
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Dict,
+    Iterable,
+    List,
+    Optional,
+    Protocol,
+    Type,
+    Union,
+)
 
 from pydantic import BaseModel
 
@@ -25,10 +35,10 @@ if TYPE_CHECKING:  # pragma: no cover - imported for type hints only
 
         def _list_impl(
             self,
-            client: Client | AsyncClient,
-            paginator_cls: type[Paginator] | type[AsyncPaginator],
+            client: Union[Client, AsyncClient],
+            paginator_cls: Union[type[Paginator], type[AsyncPaginator]],
             *,
-            study_key: Optional[str] | None = None,
+            study_key: Optional[str] = None,
             refresh: bool = False,
             extra_params: Optional[Dict[str, Any]] = None,
             **filters: Any,
@@ -56,8 +66,8 @@ class ListGetEndpointMixin:
 
     def _list_impl(
         self: Any,
-        client: Client | AsyncClient,
-        paginator_cls: type[Paginator] | type[AsyncPaginator],
+        client: Union[Client, AsyncClient],
+        paginator_cls: Union[type[Paginator], type[AsyncPaginator]],
         *,
         study_key: Optional[str] = None,
         refresh: bool = False,
@@ -110,7 +120,7 @@ class ListGetEndpointMixin:
 
         if hasattr(paginator, "__aiter__"):
 
-            async def _collect() -> list[BaseModel]:
+            async def _collect() -> List[BaseModel]:
                 result = [self._parse_item(item) async for item in paginator]
                 if not other_filters:
                     if self.requires_study_key and cache is not None:
@@ -131,8 +141,8 @@ class ListGetEndpointMixin:
 
     def _get_impl(
         self: Any,
-        client: Client | AsyncClient,
-        paginator_cls: type[Paginator] | type[AsyncPaginator],
+        client: Union[Client, AsyncClient],
+        paginator_cls: Union[type[Paginator], type[AsyncPaginator]],
         *,
         study_key: Optional[str],
         item_id: Any,

--- a/imednet/endpoints/base.py
+++ b/imednet/endpoints/base.py
@@ -2,7 +2,7 @@
 Base endpoint mix-in for all API resource endpoints.
 """
 
-from typing import Any, Dict
+from typing import Any, Dict, Optional
 
 from imednet.core.async_client import AsyncClient
 from imednet.core.client import Client
@@ -24,7 +24,7 @@ class BaseEndpoint:
         self,
         client: Client,
         ctx: Context,
-        async_client: AsyncClient | None = None,
+        async_client: Optional[AsyncClient] = None,
     ) -> None:
         self._client = client
         self._async_client = async_client

--- a/imednet/endpoints/forms.py
+++ b/imednet/endpoints/forms.py
@@ -30,7 +30,7 @@ class FormsEndpoint(ListGetEndpointMixin, BaseEndpoint):
         self,
         client: Client,
         ctx: Context,
-        async_client: AsyncClient | None = None,
+        async_client: Optional[AsyncClient] = None,
     ) -> None:
         super().__init__(client, ctx, async_client)
         self._forms_cache: Dict[str, List[Form]] = {}

--- a/imednet/endpoints/intervals.py
+++ b/imednet/endpoints/intervals.py
@@ -29,7 +29,7 @@ class IntervalsEndpoint(ListGetEndpointMixin, BaseEndpoint):
         self,
         client: Client,
         ctx: Context,
-        async_client: AsyncClient | None = None,
+        async_client: Optional[AsyncClient] = None,
     ) -> None:
         super().__init__(client, ctx, async_client)
         self._intervals_cache: Dict[str, List[Interval]] = {}

--- a/imednet/endpoints/records.py
+++ b/imednet/endpoints/records.py
@@ -1,7 +1,7 @@
 """Endpoint for managing records (eCRF instances) in a study."""
 
 import inspect
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, Dict, List, Optional, Type, Union
 
 from imednet.core.paginator import AsyncPaginator, Paginator
 from imednet.endpoints._mixins import ListGetEndpointMixin
@@ -175,7 +175,7 @@ class RecordsEndpoint(ListGetEndpointMixin, BaseEndpoint):
     def _list_impl(
         self,
         client: Any,
-        paginator_cls: type[Any],
+        paginator_cls: Type[Any],
         *,
         study_key: Optional[str] = None,
         record_data_filter: Optional[str] = None,

--- a/imednet/endpoints/studies.py
+++ b/imednet/endpoints/studies.py
@@ -29,7 +29,7 @@ class StudiesEndpoint(ListGetEndpointMixin, BaseEndpoint):
         self,
         client: Client,
         ctx: Context,
-        async_client: AsyncClient | None = None,
+        async_client: Optional[AsyncClient] = None,
     ) -> None:
         super().__init__(client, ctx, async_client)
         self._studies_cache: Optional[List[Study]] = None

--- a/imednet/endpoints/users.py
+++ b/imednet/endpoints/users.py
@@ -1,6 +1,6 @@
 """Endpoint for managing users in a study."""
 
-from typing import Any, List, Optional, Union
+from typing import Any, List, Optional, Type, Union
 
 from imednet.core.paginator import AsyncPaginator, Paginator
 from imednet.endpoints._mixins import ListGetEndpointMixin
@@ -23,7 +23,7 @@ class UsersEndpoint(ListGetEndpointMixin, BaseEndpoint):
     def _list_impl(
         self,
         client: Any,
-        paginator_cls: type[Any],
+        paginator_cls: Type[Any],
         *,
         study_key: Optional[str] = None,
         include_inactive: bool = False,

--- a/imednet/endpoints/variables.py
+++ b/imednet/endpoints/variables.py
@@ -30,7 +30,7 @@ class VariablesEndpoint(ListGetEndpointMixin, BaseEndpoint):
         self,
         client: Client,
         ctx: Context,
-        async_client: AsyncClient | None = None,
+        async_client: Optional[AsyncClient] = None,
     ) -> None:
         super().__init__(client, ctx, async_client)
         self._variables_cache: Dict[str, List[Variable]] = {}

--- a/imednet/models/__init__.py
+++ b/imednet/models/__init__.py
@@ -3,6 +3,8 @@
 This package contains all data models used by the SDK to represent iMedNet resources.
 """
 
+from typing import List
+
 from imednet.models.codings import Coding
 from imednet.models.forms import Form
 from imednet.models.intervals import FormSummary, Interval
@@ -35,7 +37,7 @@ from imednet.utils.validators import (
     parse_str_or_default,
 )
 
-__all__: list[str] = [
+__all__: List[str] = [
     "Coding",
     "Form",
     "FormSummary",

--- a/imednet/utils/__init__.py
+++ b/imednet/utils/__init__.py
@@ -3,13 +3,14 @@ Re-exports utility functions for easier access.
 """
 
 from importlib import import_module
+from typing import Dict, Tuple
 
 from .dates import format_iso_datetime, parse_iso_datetime
 from .filters import build_filter_string
 from .json_logging import configure_json_logging
 from .typing import DataFrame, JsonDict
 
-_LAZY_ATTRS: dict[str, tuple[str, str]] = {
+_LAZY_ATTRS: Dict[str, Tuple[str, str]] = {
     "records_to_dataframe": ("imednet.utils.pandas", "records_to_dataframe"),
     "export_records_csv": ("imednet.utils.pandas", "export_records_csv"),
     "parse_bool": ("imednet.utils.validators", "parse_bool"),

--- a/imednet/utils/validators.py
+++ b/imednet/utils/validators.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from datetime import datetime
-from typing import Any, Callable, Dict, List, TypeVar
+from typing import Any, Callable, Dict, List, TypeVar, Union
 
 from imednet.utils.dates import parse_iso_datetime  # Centralized date parsing
 
@@ -13,7 +13,7 @@ def _or_default(value: Any, default: Any) -> Any:
     return value if value is not None else default
 
 
-def parse_datetime(v: str | datetime) -> datetime:
+def parse_datetime(v: Union[str, datetime]) -> datetime:
     """
     Wrapper for parse_iso_datetime from utils.dates.
     Used for backwards compatibility in models.

--- a/imednet/validation/cache.py
+++ b/imednet/validation/cache.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import inspect
-from typing import TYPE_CHECKING, Any, Callable, Dict, Generic, Optional, TypeVar
+from typing import TYPE_CHECKING, Any, Callable, Dict, Generic, List, Optional, TypeVar, Union
 
 from ..core.exceptions import UnknownVariableTypeError, ValidationError
 from ..endpoints.forms import FormsEndpoint
@@ -146,7 +146,7 @@ def validate_record_data(
 class SchemaValidator(_ValidatorMixin):
     """Validate record payloads using variable metadata from the API."""
 
-    def __init__(self, sdk: "ImednetSDK | AsyncImednetSDK") -> None:
+    def __init__(self, sdk: Union["ImednetSDK", "AsyncImednetSDK"]) -> None:
         self._sdk = sdk
         import inspect
 
@@ -197,7 +197,7 @@ class SchemaValidator(_ValidatorMixin):
             return self._validate_record_async(study_key, record)
         return self._validate_record_sync(study_key, record)
 
-    def validate_batch(self, study_key: str, records: list[Dict[str, Any]]) -> Any:
+    def validate_batch(self, study_key: str, records: List[Dict[str, Any]]) -> Any:
         if self._is_async:
 
             async def _run() -> None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,9 +20,12 @@ classifiers = [
     "License :: OSI Approved :: MIT License",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3 :: Only",
+    "Programming Language :: Python :: 3.8",
+    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     "Intended Audience :: Developers",
     "Intended Audience :: Science/Research",
     "Topic :: Scientific/Engineering :: Medical Science Apps.",
@@ -45,7 +48,7 @@ homepage = "https://github.com/fderuiter/imednet-python-sdk"
 imednet = "imednet.cli:app"
 
 [tool.poetry.dependencies]
-python = "^3.10"
+python = ">=3.8,<4.0"
 requests = "2.32.4"
 h11 = "0.16.0"
 pandas = { version = ">=2.2.3,<3.0.0", optional = true }
@@ -99,7 +102,7 @@ build-backend = "poetry.core.masonry.api"
 # ------------------------
 [tool.black]
 line-length = 100
-target-version = ["py310"]
+target-version = ["py38"]
 
 [tool.ruff]
 line-length = 100
@@ -113,7 +116,7 @@ ignore = ["D", "ANN", "S101"]
 classmethod-decorators = ["field_validator", "model_validator"]
 
 [tool.mypy]
-python_version = "3.10"
+python_version = "3.8"
 strict = false
 ignore_missing_imports = true
 plugins = ["pydantic.mypy"]

--- a/tests/unit/cli/test_cli.py
+++ b/tests/unit/cli/test_cli.py
@@ -2,6 +2,7 @@ import importlib.util
 import os
 import sys
 from types import ModuleType
+from typing import Optional
 from unittest.mock import MagicMock
 
 import imednet.cli as cli
@@ -233,7 +234,7 @@ def test_export_sql_calls_helper_non_sqlite(
     engine = MagicMock()
     engine.dialect.name = "postgres"
     sa_module = ModuleType("sqlalchemy")
-    sa_module.create_engine = MagicMock(return_value=engine)
+    sa_module.create_engine = MagicMock(return_value=engine)  # type: ignore[attr-defined]
     monkeypatch.setitem(sys.modules, "sqlalchemy", sa_module)
     result = runner.invoke(
         cli.app,
@@ -253,7 +254,7 @@ def test_export_sql_sqlite_uses_by_form(
     engine = MagicMock()
     engine.dialect.name = "sqlite"
     sa_module = ModuleType("sqlalchemy")
-    sa_module.create_engine = MagicMock(return_value=engine)
+    sa_module.create_engine = MagicMock(return_value=engine)  # type: ignore[attr-defined]
     monkeypatch.setitem(sys.modules, "sqlalchemy", sa_module)
     result = runner.invoke(
         cli.app,
@@ -275,7 +276,7 @@ def test_export_sql_sqlite_single_table(
     engine = MagicMock()
     engine.dialect.name = "sqlite"
     sa_module = ModuleType("sqlalchemy")
-    sa_module.create_engine = MagicMock(return_value=engine)
+    sa_module.create_engine = MagicMock(return_value=engine)  # type: ignore[attr-defined]
     monkeypatch.setitem(sys.modules, "sqlalchemy", sa_module)
     result = runner.invoke(
         cli.app,
@@ -289,7 +290,7 @@ def test_export_sql_sqlite_single_table(
 def test_export_parquet_missing_pyarrow(runner: CliRunner, monkeypatch: pytest.MonkeyPatch) -> None:
     original_find_spec = importlib.util.find_spec
 
-    def fake_find_spec(name: str) -> object | None:
+    def fake_find_spec(name: str) -> Optional[object]:
         if name == "pyarrow":
             return None
         return original_find_spec(name)
@@ -303,7 +304,7 @@ def test_export_parquet_missing_pyarrow(runner: CliRunner, monkeypatch: pytest.M
 def test_export_sql_missing_sqlalchemy(runner: CliRunner, monkeypatch: pytest.MonkeyPatch) -> None:
     original_find_spec = importlib.util.find_spec
 
-    def fake_find_spec(name: str) -> object | None:
+    def fake_find_spec(name: str) -> Optional[object]:
         if name == "sqlalchemy":
             return None
         return original_find_spec(name)

--- a/tests/unit/test_core_paginator.py
+++ b/tests/unit/test_core_paginator.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Optional
 
 from imednet.core.paginator import Paginator
 
@@ -8,7 +8,7 @@ class DummyClient:
         self.responses = responses
         self.calls: List[Dict[str, Any]] = []
 
-    def get(self, path: str, params: Dict[str, Any] | None = None):
+    def get(self, path: str, params: Optional[Dict[str, Any]] = None):
         self.calls.append({"path": path, "params": params})
         data = self.responses.pop(0)
         return type("Resp", (), {"json": lambda self: data})()

--- a/tests/unit/test_workflows_query_management.py
+++ b/tests/unit/test_workflows_query_management.py
@@ -1,3 +1,4 @@
+from typing import List, Tuple
 from unittest.mock import MagicMock
 
 from imednet.models.queries import Query, QueryComment
@@ -5,7 +6,7 @@ from imednet.models.subjects import Subject
 from imednet.workflows.query_management import QueryManagementWorkflow
 
 
-def make_query(sequence_closed: list[tuple[int, bool]]) -> Query:
+def make_query(sequence_closed: List[Tuple[int, bool]]) -> Query:
     comments = [QueryComment(sequence=seq, closed=closed) for seq, closed in sequence_closed]
     return Query(query_comments=comments)
 

--- a/tests/workflows/test_query_management.py
+++ b/tests/workflows/test_query_management.py
@@ -1,3 +1,4 @@
+from typing import List, Tuple
 from unittest.mock import MagicMock
 
 from imednet.models.queries import Query, QueryComment
@@ -6,7 +7,7 @@ from imednet.testing import fake_data
 from imednet.workflows.query_management import QueryManagementWorkflow
 
 
-def make_query(sequence_closed: list[tuple[int, bool]]) -> Query:
+def make_query(sequence_closed: List[Tuple[int, bool]]) -> Query:
     comments = [QueryComment(sequence=seq, closed=closed) for seq, closed in sequence_closed]
     return Query(query_comments=comments)
 


### PR DESCRIPTION
## Summary
- add Python 3.8 and 3.9 to CI matrix
- relax supported Python range and tooling versions
- update pre-commit to run with repo Python
- switch type hints from PEP604 syntax
- fix tests for mypy

## Testing
- `poetry run ruff check --fix .`
- `poetry run black --check .`
- `poetry run mypy imednet`
- `poetry run pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686c0d33049c832cac1f4848e64272e6