### PR TITLE
Refactor endpoint initialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `Client`, `AsyncClient` and `ImednetSDK` accept a `retry_policy` parameter.
 - CLI commands now use shared helpers for study arguments and list output to reduce duplication.
 - Deduplicated refresh and validation logic in `SchemaValidator` with helper methods.
+- Refactored endpoint initialization in `ImednetSDK` using a registry.
 
 ## [0.1.4] 
 

--- a/imednet/sdk.py
+++ b/imednet/sdk.py
@@ -17,6 +17,7 @@ from .core.async_client import AsyncClient
 from .core.client import Client
 from .core.context import Context
 from .core.retry import RetryPolicy
+from .endpoints.base import BaseEndpoint
 from .endpoints.codings import CodingsEndpoint
 from .endpoints.forms import FormsEndpoint
 from .endpoints.intervals import IntervalsEndpoint
@@ -64,6 +65,24 @@ class Workflows:
         self.subject_data = SubjectDataWorkflow(sdk_instance)
 
 
+# Mapping of attribute names to their endpoint classes
+_ENDPOINT_REGISTRY: dict[str, type[BaseEndpoint]] = {
+    "codings": CodingsEndpoint,
+    "forms": FormsEndpoint,
+    "intervals": IntervalsEndpoint,
+    "jobs": JobsEndpoint,
+    "queries": QueriesEndpoint,
+    "record_revisions": RecordRevisionsEndpoint,
+    "records": RecordsEndpoint,
+    "sites": SitesEndpoint,
+    "studies": StudiesEndpoint,
+    "subjects": SubjectsEndpoint,
+    "users": UsersEndpoint,
+    "variables": VariablesEndpoint,
+    "visits": VisitsEndpoint,
+}
+
+
 class ImednetSDK:
     """
     Public entry-point for library users.
@@ -77,6 +96,20 @@ class ImednetSDK:
         subjects: Access to subject-related endpoints.
         etc...
     """
+
+    codings: CodingsEndpoint
+    forms: FormsEndpoint
+    intervals: IntervalsEndpoint
+    jobs: JobsEndpoint
+    queries: QueriesEndpoint
+    record_revisions: RecordRevisionsEndpoint
+    records: RecordsEndpoint
+    sites: SitesEndpoint
+    studies: StudiesEndpoint
+    subjects: SubjectsEndpoint
+    users: UsersEndpoint
+    variables: VariablesEndpoint
+    visits: VisitsEndpoint
 
     def __init__(
         self,
@@ -137,19 +170,8 @@ class ImednetSDK:
 
     def _init_endpoints(self) -> None:
         """Instantiate endpoint clients."""
-        self.codings = CodingsEndpoint(self._client, self.ctx, self._async_client)
-        self.forms = FormsEndpoint(self._client, self.ctx, self._async_client)
-        self.intervals = IntervalsEndpoint(self._client, self.ctx, self._async_client)
-        self.jobs = JobsEndpoint(self._client, self.ctx, self._async_client)
-        self.queries = QueriesEndpoint(self._client, self.ctx, self._async_client)
-        self.record_revisions = RecordRevisionsEndpoint(self._client, self.ctx, self._async_client)
-        self.records = RecordsEndpoint(self._client, self.ctx, self._async_client)
-        self.sites = SitesEndpoint(self._client, self.ctx, self._async_client)
-        self.studies = StudiesEndpoint(self._client, self.ctx, self._async_client)
-        self.subjects = SubjectsEndpoint(self._client, self.ctx, self._async_client)
-        self.users = UsersEndpoint(self._client, self.ctx, self._async_client)
-        self.variables = VariablesEndpoint(self._client, self.ctx, self._async_client)
-        self.visits = VisitsEndpoint(self._client, self.ctx, self._async_client)
+        for attr, endpoint_cls in _ENDPOINT_REGISTRY.items():
+            setattr(self, attr, endpoint_cls(self._client, self.ctx, self._async_client))
 
     def __enter__(self) -> ImednetSDK:
         """Support for context manager protocol."""


### PR DESCRIPTION
This pull request refactors the initialization of endpoints in the `ImednetSDK` class to improve maintainability and reduce redundancy. The changes introduce a centralized registry for endpoint classes, replacing individual attribute assignments with a loop-based approach.

### Refactoring of endpoint initialization:

* [`CHANGELOG.md`](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR16): Documented the refactored endpoint initialization in `ImednetSDK` using a registry.
* [`imednet/sdk.py`](diffhunk://#diff-6974bb531e16021a0d7994c9f7cd44dfaa783109edd7571049089413d5772f41R68-R85): Added `_ENDPOINT_REGISTRY`, a dictionary mapping attribute names to their corresponding endpoint classes, to centralize endpoint definitions.
* [`imednet/sdk.py`](diffhunk://#diff-6974bb531e16021a0d7994c9f7cd44dfaa783109edd7571049089413d5772f41L140-R174): Updated the `_init_endpoints` method in `ImednetSDK` to dynamically set endpoint attributes using `_ENDPOINT_REGISTRY`, replacing repetitive individual assignments.

### Codebase enhancements:

* [`imednet/sdk.py`](diffhunk://#diff-6974bb531e16021a0d7994c9f7cd44dfaa783109edd7571049089413d5772f41R100-R113): Declared endpoint attributes (e.g., `codings`, `forms`, `intervals`, etc.) explicitly in the `ImednetSDK` class to improve type hinting and code clarity.
* [`imednet/sdk.py`](diffhunk://#diff-6974bb531e16021a0d7994c9f7cd44dfaa783109edd7571049089413d5772f41R20): Imported `BaseEndpoint` to support the new registry-based initialization approach.

## Summary
- centralize endpoint class mapping in `sdk`
- instantiate SDK endpoints dynamically from registry
- update changelog

## Testing
- `poetry run ruff check --fix .`
- `poetry run black --check .`
- `poetry run mypy imednet`
- `poetry run pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686c697261f8832c9a56246de88d53b4