### PR TITLE
Fix fixture scope and filter handling

### DIFF
--- a/imednet/cli/export/__init__.py
+++ b/imednet/cli/export/__init__.py
@@ -114,7 +114,7 @@ def export_sql(
 
     engine = create_engine(connection_string)
     var_list = [v.strip() for v in vars_.split(",")] if vars_ else None
-    form_list = [f.strip() for f in forms.split(",")] if forms else None
+    form_list = [int(f.strip()) for f in forms.split(",")] if forms else None
     if long_format:
         export_to_long_sql(sdk, study_key, table, connection_string)
         return

--- a/imednet/integrations/export.py
+++ b/imednet/integrations/export.py
@@ -29,7 +29,7 @@ def _records_df(
     *,
     use_labels_as_columns: bool = False,
     variable_whitelist: Optional[List[str]] = None,
-    form_whitelist: Optional[List[str]] = None,
+    form_whitelist: Optional[List[int]] = None,
 ) -> pd.DataFrame:
     """Return a DataFrame of study records with duplicate columns removed."""
     df: pd.DataFrame = RecordMapper(sdk).dataframe(
@@ -148,7 +148,7 @@ def export_to_sql(
     *,
     use_labels_as_columns: bool = False,
     variable_whitelist: Optional[List[str]] = None,
-    form_whitelist: Optional[List[str]] = None,
+    form_whitelist: Optional[List[int]] = None,
     **kwargs: Any,
 ) -> None:
     """Export study records to a SQL table.
@@ -182,7 +182,7 @@ def export_to_sql_by_form(
     *,
     use_labels_as_columns: bool = False,
     variable_whitelist: Optional[List[str]] = None,
-    form_whitelist: Optional[List[str]] = None,
+    form_whitelist: Optional[List[int]] = None,
     **kwargs: Any,
 ) -> None:
     """Export records to separate SQL tables for each form."""

--- a/imednet/workflows/record_mapper.py
+++ b/imednet/workflows/record_mapper.py
@@ -46,13 +46,18 @@ class RecordMapper:
         self,
         study_key: str,
         variable_whitelist: Optional[List[str]] = None,
-        form_whitelist: Optional[List[str]] = None,
+        form_whitelist: Optional[List[int]] = None,
     ) -> Tuple[List[str], Dict[str, str]]:
         """Return variable names and label mapping for a study."""
+        filters: Dict[str, Any] = {}
+        if variable_whitelist is not None:
+            filters["variableNames"] = variable_whitelist
+        if form_whitelist is not None:
+            filters["formIds"] = form_whitelist
+
         variables: List[VariableModel] = self.sdk.variables.list(
             study_key=study_key,
-            variableNames=variable_whitelist,
-            formIds=form_whitelist,
+            **filters,
         )
         if not variables:
             logger.warning(
@@ -173,7 +178,7 @@ class RecordMapper:
         visit_key: Optional[str] = None,
         use_labels_as_columns: bool = True,
         variable_whitelist: Optional[List[str]] = None,
-        form_whitelist: Optional[List[str]] = None,
+        form_whitelist: Optional[List[int]] = None,
     ) -> pd.DataFrame:
         """Return a :class:`pandas.DataFrame` of records for a study."""
         variable_keys, label_map = self._fetch_variable_metadata(

--- a/tests/live/test_cli_live.py
+++ b/tests/live/test_cli_live.py
@@ -19,12 +19,12 @@ pytestmark = pytest.mark.skipif(
 )
 
 
-@pytest.fixture(scope="module")
+@pytest.fixture(scope="session")
 def runner() -> CliRunner:
     return CliRunner()
 
 
-@pytest.fixture(scope="module")
+@pytest.fixture(scope="session")
 def study_key() -> str:
     with ImednetSDK(api_key=API_KEY, security_key=SECURITY_KEY, base_url=BASE_URL) as sdk:
         studies = sdk.get_studies()

--- a/tests/live/test_endpoints_async_live.py
+++ b/tests/live/test_endpoints_async_live.py
@@ -19,13 +19,13 @@ pytestmark = pytest.mark.skipif(
 )
 
 
-@pytest.fixture(scope="module")
+@pytest.fixture(scope="session")
 def sdk() -> Iterator[ImednetSDK]:
     with ImednetSDK(api_key=API_KEY, security_key=SECURITY_KEY, base_url=BASE_URL) as client:
         yield client
 
 
-@pytest_asyncio.fixture(scope="module")
+@pytest_asyncio.fixture(scope="session")
 async def async_sdk() -> AsyncIterator[AsyncImednetSDK]:
     client = AsyncImednetSDK(
         api_key=API_KEY,
@@ -38,7 +38,7 @@ async def async_sdk() -> AsyncIterator[AsyncImednetSDK]:
         await client.aclose()
 
 
-@pytest.fixture(scope="module")
+@pytest.fixture(scope="session")
 def study_key(sdk: ImednetSDK) -> str:
     studies = sdk.studies.list()
     if not studies:

--- a/tests/live/test_endpoints_sync_live.py
+++ b/tests/live/test_endpoints_sync_live.py
@@ -31,13 +31,13 @@ pytestmark = pytest.mark.skipif(
 )
 
 
-@pytest.fixture(scope="module")
+@pytest.fixture(scope="session")
 def sdk() -> Iterator[ImednetSDK]:
     with ImednetSDK(api_key=API_KEY, security_key=SECURITY_KEY, base_url=BASE_URL) as client:
         yield client
 
 
-@pytest.fixture(scope="module")
+@pytest.fixture(scope="session")
 def study_key(sdk: ImednetSDK) -> str:
     studies = sdk.studies.list()
     if not studies:

--- a/tests/live/test_integrations_live.py
+++ b/tests/live/test_integrations_live.py
@@ -19,13 +19,13 @@ pytestmark = pytest.mark.skipif(
 )
 
 
-@pytest.fixture(scope="module")
+@pytest.fixture(scope="session")
 def sdk() -> Iterator[ImednetSDK]:
     with ImednetSDK(api_key=API_KEY, security_key=SECURITY_KEY, base_url=BASE_URL) as client:
         yield client
 
 
-@pytest.fixture(scope="module")
+@pytest.fixture(scope="session")
 def study_key(sdk: ImednetSDK) -> str:
     studies = sdk.get_studies()
     if not studies:

--- a/tests/live/test_schema_validator_live.py
+++ b/tests/live/test_schema_validator_live.py
@@ -20,13 +20,13 @@ pytestmark = pytest.mark.skipif(
 )
 
 
-@pytest.fixture(scope="module")
+@pytest.fixture(scope="session")
 def sdk() -> Iterator[ImednetSDK]:
     with ImednetSDK(api_key=API_KEY, security_key=SECURITY_KEY, base_url=BASE_URL) as client:
         yield client
 
 
-@pytest.fixture(scope="module")
+@pytest.fixture(scope="session")
 def study_key(sdk: ImednetSDK) -> str:
     studies = sdk.studies.list()
     if not studies:
@@ -51,6 +51,7 @@ def _wrong_value(var_type: str):
 def test_validator_unknown_variable(sdk: ImednetSDK, study_key: str) -> None:
     var = _get_first_variable(sdk, study_key)
     validator = SchemaValidator(sdk)
+    validator.refresh(study_key)
 
     with pytest.raises(ValidationError):
         validator.validate_record(
@@ -63,6 +64,7 @@ def test_validator_unknown_variable(sdk: ImednetSDK, study_key: str) -> None:
 def test_validator_wrong_type(sdk: ImednetSDK, study_key: str) -> None:
     var = _get_first_variable(sdk, study_key)
     validator = SchemaValidator(sdk)
+    validator.refresh(study_key)
 
     with pytest.raises(ValidationError):
         validator.validate_record(

--- a/tests/live/test_sdk_utilities_live.py
+++ b/tests/live/test_sdk_utilities_live.py
@@ -18,13 +18,13 @@ pytestmark = pytest.mark.skipif(
 )
 
 
-@pytest.fixture(scope="module")
+@pytest.fixture(scope="session")
 def sdk() -> Iterator[ImednetSDK]:
     with ImednetSDK(api_key=API_KEY, security_key=SECURITY_KEY, base_url=BASE_URL) as client:
         yield client
 
 
-@pytest.fixture(scope="module")
+@pytest.fixture(scope="session")
 def study_key(sdk: ImednetSDK) -> str:
     studies = sdk.get_studies()
     if not studies:

--- a/tests/live/test_workflows_live.py
+++ b/tests/live/test_workflows_live.py
@@ -24,13 +24,13 @@ pytestmark = pytest.mark.skipif(
 )
 
 
-@pytest.fixture(scope="module")
+@pytest.fixture(scope="session")
 def sdk() -> Iterator[ImednetSDK]:
     with ImednetSDK(api_key=API_KEY, security_key=SECURITY_KEY, base_url=BASE_URL) as client:
         yield client
 
 
-@pytest.fixture(scope="module")
+@pytest.fixture(scope="session")
 def study_key(sdk: ImednetSDK) -> str:
     studies = sdk.get_studies()
     if not studies:
@@ -38,7 +38,7 @@ def study_key(sdk: ImednetSDK) -> str:
     return studies[0].study_key
 
 
-@pytest.fixture(scope="module")
+@pytest.fixture(scope="session")
 def first_subject_key(sdk: ImednetSDK, study_key: str) -> str:
     subs = sdk.get_subjects(study_key)
     if not subs:

--- a/tests/unit/cli/test_cli.py
+++ b/tests/unit/cli/test_cli.py
@@ -257,7 +257,7 @@ def test_export_sql_calls_helper_non_sqlite(
         "table",
         "postgresql://",
         variable_whitelist=["A", "B"],
-        form_whitelist=["1", "2"],
+        form_whitelist=[1, 2],
     )
 
 
@@ -293,7 +293,7 @@ def test_export_sql_sqlite_uses_by_form(
         "STUDY",
         "sqlite://",
         variable_whitelist=["A"],
-        form_whitelist=["10"],
+        form_whitelist=[10],
     )
 
 
@@ -333,7 +333,7 @@ def test_export_sql_sqlite_single_table(
         "table",
         "sqlite://",
         variable_whitelist=["V1"],
-        form_whitelist=["5"],
+        form_whitelist=[5],
     )
     form_func.assert_not_called()
 

--- a/tests/unit/test_record_mapper.py
+++ b/tests/unit/test_record_mapper.py
@@ -24,7 +24,7 @@ def test_dataframe_builds_expected_structure() -> None:
                 "formIds": [10],
             }
             return [variables[0]]
-        assert kwargs == {"study_key": "STUDY", "variableNames": None, "formIds": None}
+        assert kwargs == {"study_key": "STUDY"}
         return variables
 
     sdk.variables.list.side_effect = var_list
@@ -44,11 +44,7 @@ def test_dataframe_builds_expected_structure() -> None:
     mapper = RecordMapper(sdk)
     df = mapper.dataframe("STUDY", visit_key="1")
 
-    sdk.variables.list.assert_called_once_with(
-        study_key="STUDY",
-        variableNames=None,
-        formIds=None,
-    )
+    sdk.variables.list.assert_called_once_with(study_key="STUDY")
     sdk.records.list.assert_called_once_with(
         study_key="STUDY",
         record_data_filter=None,


### PR DESCRIPTION
## Summary
- ensure live tests use session-scoped fixtures
- avoid sending `None` filter values
- convert CLI form arguments to integers
- update tests for new behaviour

## Testing
- `poetry run ruff check --fix .`
- `poetry run black --check .`
- `poetry run isort --check --profile black .`
- `poetry run mypy imednet`
- `poetry run pytest -q`

------
