### PR TITLE
test(validation): cover unknown form error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 - Bump project version to `0.1.4`.
- - ISO datetime parser now pads fractional seconds shorter than six digits to
+- Added tests for unknown form validation errors.
+- ISO datetime parser now pads fractional seconds shorter than six digits to
    microsecond precision.
 - Added workflow to sanitize PR bodies and comments of `chatgpt.com/codex` links.
 - Extracted common logic from `Client` and `AsyncClient` into new `HTTPClientBase`.

--- a/imednet/validation/cache.py
+++ b/imednet/validation/cache.py
@@ -125,8 +125,17 @@ def validate_record_data(
     form_key: str,
     data: Dict[str, Any],
 ) -> None:
+    """Validate ``data`` for ``form_key`` using the provided schema cache.
+
+    Raises:
+        ValidationError: If the form key is not present in the schema or the data
+            fails validation checks.
+    """
+
     variables = schema.variables_for_form(form_key)
     if not variables:
+        # The cache has no variables for the given form key, so treat it as an
+        # unknown form and fail fast.
         raise ValidationError(f"Unknown form {form_key}")
     unknown = [k for k in data if k not in variables]
     if unknown:

--- a/tests/unit/endpoints/test_records_endpoint.py
+++ b/tests/unit/endpoints/test_records_endpoint.py
@@ -86,7 +86,7 @@ def test_create_validates_data(dummy_client, context, response_factory):
 
     dummy_client.post.return_value = response_factory({"jobId": "1"})
     # unknown form key
-    with pytest.raises(ValidationError):
+    with pytest.raises(ValidationError, match="Unknown form BAD"):
         ep.create("S1", [{"formKey": "BAD", "data": {}}], schema=schema)
     dummy_client.post.assert_not_called()
 

--- a/tests/unit/test_utils_schema.py
+++ b/tests/unit/test_utils_schema.py
@@ -73,6 +73,12 @@ def test_validate_record_data_errors() -> None:
         validate_record_data(cache, "F1", {"age": "x"})
 
 
+def test_validate_record_data_unknown_form() -> None:
+    cache = SchemaCache()
+    with pytest.raises(ValidationError, match="Unknown form BAD"):
+        validate_record_data(cache, "BAD", {})
+
+
 def test_schema_validator_batch_calls_validate_record() -> None:
     sdk = MagicMock()
     validator = SchemaValidator(sdk)


### PR DESCRIPTION
## Summary
- document `validate_record_data`'s behavior for missing forms
- expect `ValidationError` when creating records with an invalid `formKey`
- add direct test for unknown form validation

## Testing
- `poetry run ruff check --fix .`
- `poetry run black --check .`
- `poetry run isort --check --profile black .`
- `poetry run mypy imednet`
- `poetry run pytest tests/unit -q`


------
