### PR TITLE
Fix ISO datetime parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 - Bump project version to `0.1.4`.
+- Relaxed ISO datetime parser to handle fractional seconds with fewer than
+  three or six digits.
 - Added workflow to sanitize PR bodies and comments of `chatgpt.com/codex` links.
 - Extracted common logic from `Client` and `AsyncClient` into new `HTTPClientBase`.
 - Added `imednet.config` module with `load_config` helper for reading credentials.

--- a/imednet/utils/dates.py
+++ b/imednet/utils/dates.py
@@ -2,6 +2,9 @@
 Utility functions for parsing and formatting ISO date/time strings.
 """
 
+from __future__ import annotations
+
+import re
 from datetime import datetime, timezone
 
 
@@ -22,6 +25,18 @@ def parse_iso_datetime(date_str: str) -> datetime:
     """
     if date_str.endswith("Z"):
         date_str = date_str[:-1] + "+00:00"
+
+    match = re.search(r"\.(\d+)(?=[+-]\d{2}:\d{2}|$)", date_str)
+    if match:
+        frac = match.group(1)
+        if len(frac) in {1, 2}:
+            padded = frac.ljust(3, "0")
+        elif len(frac) in {4, 5}:
+            padded = frac.ljust(6, "0")
+        else:
+            padded = frac
+        date_str = date_str.replace("." + frac, "." + padded)
+
     return datetime.fromisoformat(date_str)
 
 

--- a/tests/unit/test_utils_dates_and_filters.py
+++ b/tests/unit/test_utils_dates_and_filters.py
@@ -24,6 +24,16 @@ def test_parse_iso_datetime_naive() -> None:
     assert dt.year == 2024
 
 
+def test_parse_iso_datetime_millis_padding() -> None:
+    dt = parse_iso_datetime("2021-12-09T08:23:21.99Z")
+    assert dt == datetime(2021, 12, 9, 8, 23, 21, 990000, tzinfo=timezone.utc)
+
+
+def test_parse_iso_datetime_micro_padding() -> None:
+    dt = parse_iso_datetime("2025-06-30T21:40:44.98268")
+    assert dt.microsecond == 982680
+
+
 def test_parse_iso_datetime_invalid() -> None:
     with pytest.raises(ValueError):
         parse_iso_datetime("not-a-date")


### PR DESCRIPTION
## Summary
- pad fractional seconds in `parse_iso_datetime`
- test parsing timestamps with short fractional seconds
- document the fix in the changelog

## Testing
- `poetry run ruff check --fix .`
- `poetry run black --check .`
- `poetry run isort --check --profile black .`
- `poetry run mypy imednet`
- `poetry run pytest -q`

------
