### PR TITLE
fix(validation): raise error for unknown form

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Restricted smoke workflow to manual dispatch by the repository owner.
 - Ensured live schema validation tests verify the schema is populated to avoid
   false negatives when the server returns an empty schema.
+- ``validate_record_data`` now raises ``ValidationError`` when provided an unknown form key.
 
 ## [0.1.4] 
 

--- a/imednet/validation/cache.py
+++ b/imednet/validation/cache.py
@@ -127,7 +127,7 @@ def validate_record_data(
 ) -> None:
     variables = schema.variables_for_form(form_key)
     if not variables:
-        return
+        raise ValidationError(f"Unknown form {form_key}")
     unknown = [k for k in data if k not in variables]
     if unknown:
         raise ValidationError(f"Unknown variables for form {form_key}: {', '.join(unknown)}")

--- a/tests/integration/test_workflows_integration.py
+++ b/tests/integration/test_workflows_integration.py
@@ -46,7 +46,9 @@ def test_data_extraction_filters():
 def test_record_update_submit_and_wait(monkeypatch: pytest.MonkeyPatch):
     sdk = ImednetSDK(api_key="k", security_key="s", base_url="https://api.test")
     respx.get(re.compile("https://api.test/api/v1/edc/studies/ST/variables.*")).respond(
-        json={"data": []}
+        json={
+            "data": [{"variableName": "x", "variableType": "integer", "formId": 1, "formKey": "F1"}]
+        }
     )
     respx.post("https://api.test/api/v1/edc/studies/ST/records").respond(
         json={"batchId": "B1", "state": "PROCESSING"}
@@ -138,7 +140,9 @@ def test_data_extraction_no_matching_subjects() -> None:
 def test_record_update_timeout(monkeypatch: pytest.MonkeyPatch) -> None:
     sdk = ImednetSDK(api_key="k", security_key="s", base_url="https://api.test")
     respx.get(re.compile("https://api.test/api/v1/edc/studies/ST/variables.*")).respond(
-        json={"data": []}
+        json={
+            "data": [{"variableName": "x", "variableType": "integer", "formId": 1, "formKey": "F1"}]
+        }
     )
     respx.post("https://api.test/api/v1/edc/studies/ST/records").respond(
         json={"batchId": "B1", "state": "PROCESSING"}

--- a/tests/unit/endpoints/test_records_endpoint.py
+++ b/tests/unit/endpoints/test_records_endpoint.py
@@ -85,8 +85,12 @@ def test_create_validates_data(dummy_client, context, response_factory):
     schema._form_id_to_key = {1: "F1"}
 
     dummy_client.post.return_value = response_factory({"jobId": "1"})
+    # unknown form key
+    with pytest.raises(ValidationError):
+        ep.create("S1", [{"formKey": "BAD", "data": {}}], schema=schema)
+    dummy_client.post.assert_not_called()
 
-    # invalid key
+    # invalid variable key
     with pytest.raises(ValidationError):
         ep.create("S1", [{"formKey": "F1", "data": {"bad": 1}}], schema=schema)
     dummy_client.post.assert_not_called()

--- a/tests/unit/test_schema_validator.py
+++ b/tests/unit/test_schema_validator.py
@@ -54,6 +54,24 @@ def test_validate_record_wrong_type(async_mode: bool) -> None:
 
 
 @pytest.mark.parametrize("async_mode", [False, True])
+def test_validate_record_unknown_form(async_mode: bool) -> None:
+    var = Variable(variable_name="age", variable_type="integer", form_id=1, form_key="F1")
+    sdk = _build_sdk(var, async_mode)
+    validator = SchemaValidator(sdk)
+
+    with pytest.raises(ValidationError, match="Unknown form BAD"):
+        if async_mode:
+            asyncio.run(validator.validate_record("STUDY", {"formKey": "BAD", "data": {}}))
+        else:
+            validator.validate_record("STUDY", {"formKey": "BAD", "data": {}})
+
+    if async_mode:
+        sdk.variables.async_list.assert_awaited_once_with(study_key="STUDY", refresh=True)
+    else:
+        sdk.variables.list.assert_called_once_with(study_key="STUDY", refresh=True)
+
+
+@pytest.mark.parametrize("async_mode", [False, True])
 def test_refresh_called_when_form_not_cached(async_mode: bool) -> None:
     var = Variable(variable_name="age", variable_type="integer", form_id=1, form_key="F1")
     sdk = _build_sdk(var, async_mode)


### PR DESCRIPTION
## Summary
- raise `ValidationError` when `validate_record_data` encounters an unknown form key
- cover invalid form keys in schema validator and records endpoint tests
- ensure integration tests include form metadata for record updates

## Testing
- `poetry run ruff check --fix .`
- `poetry run black --check .`
- `poetry run isort --check --profile black .`
- `poetry run mypy imednet`
- `IMEDNET_RUN_E2E=0 poetry run pytest -q`


------
