### PR TITLE
Enable per-form SQLite export

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,12 @@ Example of exporting a subset of variables:
 imednet export sql MY_STUDY table sqlite:///data.db --vars AGE,SEX --forms 10,20
 ```
 
+### SQLite exports
+
+When the connection string uses SQLite, the command splits the output into one
+table per form to avoid the 2000 column limit. Pass ``--single-table`` to
+disable this behaviour. See ``docs/cli.rst`` for full examples.
+
 ## Testing & Development
 
 ```bash

--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -64,10 +64,22 @@ Use ``--help`` on any command to see all options.
 SQLite Exports
 --------------
 
-When the connection string uses SQLite, ``export sql`` writes one table per
-form to avoid the ``2000`` column limit. Pass ``--single-table`` to disable
-this behaviour. The constant ``imednet.integrations.export.MAX_SQLITE_COLUMNS``
-still enforces the maximum columns per table.
+SQLite only allows ``2000`` columns per table. When the connection string
+targets SQLite, ``export sql`` therefore creates a table for **each form** by
+default:
+
+.. code-block:: console
+
+   imednet export sql MY_STUDY sqlite:///data.db
+
+Use ``--single-table`` to combine everything into one table instead:
+
+.. code-block:: console
+
+   imednet export sql MY_STUDY table sqlite:///data.db --single-table
+
+The constant ``imednet.integrations.export.MAX_SQLITE_COLUMNS`` still enforces
+the maximum columns for any individual table.
 
 Variable Filters
 ----------------

--- a/tests/integration/test_sqlite_export_modes.py
+++ b/tests/integration/test_sqlite_export_modes.py
@@ -1,0 +1,77 @@
+import importlib.util
+import sys
+from types import ModuleType
+from unittest.mock import MagicMock
+
+import pandas as pd
+import pytest
+from typer.testing import CliRunner
+
+import imednet.cli as cli
+from imednet.integrations import export as export_mod
+
+
+@pytest.fixture
+def sqlite_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("IMEDNET_API_KEY", "k")
+    monkeypatch.setenv("IMEDNET_SECURITY_KEY", "s")
+    monkeypatch.setattr(importlib.util, "find_spec", lambda name: object())
+    engine = MagicMock()
+    engine.dialect.name = "sqlite"
+    sa_module = ModuleType("sqlalchemy")
+    sa_module.create_engine = MagicMock(return_value=engine)  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "sqlalchemy", sa_module)
+
+
+def _setup_per_form_mapper(monkeypatch: pytest.MonkeyPatch) -> None:
+    form1_vars = [MagicMock(variable_name=f"v{i}", label=f"v{i}") for i in range(1500)]
+    form2_vars = [MagicMock(variable_name=f"w{i}", label=f"w{i}") for i in range(600)]
+    sdk = MagicMock()
+    sdk.forms.list.return_value = [
+        MagicMock(form_id=1, form_key="F1"),
+        MagicMock(form_id=2, form_key="F2"),
+    ]
+    sdk.variables.list.side_effect = [form1_vars, form2_vars]
+
+    mapper_inst = MagicMock()
+    mapper_inst._build_record_model.return_value = object()
+    mapper_inst._fetch_records.side_effect = [MagicMock(), MagicMock()]
+    rows1 = [{f"v{i}": i for i in range(1500)}]
+    rows2 = [{f"w{i}": i for i in range(600)}]
+    mapper_inst._parse_records.side_effect = [(rows1, 0), (rows2, 0)]
+    mapper_inst._build_dataframe.side_effect = [pd.DataFrame(rows1), pd.DataFrame(rows2)]
+    monkeypatch.setattr(export_mod, "RecordMapper", MagicMock(return_value=mapper_inst))
+    monkeypatch.setattr(cli, "get_sdk", MagicMock(return_value=sdk))
+    monkeypatch.setattr(pd.DataFrame, "to_sql", MagicMock())
+
+
+def _setup_single_table_mapper(monkeypatch: pytest.MonkeyPatch) -> None:
+    columns = [f"c{i}" for i in range(2100)]
+    df = pd.DataFrame([range(2100)], columns=columns)
+    mapper_inst = MagicMock(dataframe=MagicMock(return_value=df))
+    monkeypatch.setattr(export_mod, "RecordMapper", MagicMock(return_value=mapper_inst))
+    monkeypatch.setattr(cli, "get_sdk", MagicMock(return_value=MagicMock()))
+    monkeypatch.setattr(pd.DataFrame, "to_sql", MagicMock())
+
+
+def test_default_sqlite_mode_splits_by_form(sqlite_env, monkeypatch: pytest.MonkeyPatch) -> None:
+    _setup_per_form_mapper(monkeypatch)
+    runner = CliRunner()
+    with runner.isolated_filesystem():
+        result = runner.invoke(
+            cli.app,
+            ["export", "sql", "STUDY", "unused", "sqlite:///db.sqlite"],
+        )
+    assert result.exit_code == 0
+
+
+def test_single_table_mode_raises(sqlite_env, monkeypatch: pytest.MonkeyPatch) -> None:
+    _setup_single_table_mapper(monkeypatch)
+    runner = CliRunner()
+    with runner.isolated_filesystem():
+        result = runner.invoke(
+            cli.app,
+            ["export", "sql", "STUDY", "table", "sqlite:///db.sqlite", "--single-table"],
+        )
+    assert result.exit_code != 0
+    assert "SQLite supports up to" in result.stdout


### PR DESCRIPTION
## Summary
- consolidate SQLite column check in `_assert_within_column_limit`
- clarify CLI documentation for per-form vs `--single-table` export
- document SQLite behaviour in README
- add integration tests ensuring per-form mode avoids the column limit

## Testing
- `poetry run ruff check --fix .`
- `poetry run black --check .`
- `poetry run isort --check --profile black .`
- `poetry run mypy imednet`
- `poetry run pytest -q`
- `poetry run doc8 docs/`

------
