### PR TITLE
Add SchemaValidator refresh docstring

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Documented the sentinel return value in ``parse_datetime``.
 - Replaced placeholder description in ``workflows/record_update.py``.
 - Added docstrings to private helpers in ``core/_requester.py``.
+- Documented ``SchemaValidator.refresh`` behavior.
 - Added tests covering the default sentinel date in ``parse_datetime``.
 - Organized Airflow integration code into ``hooks``, ``operators`` and ``sensors`` subpackages.
 - Grouped CLI commands into dedicated subpackages for easier navigation.

--- a/imednet/validation/cache.py
+++ b/imednet/validation/cache.py
@@ -182,6 +182,13 @@ class SchemaValidator(_ValidatorMixin):
         self._refresh_common(variables)
 
     def refresh(self, study_key: str) -> Any:
+        """Populate the schema cache for ``study_key`` from the Variables endpoint.
+
+        Returns ``None`` when used with a synchronous validator or a coroutine for
+        an asynchronous validator. This method never raises
+        :class:`~imednet.core.exceptions.ValidationError`; any API errors bubble up
+        as :class:`~imednet.core.exceptions.ApiError`.
+        """
         if self._is_async:
             return self._refresh_async(study_key)
         return self._refresh_sync(study_key)


### PR DESCRIPTION
## Summary
- document SchemaValidator.refresh and its return semantics
- note the change in the changelog

## Testing
- `ruff check --fix .`
- `black --check .`
- `isort --check --profile black .`
- `mypy imednet`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687fb3d5e4dc832ca9b67cea0edcbcac