### PR TITLE
DRY Refactor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added an `isort` step to pre-commit and CI checks.
 - Fixed import order and formatting across the project.
 - CI now fails if test coverage drops below 90%.
+- Centralized DataFrame creation in export helpers with new ``_records_df``
+  to ensure duplicate columns are removed consistently.
 
 ## [0.1.4] 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - CI now fails if test coverage drops below 90%.
 - Centralized DataFrame creation in export helpers with new ``_records_df``
   to ensure duplicate columns are removed consistently.
+- Refactored ``JobPoller`` to share a ``_run_common`` loop between sync and async polling.
 
 ## [0.1.4] 
 

--- a/imednet/endpoints/base.py
+++ b/imednet/endpoints/base.py
@@ -2,7 +2,7 @@
 Base endpoint mix-in for all API resource endpoints.
 """
 
-from typing import Any, Dict
+from typing import Any, Dict, Optional
 
 from imednet.core.async_client import AsyncClient
 from imednet.core.client import Client
@@ -29,6 +29,12 @@ class BaseEndpoint:
         self._client = client
         self._async_client = async_client
         self._ctx = ctx
+        cache_name: Optional[str] = getattr(self, "_cache_name", None)
+        if cache_name:
+            if getattr(self, "requires_study_key", True):
+                setattr(self, cache_name, {})
+            else:
+                setattr(self, cache_name, None)
 
     def _auto_filter(self, filters: Dict[str, Any]) -> Dict[str, Any]:
         # inject default studyKey if missing

--- a/imednet/endpoints/forms.py
+++ b/imednet/endpoints/forms.py
@@ -1,10 +1,5 @@
 """Endpoint for managing forms (eCRFs) in a study."""
 
-from typing import Dict, List
-
-from imednet.core.async_client import AsyncClient
-from imednet.core.client import Client
-from imednet.core.context import Context
 from imednet.core.paginator import AsyncPaginator, Paginator  # noqa: F401
 from imednet.endpoints._mixins import ListGetEndpoint
 from imednet.models.forms import Form
@@ -24,12 +19,3 @@ class FormsEndpoint(ListGetEndpoint):
     PAGE_SIZE = 500
     _pop_study_filter = True
     _missing_study_exception = KeyError
-
-    def __init__(
-        self,
-        client: Client,
-        ctx: Context,
-        async_client: AsyncClient | None = None,
-    ) -> None:
-        super().__init__(client, ctx, async_client)
-        self._forms_cache: Dict[str, List[Form]] = {}

--- a/imednet/endpoints/intervals.py
+++ b/imednet/endpoints/intervals.py
@@ -1,10 +1,5 @@
 """Endpoint for managing intervals (visit definitions) in a study."""
 
-from typing import Dict, List
-
-from imednet.core.async_client import AsyncClient
-from imednet.core.client import Client
-from imednet.core.context import Context
 from imednet.core.paginator import AsyncPaginator, Paginator  # noqa: F401
 from imednet.endpoints._mixins import ListGetEndpoint
 from imednet.models.intervals import Interval
@@ -23,12 +18,3 @@ class IntervalsEndpoint(ListGetEndpoint):
     _cache_name = "_intervals_cache"
     PAGE_SIZE = 500
     _pop_study_filter = True
-
-    def __init__(
-        self,
-        client: Client,
-        ctx: Context,
-        async_client: AsyncClient | None = None,
-    ) -> None:
-        super().__init__(client, ctx, async_client)
-        self._intervals_cache: Dict[str, List[Interval]] = {}

--- a/imednet/endpoints/studies.py
+++ b/imednet/endpoints/studies.py
@@ -1,10 +1,5 @@
 """Endpoint for managing studies in the iMedNet system."""
 
-from typing import List, Optional
-
-from imednet.core.async_client import AsyncClient
-from imednet.core.client import Client
-from imednet.core.context import Context
 from imednet.core.paginator import AsyncPaginator, Paginator  # noqa: F401
 from imednet.endpoints._mixins import ListGetEndpoint
 from imednet.models.studies import Study
@@ -22,13 +17,3 @@ class StudiesEndpoint(ListGetEndpoint):
     _id_param = "studyKey"
     _cache_name = "_studies_cache"
     requires_study_key = False
-    _studies_cache: Optional[List[Study]]
-
-    def __init__(
-        self,
-        client: Client,
-        ctx: Context,
-        async_client: AsyncClient | None = None,
-    ) -> None:
-        super().__init__(client, ctx, async_client)
-        self._studies_cache: Optional[List[Study]] = None

--- a/imednet/endpoints/variables.py
+++ b/imednet/endpoints/variables.py
@@ -1,10 +1,5 @@
 """Endpoint for managing variables (data points on eCRFs) in a study."""
 
-from typing import Dict, List
-
-from imednet.core.async_client import AsyncClient
-from imednet.core.client import Client
-from imednet.core.context import Context
 from imednet.core.paginator import AsyncPaginator, Paginator  # noqa: F401
 from imednet.endpoints._mixins import ListGetEndpoint
 from imednet.models.variables import Variable
@@ -24,12 +19,3 @@ class VariablesEndpoint(ListGetEndpoint):
     PAGE_SIZE = 500
     _pop_study_filter = True
     _missing_study_exception = KeyError
-
-    def __init__(
-        self,
-        client: Client,
-        ctx: Context,
-        async_client: AsyncClient | None = None,
-    ) -> None:
-        super().__init__(client, ctx, async_client)
-        self._variables_cache: Dict[str, List[Variable]] = {}


### PR DESCRIPTION
## Summary
- set up endpoint caches in BaseEndpoint
- drop duplicate __init__ implementations in endpoint modules

## Testing
- `poetry run ruff check --fix .`
- `poetry run black --check .`
- `poetry run isort --check --profile black .`
- `poetry run mypy imednet`
- `poetry run pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686d8c3b51a8832c85f28c0e36cfe8d6