### PR TITLE
Refactor async client handling

### DIFF
--- a/imednet/endpoints/base.py
+++ b/imednet/endpoints/base.py
@@ -61,3 +61,9 @@ class BaseEndpoint:
             if str(getattr(item, attr)) == str(item_id):
                 return item
         raise ValueError(f"{attr} {item_id} not found in study {study_key}")
+
+    def _require_async_client(self) -> AsyncClient:
+        """Return the configured async client or raise if missing."""
+        if self._async_client is None:
+            raise RuntimeError("Async client not configured")
+        return self._async_client

--- a/imednet/endpoints/codings.py
+++ b/imednet/endpoints/codings.py
@@ -1,14 +1,11 @@
 """Endpoint for managing codings (medical coding) in a study."""
 
-from typing import Any, List, Optional
-
-from imednet.core.paginator import AsyncPaginator, Paginator
-from imednet.endpoints._mixins import ListGetEndpointMixin
-from imednet.endpoints.base import BaseEndpoint
+from imednet.core.paginator import AsyncPaginator, Paginator  # noqa: F401
+from imednet.endpoints._mixins import ListGetEndpoint
 from imednet.models.codings import Coding
 
 
-class CodingsEndpoint(ListGetEndpointMixin, BaseEndpoint):
+class CodingsEndpoint(ListGetEndpoint):
     """
     API endpoint for interacting with codings (medical coding) in an iMedNet study.
 
@@ -20,53 +17,3 @@ class CodingsEndpoint(ListGetEndpointMixin, BaseEndpoint):
     _id_param = "codingId"
     _pop_study_filter = True
     _missing_study_exception = KeyError
-
-    def list(self, study_key: Optional[str] = None, **filters) -> List[Coding]:
-        """List codings in a study with optional filtering."""
-        result = self._list_impl(
-            self._client,
-            Paginator,
-            study_key=study_key,
-            **filters,
-        )
-        return result  # type: ignore[return-value]
-
-    async def async_list(self, study_key: Optional[str] = None, **filters: Any) -> List[Coding]:
-        """Asynchronous version of :meth:`list`."""
-        if self._async_client is None:
-            raise RuntimeError("Async client not configured")
-        result = await self._list_impl(
-            self._async_client,
-            AsyncPaginator,
-            study_key=study_key,
-            **filters,
-        )
-        return result
-
-    def get(self, study_key: str, coding_id: str) -> Coding:
-        """
-        Get a specific coding by ID.
-
-        The ``coding_id`` value is supplied as a filter to :meth:`list`.
-
-        Args:
-            study_key: Study identifier
-            coding_id: Coding identifier
-
-        Returns:
-            Coding object
-        """
-
-        result = self._get_impl(self._client, Paginator, study_key=study_key, item_id=coding_id)
-        return result  # type: ignore[return-value]
-
-    async def async_get(self, study_key: str, coding_id: str) -> Coding:
-        """Asynchronous version of :meth:`get`.
-
-        This method also filters :meth:`async_list` by ``coding_id``.
-        """
-        if self._async_client is None:
-            raise RuntimeError("Async client not configured")
-        return await self._get_impl(
-            self._async_client, AsyncPaginator, study_key=study_key, item_id=coding_id
-        )

--- a/imednet/endpoints/intervals.py
+++ b/imednet/endpoints/intervals.py
@@ -5,13 +5,12 @@ from typing import Any, Dict, List, Optional
 from imednet.core.async_client import AsyncClient
 from imednet.core.client import Client
 from imednet.core.context import Context
-from imednet.core.paginator import AsyncPaginator, Paginator
-from imednet.endpoints._mixins import ListGetEndpointMixin
-from imednet.endpoints.base import BaseEndpoint
+from imednet.core.paginator import AsyncPaginator, Paginator  # noqa: F401
+from imednet.endpoints._mixins import ListGetEndpoint
 from imednet.models.intervals import Interval
 
 
-class IntervalsEndpoint(ListGetEndpointMixin, BaseEndpoint):
+class IntervalsEndpoint(ListGetEndpoint):
     """
     API endpoint for interacting with intervals (visit definitions) in an iMedNet study.
 
@@ -34,35 +33,31 @@ class IntervalsEndpoint(ListGetEndpointMixin, BaseEndpoint):
         super().__init__(client, ctx, async_client)
         self._intervals_cache: Dict[str, List[Interval]] = {}
 
