### PR TITLE
Restrict smoke workflow trigger

### DIFF
--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -4,11 +4,10 @@ name: Smoke
 
 on:
   workflow_dispatch:
-  schedule:
-    - cron: "0 0 * * *"
 
 jobs:
   smoke:
+    if: github.actor == github.repository_owner
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Documented Sphinx conventions in new `docs/AGENTS.md`.
 - Added smoke workflow for live API tests.
 - Documented optional `smoke.yml` workflow which uses `APIKEY` and `SECURITYKEY` to run `tests/live`.
+- Restricted smoke workflow to manual dispatch by the repository owner.
 
 ## [0.1.4] 
 


### PR DESCRIPTION
## Summary
- lock smoke workflow to manual dispatch
- only repository owner can run it
- document restriction in changelog

## Testing
- `poetry run ruff check --fix .`
- `poetry run black --check .`
- `poetry run isort --check --profile black .`
- `poetry run mypy imednet`
- `poetry run pytest -q`

------
