### PR TITLE
Introduce RetryPolicy abstraction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Bump project version to `0.1.4`.
 - Extracted common logic from `Client` and `AsyncClient` into new `HTTPClientBase`.
 - Added `imednet.config` module with `load_config` helper for reading credentials.
+- Introduced `RetryPolicy` abstraction for configuring request retries.
+  `Client`, `AsyncClient` and `ImednetSDK` accept a `retry_policy` parameter.
 
 ## [0.1.4] 
 

--- a/docs/imednet.core.rst
+++ b/docs/imednet.core.rst
@@ -74,3 +74,23 @@ imednet.core.paginator module
    :undoc-members:
    :show-inheritance:
 
+Retry policy
+------------
+
+The :class:`~imednet.core.retry.RetryPolicy` interface controls if failed
+requests should be retried. The SDK uses
+``DefaultRetryPolicy`` which retries when ``httpx`` raises a
+``RequestError``. Provide your own policy to customize this behaviour.
+
+.. code-block:: python
+
+   from imednet.core.client import Client
+   from imednet.core.retry import RetryPolicy, RetryState
+   from imednet.core.exceptions import ServerError
+
+   class ServerRetry(RetryPolicy):
+       def should_retry(self, state: RetryState) -> bool:
+           return isinstance(state.exception, ServerError)
+
+   client = Client("A", "B", retry_policy=ServerRetry())
+

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -15,6 +15,7 @@ Welcome to imednet's documentation!
    cli
    workflow_interactions
    caching
+   retry_policy
    job_polling
    record_mapping
    airflow

--- a/docs/quick_start.rst
+++ b/docs/quick_start.rst
@@ -37,3 +37,16 @@ The example script :mod:`examples.quick_start` provides a runnable version that
 validates required environment variables.
 
 Cached endpoints can be refreshed with ``refresh=True``. The caches are not thread safe so long running applications should recreate the SDK when needed.
+
+Custom retry logic can be provided via a ``RetryPolicy``:
+
+.. code-block:: python
+
+   from imednet.core.retry import RetryPolicy, RetryState
+   from imednet.core.exceptions import ServerError
+
+   class ServerRetry(RetryPolicy):
+       def should_retry(self, state: RetryState) -> bool:
+           return isinstance(state.exception, ServerError)
+
+   sdk = ImednetSDK(retry_policy=ServerRetry())

--- a/docs/retry_policy.rst
+++ b/docs/retry_policy.rst
@@ -1,0 +1,21 @@
+Retry Policy
+============
+
+``RetryPolicy`` decouples retry decisions from the underlying tenacity logic.
+The default implementation only retries for network errors raised by ``httpx``.
+You can implement your own strategy by inspecting :class:`imednet.core.retry.RetryState`.
+
+Example
+-------
+
+.. code-block:: python
+
+   from imednet.core.client import Client
+   from imednet.core.retry import RetryPolicy, RetryState
+   from imednet.core.exceptions import ServerError
+
+   class ServerRetry(RetryPolicy):
+       def should_retry(self, state: RetryState) -> bool:
+           return isinstance(state.exception, ServerError)
+
+   client = Client("A", "B", retry_policy=ServerRetry())

--- a/imednet/__init__.py
+++ b/imednet/__init__.py
@@ -2,6 +2,7 @@ from importlib import metadata as _metadata
 
 from .config import Config, load_config
 from .core.base_client import BaseClient
+from .core.retry import DefaultRetryPolicy, RetryPolicy, RetryState
 from .sdk import AsyncImednetSDK, ImednetSDK
 
 # Provide a backward-compatible alias
