### PR TITLE
Refactor SchemaValidator refresh/validate logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Introduced `RetryPolicy` abstraction for configuring request retries.
   `Client`, `AsyncClient` and `ImednetSDK` accept a `retry_policy` parameter.
 - CLI commands now use shared helpers for study arguments and list output to reduce duplication.
+- Deduplicated refresh and validation logic in `SchemaValidator` with helper methods.
 
 ## [0.1.4] 
 


### PR DESCRIPTION
This pull request introduces improvements to code deduplication and type hints, focusing on streamlining validation logic and enhancing maintainability. The most notable changes include the addition of helper methods for shared logic in `SchemaValidator` and `Cache`, as well as updates to type annotations to support iterable inputs.

### Code deduplication:
* [`CHANGELOG.md`](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR15): Added a note about deduplicating refresh and validation logic in `SchemaValidator` using helper methods.
* [`imednet/validation/cache.py`](diffhunk://#diff-9e5ee98bbc94d65656247fe5126d87b543d9b1cfbc44b1d296c19c4c57e52887L160-R198): Refactored `_refresh_async`, `_refresh_sync`, and `_validate_record_async` to use shared helper methods (`_refresh_common` and `_validate_record_common`) to reduce code duplication.

### Type hint improvements:
* [`imednet/validation/cache.py`](diffhunk://#diff-9e5ee98bbc94d65656247fe5126d87b543d9b1cfbc44b1d296c19c4c57e52887L4-R4): Updated type hints to include `Iterable` for variables in `_refresh_common`, improving clarity and compatibility with various iterable types.

## Summary
- deduplicate refresh and validation logic in `SchemaValidator`
- use helper methods in async and sync variants
- update changelog

## Testing
- `poetry run ruff check --fix .`
- `poetry run black --check .`
- `poetry run mypy imednet`
- `poetry run pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686c55a599d8832ca15838187f648d96