### PR TITLE
Handle teardown errors in live tests

### DIFF
--- a/tests/live/conftest.py
+++ b/tests/live/conftest.py
@@ -31,7 +31,10 @@ async def async_sdk() -> AsyncIterator[AsyncImednetSDK]:
     try:
         yield client
     finally:
-        await client.aclose()
+        try:
+            await client.aclose()
+        except RuntimeError as exc:  # pragma: no cover - cleanup safeguard
+            pytest.fail(f"Async SDK teardown failed: {exc}")
 
 
 @pytest.fixture(scope="session")

--- a/tests/live/test_workflows_live.py
+++ b/tests/live/test_workflows_live.py
@@ -26,8 +26,14 @@ pytestmark = pytest.mark.skipif(
 
 @pytest.fixture(scope="session")
 def sdk() -> Iterator[ImednetSDK]:
-    with ImednetSDK(api_key=API_KEY, security_key=SECURITY_KEY, base_url=BASE_URL) as client:
+    client = ImednetSDK(api_key=API_KEY, security_key=SECURITY_KEY, base_url=BASE_URL)
+    try:
         yield client
+    finally:
+        try:
+            client.close()
+        except Exception as exc:  # pragma: no cover - defensive cleanup
+            pytest.fail(f"SDK teardown failed: {exc}")
 
 
 @pytest.fixture(scope="session")


### PR DESCRIPTION
## Summary
- safeguard teardown of `sdk` fixture in live workflow tests
- guard async client teardown from `RuntimeError`

## Testing
- `poetry run ruff check --fix .`
- `poetry run black --check .`
- `poetry run isort --check --profile black .`
- `poetry run mypy imednet`
- `poetry run pytest -q` *(fails: RuntimeError: Event loop is closed)*

------
