### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,3 +1,5 @@
+permissions:
+  contents: read
 name: CI
 
 on:


### PR DESCRIPTION
Potential fix for [https://github.com/fderuiter/imednet-python-sdk/security/code-scanning/1](https://github.com/fderuiter/imednet-python-sdk/security/code-scanning/1)

To fix the problem, the workflow YAML file should be updated to explicitly set the permissions for the GITHUB_TOKEN. This can be done by adding a `permissions` block at the workflow level (top-level, just under the `name` key and above `on:`), or for each job. Given that all jobs in this workflow only need read access to repository contents, the minimal and preferred fix is to add `permissions: contents: read` at the root of the workflow. This change will not affect existing functionality, as all current steps only require read access. You do not need to add any imports or change any lines outside of the workflow YAML.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
