### PR TITLE
Refactor SDK config loading

### DIFF
--- a/imednet/sdk.py
+++ b/imednet/sdk.py
@@ -164,8 +164,12 @@ class ImednetSDK:
 
     def _validate_env(self, config: Config) -> None:
         """Ensure required credentials are present."""
-        if not config.api_key or not config.security_key:
+        if not config.api_key and not config.security_key:
             raise ValueError("API key and security key are required")
+        elif not config.api_key:
+            raise ValueError("API key is required")
+        elif not config.security_key:
+            raise ValueError("Security key is required")
 
     @property
     def retry_policy(self) -> RetryPolicy:

--- a/imednet/sdk.py
+++ b/imednet/sdk.py
@@ -12,7 +12,7 @@ from __future__ import annotations
 import asyncio
 from typing import Any, Dict, List, Optional, Union
 
-from .config import load_config
+from .config import Config, load_config
 from .core.async_client import AsyncClient
 from .core.client import Client
 from .core.context import Context
@@ -110,6 +110,7 @@ class ImednetSDK:
     users: UsersEndpoint
     variables: VariablesEndpoint
     visits: VisitsEndpoint
+    config: Config
 
     def __init__(
         self,
@@ -126,6 +127,9 @@ class ImednetSDK:
 
         config = load_config(api_key=api_key, security_key=security_key, base_url=base_url)
 
+        self._validate_env(config)
+
+        self.config = config
         self._api_key = config.api_key
         self._security_key = config.security_key
         self._base_url = config.base_url
@@ -157,6 +161,11 @@ class ImednetSDK:
 
         self._init_endpoints()
         self.workflows = Workflows(self)
+
+    def _validate_env(self, config: Config) -> None:
+        """Ensure required credentials are present."""
+        if not config.api_key or not config.security_key:
+            raise ValueError("API key and security key are required")
 
     @property
     def retry_policy(self) -> RetryPolicy:


### PR DESCRIPTION
This pull request introduces enhancements to the `ImednetSDK` class in `imednet/sdk.py` to improve configuration handling and validation. The main changes include adding a new `_validate_env` method for credential validation and integrating the `Config` object into the SDK initialization process.

### Configuration Handling Enhancements:
* [`imednet/sdk.py`](diffhunk://#diff-6974bb531e16021a0d7994c9f7cd44dfaa783109edd7571049089413d5772f41L15-R15): Imported the `Config` class from `.config` and added it as an attribute to the `ImednetSDK` class. This provides direct access to the configuration object throughout the SDK. [[1]](diffhunk://#diff-6974bb531e16021a0d7994c9f7cd44dfaa783109edd7571049089413d5772f41L15-R15) [[2]](diffhunk://#diff-6974bb531e16021a0d7994c9f7cd44dfaa783109edd7571049089413d5772f41R113)

### Credential Validation:
* [`imednet/sdk.py`](diffhunk://#diff-6974bb531e16021a0d7994c9f7cd44dfaa783109edd7571049089413d5772f41R130-R132): Introduced a `_validate_env` method in the `ImednetSDK` class to ensure that the `api_key` and `security_key` are present in the configuration. If either is missing, a `ValueError` is raised. This method is called during SDK initialization. [[1]](diffhunk://#diff-6974bb531e16021a0d7994c9f7cd44dfaa783109edd7571049089413d5772f41R130-R132) [[2]](diffhunk://#diff-6974bb531e16021a0d7994c9f7cd44dfaa783109edd7571049089413d5772f41R165-R169)

## Summary
- centralize ImednetSDK configuration using `load_config`
- expose `config` attribute and validate credentials with `_validate_env`

## Testing
- `poetry run ruff check --fix .`
- `poetry run black --check .`
- `poetry run mypy imednet`
- `poetry run pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686c6d93ba08832cad1d4f8c189a707f