### PR TITLE
Add sanitizer for chatgpt links

### DIFF
--- a/.github/workflows/sanitize-links.yml
+++ b/.github/workflows/sanitize-links.yml
@@ -1,0 +1,50 @@
+name: Sanitize PR Links
+
+on:
+  pull_request_target:
+    types: [opened, edited, synchronize]
+
+permissions:
+  pull-requests: write
+
+jobs:
+  sanitize:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@v7
+        with:
+          script: |
+            const pr = context.payload.pull_request;
+            if (!pr) return;
+            const regex = /https:\/\/chatgpt\.com\/codex\/\S+/g;
+            const body = pr.body || '';
+            const sanitizedBody = body.replace(regex, '');
+            if (sanitizedBody !== body) {
+              await github.rest.pulls.update({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pull_number: pr.number,
+                body: sanitizedBody,
+              });
+            }
+            const comments = await github.paginate(
+              github.rest.issues.listComments,
+              {
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: pr.number,
+                per_page: 100,
+              }
+            );
+            for (const comment of comments) {
+              if (!comment.body) continue;
+              const sanitizedComment = comment.body.replace(regex, '');
+              if (sanitizedComment !== comment.body) {
+                await github.rest.issues.updateComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  comment_id: comment.id,
+                  body: sanitizedComment,
+                });
+              }
+            }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 - Bump project version to `0.1.4`.
+- Added workflow to sanitize PR bodies and comments of `chatgpt.com/codex` links.
 - Extracted common logic from `Client` and `AsyncClient` into new `HTTPClientBase`.
 - Added `imednet.config` module with `load_config` helper for reading credentials.
 - Introduced `RetryPolicy` abstraction for configuring request retries.


### PR DESCRIPTION
## Summary
- sanitize PR bodies and comments so chatgpt.com Codex links are removed automatically
- document the new workflow in the changelog

## Testing
- `poetry run ruff check --fix .`
- `poetry run black --check .`
- `poetry run isort --check --profile black .`
- `poetry run mypy imednet`
- `poetry run pytest -q`

------