### PR TITLE
Fix tests for new ListGetEndpoint signature

### DIFF
--- a/tests/live/test_endpoints_sync_live.py
+++ b/tests/live/test_endpoints_sync_live.py
@@ -50,7 +50,7 @@ def test_list_studies(sdk: ImednetSDK) -> None:
     assert isinstance(studies, list)
     assert studies, "No studies returned from server"
     assert isinstance(studies[0], Study)
-    study = sdk.studies.get(studies[0].study_key)
+    study = sdk.studies.get(None, studies[0].study_key)
     assert study.study_key == studies[0].study_key
 
 
@@ -65,7 +65,7 @@ def test_list_sites(sdk: ImednetSDK, study_key: str) -> None:
 
 def test_get_study(sdk: ImednetSDK, study_key: str) -> None:
     try:
-        study = sdk.studies.get(study_key)
+        study = sdk.studies.get(None, study_key)
     except ServerError as exc:
         pytest.fail(f"Server error retrieving study {study_key}: {exc.response}")
     else:


### PR DESCRIPTION
## Summary
- update live sync endpoint tests to pass item ID when retrieving a study

## Testing
- `poetry run ruff check --fix tests/live/test_endpoints_sync_live.py`
- `poetry run black --check tests/live/test_endpoints_sync_live.py`
- `poetry run isort --check --profile black tests/live/test_endpoints_sync_live.py`
- `poetry run mypy imednet`
- `poetry run pytest -q`

------