-    def list(
+    def list(  # type: ignore[override]
         self, study_key: Optional[str] = None, refresh: bool = False, **filters: Any
     ) -> List[Interval]:
         """List intervals in a study with optional filtering."""
-        result = self._list_impl(
-            self._client,
-            Paginator,
+        result = self._list_common(
+            False,
             study_key=study_key,
             refresh=refresh,
             **filters,
         )
         return result  # type: ignore[return-value]
 
-    async def async_list(
+    async def async_list(  # type: ignore[override]
         self, study_key: Optional[str] = None, refresh: bool = False, **filters: Any
     ) -> List[Interval]:
         """Asynchronous version of :meth:`list`."""
-        if self._async_client is None:
-            raise RuntimeError("Async client not configured")
-        result = await self._list_impl(
-            self._async_client,
-            AsyncPaginator,
+        result = await self._list_common(
+            True,
             study_key=study_key,
             refresh=refresh,
             **filters,
         )
         return result
 
-    def get(self, study_key: str, interval_id: int) -> Interval:
+    def get(self, study_key: str, interval_id: int) -> Interval:  # type: ignore[override]
         """
         Get a specific interval by ID.
 
@@ -76,17 +71,13 @@ class IntervalsEndpoint(ListGetEndpointMixin, BaseEndpoint):
         Returns:
             Interval object
         """
-        result = self._get_impl(self._client, Paginator, study_key=study_key, item_id=interval_id)
+        result = self._get_common(False, study_key=study_key, item_id=interval_id)
         return result  # type: ignore[return-value]
 
-    async def async_get(self, study_key: str, interval_id: int) -> Interval:
+    async def async_get(self, study_key: str, interval_id: int) -> Interval:  # type: ignore[override]
         """Asynchronous version of :meth:`get`.
 
         The asynchronous call also passes ``refresh=True`` to
         :meth:`async_list`.
         """
-        if self._async_client is None:
-            raise RuntimeError("Async client not configured")
-        return await self._get_impl(
-            self._async_client, AsyncPaginator, study_key=study_key, item_id=interval_id
-        )
+        return await self._get_common(True, study_key=study_key, item_id=interval_id)

--- a/imednet/endpoints/jobs.py
+++ b/imednet/endpoints/jobs.py
@@ -58,6 +58,5 @@ class JobsEndpoint(BaseEndpoint):
         Like the sync variant, it simply issues a request by ``batch_id``
         without any caching.
         """
-        if self._async_client is None:
-            raise RuntimeError("Async client not configured")
-        return await self._get_impl(self._async_client, study_key, batch_id)
+        client = self._require_async_client()
+        return await self._get_impl(client, study_key, batch_id)

--- a/imednet/endpoints/queries.py
+++ b/imednet/endpoints/queries.py
@@ -2,13 +2,12 @@
 
 from typing import Any, List, Optional
 
-from imednet.core.paginator import AsyncPaginator, Paginator
-from imednet.endpoints._mixins import ListGetEndpointMixin
-from imednet.endpoints.base import BaseEndpoint
+from imednet.core.paginator import AsyncPaginator, Paginator  # noqa: F401
+from imednet.endpoints._mixins import ListGetEndpoint
 from imednet.models.queries import Query
 
 
-class QueriesEndpoint(ListGetEndpointMixin, BaseEndpoint):
+class QueriesEndpoint(ListGetEndpoint):
     """
     API endpoint for interacting with queries (dialogue/questions) in an iMedNet study.
 
@@ -19,29 +18,17 @@ class QueriesEndpoint(ListGetEndpointMixin, BaseEndpoint):
     MODEL = Query
     _id_param = "annotationId"
 
-    def list(self, study_key: Optional[str] = None, **filters) -> List[Query]:
+    def list(self, study_key: Optional[str] = None, **filters) -> List[Query]:  # type: ignore[override]
         """List queries in a study with optional filtering."""
-        result = self._list_impl(
-            self._client,
-            Paginator,
-            study_key=study_key,
-            **filters,
-        )
+        result = self._list_common(False, study_key=study_key, **filters)
         return result  # type: ignore[return-value]
 
-    async def async_list(self, study_key: Optional[str] = None, **filters: Any) -> List[Query]:
+    async def async_list(self, study_key: Optional[str] = None, **filters: Any) -> List[Query]:  # type: ignore[override]
         """Asynchronous version of :meth:`list`."""
-        if self._async_client is None:
-            raise RuntimeError("Async client not configured")
-        result = await self._list_impl(
-            self._async_client,
-            AsyncPaginator,
-            study_key=study_key,
-            **filters,
-        )
+        result = await self._list_common(True, study_key=study_key, **filters)
         return result
 
-    def get(self, study_key: str, annotation_id: int) -> Query:
+    def get(self, study_key: str, annotation_id: int) -> Query:  # type: ignore[override]
         """
         Get a specific query by annotation ID.
 
@@ -54,16 +41,12 @@ class QueriesEndpoint(ListGetEndpointMixin, BaseEndpoint):
         Returns:
             Query object
         """
-        result = self._get_impl(self._client, Paginator, study_key=study_key, item_id=annotation_id)
+        result = self._get_common(False, study_key=study_key, item_id=annotation_id)
         return result  # type: ignore[return-value]
 
-    async def async_get(self, study_key: str, annotation_id: int) -> Query:
+    async def async_get(self, study_key: str, annotation_id: int) -> Query:  # type: ignore[override]
         """Asynchronous version of :meth:`get`.
 
         This call filters :meth:`async_list` by ``annotation_id``.
         """
-        if self._async_client is None:
-            raise RuntimeError("Async client not configured")
-        return await self._get_impl(
-            self._async_client, AsyncPaginator, study_key=study_key, item_id=annotation_id
-        )
+        return await self._get_common(True, study_key=study_key, item_id=annotation_id)

--- a/imednet/endpoints/record_revisions.py
+++ b/imednet/endpoints/record_revisions.py
@@ -2,13 +2,12 @@
 
 from typing import Any, List, Optional
 
-from imednet.core.paginator import AsyncPaginator, Paginator
-from imednet.endpoints._mixins import ListGetEndpointMixin
-from imednet.endpoints.base import BaseEndpoint
+from imednet.core.paginator import AsyncPaginator, Paginator  # noqa: F401
+from imednet.endpoints._mixins import ListGetEndpoint
 from imednet.models.record_revisions import RecordRevision
 
 
-class RecordRevisionsEndpoint(ListGetEndpointMixin, BaseEndpoint):
+class RecordRevisionsEndpoint(ListGetEndpoint):
     """
     API endpoint for accessing record revision history in an iMedNet study.
 
@@ -19,31 +18,19 @@ class RecordRevisionsEndpoint(ListGetEndpointMixin, BaseEndpoint):
     MODEL = RecordRevision
     _id_param = "recordRevisionId"
 
-    def list(self, study_key: Optional[str] = None, **filters) -> List[RecordRevision]:
+    def list(self, study_key: Optional[str] = None, **filters) -> List[RecordRevision]:  # type: ignore[override]
         """List record revisions in a study with optional filtering."""
-        result = self._list_impl(
-            self._client,
-            Paginator,
-            study_key=study_key,
-            **filters,
-        )
+        result = self._list_common(False, study_key=study_key, **filters)
         return result  # type: ignore[return-value]
 
-    async def async_list(
+    async def async_list(  # type: ignore[override]
         self, study_key: Optional[str] = None, **filters: Any
     ) -> List[RecordRevision]:
         """Asynchronous version of :meth:`list`."""
-        if self._async_client is None:
-            raise RuntimeError("Async client not configured")
-        result = await self._list_impl(
-            self._async_client,
-            AsyncPaginator,
-            study_key=study_key,
-            **filters,
-        )
+        result = await self._list_common(True, study_key=study_key, **filters)
         return result
 
-    def get(self, study_key: str, record_revision_id: int) -> RecordRevision:
+    def get(self, study_key: str, record_revision_id: int) -> RecordRevision:  # type: ignore[override]
         """
         Get a specific record revision by ID.
 
@@ -56,21 +43,12 @@ class RecordRevisionsEndpoint(ListGetEndpointMixin, BaseEndpoint):
         Returns:
             RecordRevision object
         """
-        result = self._get_impl(
-            self._client, Paginator, study_key=study_key, item_id=record_revision_id
-        )
+        result = self._get_common(False, study_key=study_key, item_id=record_revision_id)
         return result  # type: ignore[return-value]
 
-    async def async_get(self, study_key: str, record_revision_id: int) -> RecordRevision:
+    async def async_get(self, study_key: str, record_revision_id: int) -> RecordRevision:  # type: ignore[override]
         """Asynchronous version of :meth:`get`.
 
         This call also filters :meth:`async_list` by ``record_revision_id``.
         """
-        if self._async_client is None:
-            raise RuntimeError("Async client not configured")
-        return await self._get_impl(
-            self._async_client,
-            AsyncPaginator,
-            study_key=study_key,
-            item_id=record_revision_id,
-        )
+        return await self._get_common(True, study_key=study_key, item_id=record_revision_id)

--- a/imednet/endpoints/records.py
+++ b/imednet/endpoints/records.py
@@ -3,15 +3,14 @@
 import inspect
 from typing import Any, Dict, List, Optional, Union
 
-from imednet.core.paginator import AsyncPaginator, Paginator
-from imednet.endpoints._mixins import ListGetEndpointMixin
-from imednet.endpoints.base import BaseEndpoint
+from imednet.core.paginator import AsyncPaginator, Paginator  # noqa: F401
+from imednet.endpoints._mixins import ListGetEndpoint
 from imednet.models.jobs import Job
 from imednet.models.records import Record
 from imednet.validation.cache import SchemaCache, validate_record_data
 
 
-class RecordsEndpoint(ListGetEndpointMixin, BaseEndpoint):
+class RecordsEndpoint(ListGetEndpoint):
     """
     API endpoint for interacting with records (eCRF instances) in an iMedNet study.
 
@@ -50,64 +49,48 @@ class RecordsEndpoint(ListGetEndpointMixin, BaseEndpoint):
         response = client.post(path, json=records_data, headers=headers)
         return Job.from_json(response.json())
 
-    def list(
+    def list(  # type: ignore[override]
         self, study_key: Optional[str] = None, record_data_filter: Optional[str] = None, **filters
     ) -> List[Record]:
         """List records in a study with optional filtering."""
-        result = self._list_impl(
-            self._client,
-            Paginator,
+        result = self._list_common(
+            False,
             study_key=study_key,
             record_data_filter=record_data_filter,
             **filters,
         )
         return result  # type: ignore[return-value]
 
-    async def async_list(
+    async def async_list(  # type: ignore[override]
         self,
         study_key: Optional[str] = None,
         record_data_filter: Optional[str] = None,
         **filters: Any,
     ) -> List[Record]:
         """Asynchronous version of :meth:`list`."""
-        if self._async_client is None:
-            raise RuntimeError("Async client not configured")
-        result = await self._list_impl(
-            self._async_client,
-            AsyncPaginator,
+        result = await self._list_common(
+            True,
             study_key=study_key,
             record_data_filter=record_data_filter,
             **filters,
         )
         return result
 
-    def get(self, study_key: str, record_id: Union[str, int]) -> Record:
+    def get(self, study_key: str, record_id: Union[str, int]) -> Record:  # type: ignore[override]
         """Get a specific record by ID."""
-        result = self._list_impl(
-            self._client,
-            Paginator,
-            study_key=study_key,
-            recordId=record_id,
-        )
+        result = self._list_common(False, study_key=study_key, recordId=record_id)
         if inspect.isawaitable(result):
             raise RuntimeError("Unexpected awaitable result")
         if not result:
             raise ValueError(f"Record {record_id} not found in study {study_key}")
         return result[0]
 
-    async def async_get(self, study_key: str, record_id: Union[str, int]) -> Record:
+    async def async_get(self, study_key: str, record_id: Union[str, int]) -> Record:  # type: ignore[override]
         """Asynchronous version of :meth:`get`.
 
         This method also filters :meth:`async_list` by ``record_id``.
         """
-        if self._async_client is None:
-            raise RuntimeError("Async client not configured")
-        result = await self._list_impl(
-            self._async_client,
-            AsyncPaginator,
-            study_key=study_key,
-            recordId=record_id,
-        )
+        result = await self._list_common(True, study_key=study_key, recordId=record_id)
         if not result:
             raise ValueError(f"Record {record_id} not found in study {study_key}")
         return result[0]
@@ -157,8 +140,7 @@ class RecordsEndpoint(ListGetEndpointMixin, BaseEndpoint):
         schema: Optional[SchemaCache] = None,
     ) -> Job:
         """Asynchronous version of :meth:`create`."""
-        if self._async_client is None:
-            raise RuntimeError("Async client not configured")
+        self._require_async_client()
         if schema is not None:
             for rec in records_data:
                 fk = rec.get("formKey") or schema.form_key_from_id(rec.get("formId", 0))

--- a/imednet/endpoints/sites.py
+++ b/imednet/endpoints/sites.py
@@ -2,13 +2,12 @@
 
 from typing import Any, List, Optional
 
-from imednet.core.paginator import AsyncPaginator, Paginator
-from imednet.endpoints._mixins import ListGetEndpointMixin
-from imednet.endpoints.base import BaseEndpoint
+from imednet.core.paginator import AsyncPaginator, Paginator  # noqa: F401
+from imednet.endpoints._mixins import ListGetEndpoint
 from imednet.models.sites import Site
 
 
-class SitesEndpoint(ListGetEndpointMixin, BaseEndpoint):
+class SitesEndpoint(ListGetEndpoint):
     """
     API endpoint for interacting with sites (study locations) in an iMedNet study.
 
@@ -21,29 +20,17 @@ class SitesEndpoint(ListGetEndpointMixin, BaseEndpoint):
     _pop_study_filter = True
     _missing_study_exception = KeyError
 
-    def list(self, study_key: Optional[str] = None, **filters) -> List[Site]:
+    def list(self, study_key: Optional[str] = None, **filters) -> List[Site]:  # type: ignore[override]
         """List sites in a study with optional filtering."""
-        result = self._list_impl(
-            self._client,
-            Paginator,
-            study_key=study_key,
-            **filters,
-        )
+        result = self._list_common(False, study_key=study_key, **filters)
         return result  # type: ignore[return-value]
 
-    async def async_list(self, study_key: Optional[str] = None, **filters: Any) -> List[Site]:
+    async def async_list(self, study_key: Optional[str] = None, **filters: Any) -> List[Site]:  # type: ignore[override]
         """Asynchronous version of :meth:`list`."""
-        if self._async_client is None:
-            raise RuntimeError("Async client not configured")
-        result = await self._list_impl(
-            self._async_client,
-            AsyncPaginator,
-            study_key=study_key,
-            **filters,
-        )
+        result = await self._list_common(True, study_key=study_key, **filters)
         return result
 
-    def get(self, study_key: str, site_id: int) -> Site:
+    def get(self, study_key: str, site_id: int) -> Site:  # type: ignore[override]
         """
         Get a specific site by ID.
 
@@ -56,16 +43,12 @@ class SitesEndpoint(ListGetEndpointMixin, BaseEndpoint):
         Returns:
             Site object
         """
-        result = self._get_impl(self._client, Paginator, study_key=study_key, item_id=site_id)
+        result = self._get_common(False, study_key=study_key, item_id=site_id)
         return result  # type: ignore[return-value]
 
-    async def async_get(self, study_key: str, site_id: int) -> Site:
+    async def async_get(self, study_key: str, site_id: int) -> Site:  # type: ignore[override]
         """Asynchronous version of :meth:`get`.
 
         This method also filters :meth:`async_list` by ``site_id``.
         """
-        if self._async_client is None:
-            raise RuntimeError("Async client not configured")
-        return await self._get_impl(
-            self._async_client, AsyncPaginator, study_key=study_key, item_id=site_id
-        )
+        return await self._get_common(True, study_key=study_key, item_id=site_id)

--- a/imednet/endpoints/studies.py
+++ b/imednet/endpoints/studies.py
@@ -5,13 +5,12 @@ from typing import Any, List, Optional
 from imednet.core.async_client import AsyncClient
 from imednet.core.client import Client
 from imednet.core.context import Context
-from imednet.core.paginator import AsyncPaginator, Paginator
-from imednet.endpoints._mixins import ListGetEndpointMixin
-from imednet.endpoints.base import BaseEndpoint
+from imednet.core.paginator import AsyncPaginator, Paginator  # noqa: F401
+from imednet.endpoints._mixins import ListGetEndpoint
 from imednet.models.studies import Study
 
 
-class StudiesEndpoint(ListGetEndpointMixin, BaseEndpoint):
+class StudiesEndpoint(ListGetEndpoint):
     """
     API endpoint for interacting with studies in the iMedNet system.
 
@@ -34,29 +33,17 @@ class StudiesEndpoint(ListGetEndpointMixin, BaseEndpoint):
         super().__init__(client, ctx, async_client)
         self._studies_cache: Optional[List[Study]] = None
 
-    def list(self, refresh: bool = False, **filters) -> List[Study]:
+    def list(self, refresh: bool = False, **filters) -> List[Study]:  # type: ignore[override]
         """List studies with optional filtering."""
-        result = self._list_impl(
-            self._client,
-            Paginator,
-            refresh=refresh,
-            **filters,
-        )
+        result = self._list_common(False, refresh=refresh, **filters)
         return result  # type: ignore[return-value]
 
-    async def async_list(self, refresh: bool = False, **filters: Any) -> List[Study]:
+    async def async_list(self, refresh: bool = False, **filters: Any) -> List[Study]:  # type: ignore[override]
         """Asynchronous version of :meth:`list`."""
-        if self._async_client is None:
-            raise RuntimeError("Async client not configured")
-        result = await self._list_impl(
-            self._async_client,
-            AsyncPaginator,
-            refresh=refresh,
-            **filters,
-        )
+        result = await self._list_common(True, refresh=refresh, **filters)
         return result
 
-    def get(self, study_key: str) -> Study:
+    def get(self, study_key: str) -> Study:  # type: ignore[override]
         """
         Get a specific study by key.
 
@@ -69,17 +56,13 @@ class StudiesEndpoint(ListGetEndpointMixin, BaseEndpoint):
         Returns:
             Study object
         """
-        result = self._get_impl(self._client, Paginator, study_key=None, item_id=study_key)
+        result = self._get_common(False, study_key=None, item_id=study_key)
         return result  # type: ignore[return-value]
 
-    async def async_get(self, study_key: str) -> Study:
+    async def async_get(self, study_key: str) -> Study:  # type: ignore[override]
         """Asynchronous version of :meth:`get`.
 
         Like the synchronous variant, this call passes ``refresh=True`` to
         :meth:`async_list` to bypass the cache.
         """
-        if self._async_client is None:
-            raise RuntimeError("Async client not configured")
-        return await self._get_impl(
-            self._async_client, AsyncPaginator, study_key=None, item_id=study_key
-        )
+        return await self._get_common(True, study_key=None, item_id=study_key)

--- a/imednet/endpoints/subjects.py
+++ b/imednet/endpoints/subjects.py
@@ -2,13 +2,12 @@
 
 from typing import Any, List, Optional
 
-from imednet.core.paginator import AsyncPaginator, Paginator
-from imednet.endpoints._mixins import ListGetEndpointMixin
-from imednet.endpoints.base import BaseEndpoint
+from imednet.core.paginator import AsyncPaginator, Paginator  # noqa: F401
+from imednet.endpoints._mixins import ListGetEndpoint
 from imednet.models.subjects import Subject
 
 
-class SubjectsEndpoint(ListGetEndpointMixin, BaseEndpoint):
+class SubjectsEndpoint(ListGetEndpoint):
     """
     API endpoint for interacting with subjects in an iMedNet study.
 
@@ -19,29 +18,17 @@ class SubjectsEndpoint(ListGetEndpointMixin, BaseEndpoint):
     MODEL = Subject
     _id_param = "subjectKey"
 
-    def list(self, study_key: Optional[str] = None, **filters) -> List[Subject]:
+    def list(self, study_key: Optional[str] = None, **filters) -> List[Subject]:  # type: ignore[override]
         """List subjects in a study with optional filtering."""
-        result = self._list_impl(
-            self._client,
-            Paginator,
-            study_key=study_key,
-            **filters,
-        )
+        result = self._list_common(False, study_key=study_key, **filters)
         return result  # type: ignore[return-value]
 
-    async def async_list(self, study_key: Optional[str] = None, **filters: Any) -> List[Subject]:
+    async def async_list(self, study_key: Optional[str] = None, **filters: Any) -> List[Subject]:  # type: ignore[override]
         """Asynchronous version of :meth:`list`."""
-        if self._async_client is None:
-            raise RuntimeError("Async client not configured")
-        result = await self._list_impl(
-            self._async_client,
-            AsyncPaginator,
-            study_key=study_key,
-            **filters,
-        )
+        result = await self._list_common(True, study_key=study_key, **filters)
         return result
 
-    def get(self, study_key: str, subject_key: str) -> Subject:
+    def get(self, study_key: str, subject_key: str) -> Subject:  # type: ignore[override]
         """
         Get a specific subject by key.
 
@@ -54,19 +41,12 @@ class SubjectsEndpoint(ListGetEndpointMixin, BaseEndpoint):
         Returns:
             Subject object
         """
-        result = self._get_impl(self._client, Paginator, study_key=study_key, item_id=subject_key)
+        result = self._get_common(False, study_key=study_key, item_id=subject_key)
         return result  # type: ignore[return-value]
 
-    async def async_get(self, study_key: str, subject_key: str) -> Subject:
+    async def async_get(self, study_key: str, subject_key: str) -> Subject:  # type: ignore[override]
         """Asynchronous version of :meth:`get`.
 
         This call also filters :meth:`async_list` by ``subject_key``.
         """
-        if self._async_client is None:
-            raise RuntimeError("Async client not configured")
-        return await self._get_impl(
-            self._async_client,
-            AsyncPaginator,
-            study_key=study_key,
-            item_id=subject_key,
-        )
+        return await self._get_common(True, study_key=study_key, item_id=subject_key)

--- a/imednet/endpoints/users.py
+++ b/imednet/endpoints/users.py
@@ -2,13 +2,12 @@
 
 from typing import Any, List, Optional, Union
 
-from imednet.core.paginator import AsyncPaginator, Paginator
-from imednet.endpoints._mixins import ListGetEndpointMixin
-from imednet.endpoints.base import BaseEndpoint
+from imednet.core.paginator import AsyncPaginator, Paginator  # noqa: F401
+from imednet.endpoints._mixins import ListGetEndpoint
 from imednet.models.users import User
 
 
-class UsersEndpoint(ListGetEndpointMixin, BaseEndpoint):
+class UsersEndpoint(ListGetEndpoint):
     """
     API endpoint for interacting with users in an iMedNet study.
 
@@ -38,38 +37,34 @@ class UsersEndpoint(ListGetEndpointMixin, BaseEndpoint):
             **filters,
         )
 
-    def list(
+    def list(  # type: ignore[override]
         self, study_key: Optional[str] = None, include_inactive: bool = False, **filters: Any
     ) -> List[User]:
         """List users in a study with optional filtering."""
-        result = self._list_impl(
-            self._client,
-            Paginator,
+        result = self._list_common(
+            False,
             study_key=study_key,
             include_inactive=include_inactive,
             **filters,
         )
         return result  # type: ignore[return-value]
 
-    async def async_list(
+    async def async_list(  # type: ignore[override]
         self,
         study_key: Optional[str] = None,
         include_inactive: bool = False,
         **filters: Any,
     ) -> List[User]:
         """Asynchronous version of :meth:`list`."""
-        if self._async_client is None:
-            raise RuntimeError("Async client not configured")
-        result = await self._list_impl(
-            self._async_client,
-            AsyncPaginator,
+        result = await self._list_common(
+            True,
             study_key=study_key,
             include_inactive=include_inactive,
             **filters,
         )
         return result
 
-    def get(self, study_key: str, user_id: Union[str, int]) -> User:
+    def get(self, study_key: str, user_id: Union[str, int]) -> User:  # type: ignore[override]
         """
         Get a specific user by ID.
 
@@ -80,13 +75,9 @@ class UsersEndpoint(ListGetEndpointMixin, BaseEndpoint):
         Returns:
             User object
         """
-        result = self._get_impl(self._client, Paginator, study_key=study_key, item_id=user_id)
+        result = self._get_common(False, study_key=study_key, item_id=user_id)
         return result  # type: ignore[return-value]
 
-    async def async_get(self, study_key: str, user_id: Union[str, int]) -> User:
+    async def async_get(self, study_key: str, user_id: Union[str, int]) -> User:  # type: ignore[override]
         """Asynchronous version of :meth:`get`."""
-        if self._async_client is None:
-            raise RuntimeError("Async client not configured")
-        return await self._get_impl(
-            self._async_client, AsyncPaginator, study_key=study_key, item_id=user_id
-        )
+        return await self._get_common(True, study_key=study_key, item_id=user_id)

--- a/imednet/endpoints/visits.py
+++ b/imednet/endpoints/visits.py
@@ -2,13 +2,12 @@
 
 from typing import Any, List, Optional
 
-from imednet.core.paginator import AsyncPaginator, Paginator
-from imednet.endpoints._mixins import ListGetEndpointMixin
-from imednet.endpoints.base import BaseEndpoint
+from imednet.core.paginator import AsyncPaginator, Paginator  # noqa: F401
+from imednet.endpoints._mixins import ListGetEndpoint
 from imednet.models.visits import Visit
 
 
-class VisitsEndpoint(ListGetEndpointMixin, BaseEndpoint):
+class VisitsEndpoint(ListGetEndpoint):
     """
     API endpoint for interacting with visits (interval instances) in an iMedNet study.
 
@@ -19,29 +18,17 @@ class VisitsEndpoint(ListGetEndpointMixin, BaseEndpoint):
     MODEL = Visit
     _id_param = "visitId"
 
-    def list(self, study_key: Optional[str] = None, **filters) -> List[Visit]:
+    def list(self, study_key: Optional[str] = None, **filters) -> List[Visit]:  # type: ignore[override]
         """List visits in a study with optional filtering."""
-        result = self._list_impl(
-            self._client,
-            Paginator,
-            study_key=study_key,
-            **filters,
-        )
+        result = self._list_common(False, study_key=study_key, **filters)
         return result  # type: ignore[return-value]
 
-    async def async_list(self, study_key: Optional[str] = None, **filters: Any) -> List[Visit]:
+    async def async_list(self, study_key: Optional[str] = None, **filters: Any) -> List[Visit]:  # type: ignore[override]
         """Asynchronous version of :meth:`list`."""
-        if self._async_client is None:
-            raise RuntimeError("Async client not configured")
-        result = await self._list_impl(
-            self._async_client,
-            AsyncPaginator,
-            study_key=study_key,
-            **filters,
-        )
+        result = await self._list_common(True, study_key=study_key, **filters)
         return result
 
-    def get(self, study_key: str, visit_id: int) -> Visit:
+    def get(self, study_key: str, visit_id: int) -> Visit:  # type: ignore[override]
         """
         Get a specific visit by ID.
 
@@ -54,16 +41,12 @@ class VisitsEndpoint(ListGetEndpointMixin, BaseEndpoint):
         Returns:
             Visit object
         """
-        result = self._get_impl(self._client, Paginator, study_key=study_key, item_id=visit_id)
+        result = self._get_common(False, study_key=study_key, item_id=visit_id)
         return result  # type: ignore[return-value]
 
-    async def async_get(self, study_key: str, visit_id: int) -> Visit:
+    async def async_get(self, study_key: str, visit_id: int) -> Visit:  # type: ignore[override]
         """Asynchronous version of :meth:`get`.
 
         The asynchronous call also filters by ``visit_id``.
         """
-        if self._async_client is None:
-            raise RuntimeError("Async client not configured")
-        return await self._get_impl(
-            self._async_client, AsyncPaginator, study_key=study_key, item_id=visit_id
-        )
+        return await self._get_common(True, study_key=study_key, item_id=visit_id)

--- a/imednet/sdk.py
+++ b/imednet/sdk.py
@@ -280,9 +280,6 @@ class ImednetSDK:
     ) -> JobStatus:
         """Asynchronously poll a job until it reaches a terminal state."""
 
-        if self._async_client is None:
-            raise RuntimeError("Async client not configured")
-
         return await JobPoller(self.jobs.async_get, True).run_async(
             study_key, batch_id, interval, timeout
         )


### PR DESCRIPTION
## Summary
- add `_require_async_client` helper to base endpoint
- implement `ListGetEndpoint` with shared list/get logic
- refactor all list/get endpoints to use new base
- remove redundant async checks and update SDK polling helper

## Testing
- `poetry run ruff check --fix imednet/endpoints/*.py imednet/sdk.py`
- `poetry run black --check imednet/endpoints imednet/sdk.py`
- `poetry run mypy imednet`
- `poetry run pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686c218ae16c832ca7c621ff3fe37cc1