@@ -12,6 +13,9 @@ __all__ = [
     "AsyncImednetSDK",
     "ImednetClient",
     "BaseClient",
+    "RetryPolicy",
+    "RetryState",
+    "DefaultRetryPolicy",
     "Config",
     "load_config",
     "__version__",

--- a/imednet/core/__init__.py
+++ b/imednet/core/__init__.py
@@ -23,6 +23,7 @@ from .exceptions import (
 )
 from .http_client_base import HTTPClientBase
 from .paginator import AsyncPaginator, Paginator
+from .retry import DefaultRetryPolicy, RetryPolicy, RetryState
 
 __all__ = [
     "BaseClient",
@@ -45,4 +46,7 @@ __all__ = [
     "ValidationError",
     "Paginator",
     "AsyncPaginator",
+    "RetryPolicy",
+    "RetryState",
+    "DefaultRetryPolicy",
 ]

--- a/imednet/core/http_client_base.py
+++ b/imednet/core/http_client_base.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import logging
-from typing import Any, Awaitable, Optional, Type, Union, cast
+from typing import Any, Awaitable, Optional, Union, cast
 
 import httpx
 

--- a/imednet/core/http_client_base.py
+++ b/imednet/core/http_client_base.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import logging
-from typing import Any, Awaitable, Optional, Union, cast
+from typing import Any, Awaitable, Optional, Type, Union, cast
 
 import httpx
 

--- a/imednet/core/retry.py
+++ b/imednet/core/retry.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Optional, Protocol, runtime_checkable
+
+import httpx
+
+
+@dataclass
+class RetryState:
+    """State information passed to :class:`RetryPolicy`."""
+
+    attempt_number: int
+    exception: Optional[BaseException] = None
+    result: Optional[Any] = None
+
+
+@runtime_checkable
+class RetryPolicy(Protocol):
+    """Interface to determine whether a request should be retried."""
+
+    def should_retry(self, state: RetryState) -> bool:
+        """Return ``True`` to retry the request for the given state."""
+
+
+class DefaultRetryPolicy:
+    """Retry only when a network :class:`httpx.RequestError` occurred."""
+
+    def should_retry(self, state: RetryState) -> bool:  # pragma: no cover - trivial
+        return isinstance(state.exception, httpx.RequestError)

--- a/imednet/sdk.py
+++ b/imednet/sdk.py
@@ -16,6 +16,7 @@ from typing import Any, Dict, List, Optional, Union
 from .core.async_client import AsyncClient
 from .core.client import Client
 from .core.context import Context
+from .core.retry import RetryPolicy
 from .endpoints.codings import CodingsEndpoint
 from .endpoints.forms import FormsEndpoint
 from .endpoints.intervals import IntervalsEndpoint
@@ -85,6 +86,7 @@ class ImednetSDK:
         timeout: float = 30.0,
         retries: int = 3,
         backoff_factor: float = 1.0,
+        retry_policy: RetryPolicy | None = None,
         enable_async: bool = False,
     ) -> None:
         """Initialize the SDK with credentials and configuration."""
@@ -104,6 +106,7 @@ class ImednetSDK:
             timeout=timeout,
             retries=retries,
             backoff_factor=backoff_factor,
+            retry_policy=retry_policy,
         )
         self._async_client = (
             AsyncClient(
@@ -113,6 +116,7 @@ class ImednetSDK:
                 timeout=timeout,
                 retries=retries,
                 backoff_factor=backoff_factor,
+                retry_policy=retry_policy,
             )
             if enable_async
             else None
@@ -120,6 +124,16 @@ class ImednetSDK:
 
         self._init_endpoints()
         self.workflows = Workflows(self)
+
+    @property
+    def retry_policy(self) -> RetryPolicy:
+        return self._client.retry_policy
+
+    @retry_policy.setter
+    def retry_policy(self, policy: RetryPolicy) -> None:
+        self._client.retry_policy = policy
+        if self._async_client is not None:
+            self._async_client.retry_policy = policy
 
     def _validate_env(self) -> None:
         """Ensure required credentials are present."""

--- a/tests/core/test_retry_policy.py
+++ b/tests/core/test_retry_policy.py
@@ -1,0 +1,35 @@
+import httpx
+from imednet.core.client import Client
+from imednet.core.exceptions import ServerError
+from imednet.core.retry import DefaultRetryPolicy, RetryState
+
+
+def test_default_policy_request_error():
+    policy = DefaultRetryPolicy()
+    state = RetryState(
+        1, exception=httpx.RequestError("boom", request=httpx.Request("GET", "https://x"))
+    )
+    assert policy.should_retry(state)
+    assert not policy.should_retry(RetryState(1))
+
+
+def test_custom_policy(monkeypatch):
+    class ServerPolicy:
+        def should_retry(self, state: RetryState) -> bool:
+            return isinstance(state.exception, ServerError)
+
+    client = Client("k", "s", base_url="https://api.test", retries=3, retry_policy=ServerPolicy())
+    calls = {"count": 0}
+
+    def request(method: str, url: str, **kwargs: object) -> httpx.Response:
+        calls["count"] += 1
+        if calls["count"] < 3:
+            raise ServerError({}, status_code=500)
+        return httpx.Response(200, json={"ok": True})
+
+    monkeypatch.setattr(client._executor, "send", request)
+
+    resp = client.get("/x")
+
+    assert resp.status_code == 200
+    assert calls["count"] == 3


### PR DESCRIPTION
This pull request introduces a `RetryPolicy` abstraction to improve the flexibility of request retry logic across the SDK. The changes include implementing the `RetryPolicy` interface, integrating it into key components, updating documentation, and adding tests to validate the new functionality.

### Retry Policy Implementation:
* [`imednet/core/retry.py`](diffhunk://#diff-ed6ceb08478aed3772cd006eed9aa878ceeb49e17bced7d923096017a25a4f12R1-R30): Added the `RetryPolicy` interface and `DefaultRetryPolicy` class to decouple retry logic from the SDK. The `RetryPolicy` determines whether a request should be retried based on the `RetryState`.

### Integration into SDK Components:
* [`imednet/core/_requester.py`](diffhunk://#diff-1e78f7de6cdd03f64172d90b85eb7717c72bb03520e8f3fb9cdda903fa7764dcL53-R75): Replaced the previous retry logic with the `RetryPolicy` abstraction, ensuring requests use the new policy interface. Introduced a `retry_policy` parameter and updated the `_should_retry` method to use `RetryPolicy`. [[1]](diffhunk://#diff-1e78f7de6cdd03f64172d90b85eb7717c72bb03520e8f3fb9cdda903fa7764dcL53-R75) [[2]](diffhunk://#diff-1e78f7de6cdd03f64172d90b85eb7717c72bb03520e8f3fb9cdda903fa7764dcL94-R110) [[3]](diffhunk://#diff-1e78f7de6cdd03f64172d90b85eb7717c72bb03520e8f3fb9cdda903fa7764dcL125-R141)
* [`imednet/core/http_client_base.py`](diffhunk://#diff-7d17bcf2e1ba3352ff4da878ddc7bd4c413e3bd37f6500a61da7f7914776f673R31): Added support for `RetryPolicy` in the `HTTPClientBase` class, allowing clients to specify custom retry logic. [[1]](diffhunk://#diff-7d17bcf2e1ba3352ff4da878ddc7bd4c413e3bd37f6500a61da7f7914776f673R31) [[2]](diffhunk://#diff-7d17bcf2e1ba3352ff4da878ddc7bd4c413e3bd37f6500a61da7f7914776f673L63-R70)
* [`imednet/sdk.py`](diffhunk://#diff-6974bb531e16021a0d7994c9f7cd44dfaa783109edd7571049089413d5772f41R89): Integrated `RetryPolicy` into the SDK, enabling users to configure retry behavior for synchronous and asynchronous clients. [[1]](diffhunk://#diff-6974bb531e16021a0d7994c9f7cd44dfaa783109edd7571049089413d5772f41R89) [[2]](diffhunk://#diff-6974bb531e16021a0d7994c9f7cd44dfaa783109edd7571049089413d5772f41R128-R137)

### Documentation Updates:
* [`docs/retry_policy.rst`](diffhunk://#diff-cb55ee35ee4a437fe73f500f2e11df1c0db51402665467c25fed2b2307f63adfR1-R21): Created a new section explaining the `RetryPolicy` interface, its default implementation, and how to customize retry logic.
* `docs/index.rst`, `docs/quick_start.rst`, `docs/imednet.core.rst`: Updated documentation to include references and examples for the new `RetryPolicy` functionality. [[1]](diffhunk://#diff-8d068e8797e88947c320f79e856c3e16a72b730124a8f9d7031e2c4680dfa534R18) [[2]](diffhunk://#diff-52a86249726a8745f0730a891e0f6d80962a91c443743b77157fa2f1c3d61bd1R40-R52) [[3]](diffhunk://#diff-71c2b0e89a5d134d7b990e0cbdb212955ed399c13490bd82d7454d91a3c762d0R77-R96)

### Tests for Retry Policy:
* [`tests/core/test_retry_policy.py`](diffhunk://#diff-a7808321456f26a5244be8a12ece15c69ad900d912da7fd3067cb250c055fd01R1-R35): Added unit tests to verify the behavior of `DefaultRetryPolicy` and custom retry policies.
* [`tests/integration/test_core_client_integration.py`](diffhunk://#diff-94ecba7a2d1a449fdb3374405901c271accf46ada8874e1462f1b38c95cde174L23-R27): Updated integration tests to validate retry logic using the new `RetryPolicy` abstraction. [[1]](diffhunk://#diff-94ecba7a2d1a449fdb3374405901c271accf46ada8874e1462f1b38c95cde174L23-R27) [[2]](diffhunk://#diff-94ecba7a2d1a449fdb3374405901c271accf46ada8874e1462f1b38c95cde174L33-L37)

## Summary
- add RetryPolicy and DefaultRetryPolicy
- refactor RequestExecutor and HTTP clients to use retry policies
- expose retry_policy on Client, AsyncClient and ImednetSDK
- document custom retry logic
- add regression tests

## Testing
- `poetry run ruff check --fix .`
- `poetry run black --check .`
- `poetry run mypy imednet`
- `poetry run pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686c373b57e0832cae48d067b736695e