### PR TITLE
Allow hitting live API in testing guidelines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added long-format SQL export via `export_to_long_sql` and the `--long-format` CLI option.
 - CLI commands now use shared helpers for study arguments and list output to reduce duplication.
 - Deduplicated refresh and validation logic in `SchemaValidator` with helper methods.
+- Updated `tests/AGENTS.md` to permit hitting the live iMednet API when running the `tests/live` suite.
 - Refactored endpoint initialization in `ImednetSDK` using a registry.
 - Added `_build_record_payload` helper to `RecordUpdateWorkflow` to deduplicate
   record dictionary construction.

--- a/tests/AGENTS.md
+++ b/tests/AGENTS.md
@@ -15,7 +15,7 @@ Provide ground rules for creating and maintaining **pytest** tests so that every
 ## Test style & tools
 - Use **pytest** with strictly-typed assertions (`assert isinstance(result, MyType)`).
 - Prefer **pytest-asyncio** for async code; mark async tests with `@pytest.mark.asyncio`.
-- Mock HTTP traffic with **respx** or **responses** – **NEVER** hit the live iMednet API.  The examples under `tests/live/` require `IMEDNET_RUN_E2E=1` and valid credentials and are skipped otherwise.
+- Mock HTTP traffic with **respx** or **responses** when testing offline. It's OK to hit the live iMednet API if you set `IMEDNET_RUN_E2E=1` with valid credentials and want to run the examples under `tests/live/`.
 - Keep helpers that are shared across modules in `tests/conftest.py` or `tests/utils/`.
 
 ---


### PR DESCRIPTION
## Summary
- update test suite guidelines so hitting the live API is permitted
- note change in changelog

## Testing
- `poetry run ruff check --fix .`
- `poetry run black --check .`
- `poetry run isort --check --profile black .`
- `poetry run mypy imednet`
- `poetry run pytest -q` *(fails: 6 failed, 479 passed, 23 skipped, 8 warnings, 1 error)*

------
