### PR TITLE
Ensure schema check in live validator tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added smoke workflow for live API tests.
 - Documented optional `smoke.yml` workflow which uses `APIKEY` and `SECURITYKEY` to run `tests/live`.
 - Restricted smoke workflow to manual dispatch by the repository owner.
+- Ensured live schema validation tests verify the schema is populated to avoid
+  false negatives when the server returns an empty schema.
 
 ## [0.1.4] 
 

--- a/tests/live/test_schema_validator_live.py
+++ b/tests/live/test_schema_validator_live.py
@@ -53,12 +53,14 @@ def test_validator_unknown_variable(sdk: ImednetSDK, study_key: str) -> None:
     validator = SchemaValidator(sdk)
     validator.refresh(study_key)
 
+    # Ensure schema contains variables for the form; an empty schema would cause
+    # false negatives when validating.
+    assert validator.schema.variables_for_form(var.form_key)
+
     with pytest.raises(ValidationError):
         validator.validate_record(
             study_key, {"formKey": var.form_key, "data": {var.variable_name + "_x": 1}}
         )
-
-    assert validator.schema.variables_for_form(var.form_key)
 
 
 def test_validator_wrong_type(sdk: ImednetSDK, study_key: str) -> None:
@@ -66,10 +68,12 @@ def test_validator_wrong_type(sdk: ImednetSDK, study_key: str) -> None:
     validator = SchemaValidator(sdk)
     validator.refresh(study_key)
 
+    # The validator requires a populated schema; without this check the test
+    # could pass incorrectly if the form variables are missing.
+    assert validator.schema.variables_for_form(var.form_key)
+
     with pytest.raises(ValidationError):
         validator.validate_record(
             study_key,
             {"formKey": var.form_key, "data": {var.variable_name: _wrong_value(var.variable_type)}},
         )
-
-    assert validator.schema.variables_for_form(var.form_key)


### PR DESCRIPTION
## Summary
- guard against an empty schema in live SchemaValidator tests
- document behavior in changelog

## Testing
- `poetry run ruff check --fix .`
- `poetry run black --check .`
- `poetry run isort --check --profile black .`
- `poetry run mypy imednet`
- `IMEDNET_RUN_E2E=0 poetry run pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687fbcc6e514832cb596f2547c43e2e9