### PR TITLE
Add doc guidelines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added an `isort` step to pre-commit and CI checks.
 - Fixed import order and formatting across the project.
 - CI now fails if test coverage drops below 90%.
+- Documented Sphinx conventions in new `docs/AGENTS.md`.
 
 ## [0.1.4] 
 

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -1,0 +1,55 @@
+# AGENTS.md – Documentation Rules (Sphinx)
+
+## Purpose  
+Ensure the Sphinx site builds consistently and remains readable for both humans and Codex-style agents.
+
+---
+
+## Build & preview
+
+```bash
+# generate HTML docs locally
+make docs      # alias for `sphinx-build -b html docs/ build/docs`
+
+# open the result
+open build/docs/index.html  # or `python -m webbrowser`
+````
+
+* CI calls the same `make docs` target; the build **MUST** succeed without warnings.
+
+---
+
+## reStructuredText conventions
+
+| Guideline                                                                    | Example                                                              |
+| ---------------------------------------------------------------------------- | -------------------------------------------------------------------- |
+| Wrap code longer than ≈ 15 lines in a collapsible block.                     | `rst  .. collapse:: Usage example      `python      >>> ...   \`\`\` |
+| Prefer **NumPy-style** docstrings in source files; autodoc will render them. | —                                                                    |
+| Use `:class:`, `:func:` & `:py:meth:` roles for cross-referencing.           | —                                                                    |
+| Keep headings sequential (`===`, `---`, `^^^`).                              | —                                                                    |
+
+**DO NOT** embed raw HTML; stick to RST directives so themes remain portable.
+
+---
+
+## Structure & navigation
+
+* Top-level toctree lives in `docs/index.rst`; **MUST** list every new page.
+* Tutorials belong in `docs/tutorials/`; API reference is auto-generated from `imednet/`.
+* If you add third-party libraries that need mocking, declare them in `docs/conf.py` → `autodoc_mock_imports`.
+
+---
+
+## Style checks
+
+* Run `poetry run doc8 docs/` before committing to catch line-length or indentation issues.
+* Spell-check with `codespell`; add accepted domain terms to `docs/.codespell-ignore`.
+
+---
+
+## Publishing
+
+The GitHub Pages site is rebuilt by the **release workflow** after every version tag (`v*`).
+Failing to keep the docs build-clean will block the PyPI publish step.
+
+````


### PR DESCRIPTION
## Summary
- add contributing tips for Sphinx in `docs/AGENTS.md`
- document new guide in changelog

## Testing
- `poetry run ruff check --fix .`
- `poetry run black --check .`
- `poetry run isort --check --profile black .`
- `poetry run mypy imednet`
- `poetry run pytest -q`
- `make docs` *(fails: missing myst-parser, produces warnings)*
- `poetry run doc8 docs/` *(fails: command not found)*
- `poetry run codespell docs/` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686d8f822074832c9caab6a99191f715