### PR TITLE
feat: validate form key existence before submitting records

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Ensured live schema validation tests verify the schema is populated to avoid
   false negatives when the server returns an empty schema.
 - ``validate_record_data`` now raises ``ValidationError`` when provided an unknown form key.
+- Record update workflow now raises ``ValueError`` when a form key is missing from the schema.
 
 ## [0.1.4] 
 

--- a/imednet/validation/cache.py
+++ b/imednet/validation/cache.py
@@ -66,6 +66,11 @@ class BaseSchemaCache(Generic[_TClient]):
     def form_key_from_id(self, form_id: int) -> Optional[str]:
         return self._form_id_to_key.get(form_id)
 
+    @property
+    def forms(self) -> Dict[str, Dict[str, Variable]]:
+        """Return the cached mapping of form keys to their variables."""
+        return self._form_variables
+
 
 class SchemaCache(BaseSchemaCache["ImednetSDK"]):
     def __init__(self) -> None:

--- a/imednet/workflows/record_update.py
+++ b/imednet/workflows/record_update.py
@@ -91,6 +91,8 @@ class RecordUpdateWorkflow:
                 result = self._validator.refresh(study_key)
                 if inspect.isawaitable(result):
                     await result
+                if first_ref not in self._schema.forms:
+                    raise ValueError(f"Form key '{first_ref}' not found in study schema")
 
         result = self._validator.validate_batch(study_key, records_data)
         if inspect.isawaitable(result):


### PR DESCRIPTION
## Summary
- raise ValueError when referenced form key is missing from schema
- expose cached forms via SchemaCache
- cover invalid form key scenario in record update workflow tests

## Testing
- `poetry run ruff check --fix tests/workflows/test_record_update.py imednet/workflows/record_update.py imednet/validation/cache.py`
- `poetry run black --check tests/workflows/test_record_update.py imednet/workflows/record_update.py imednet/validation/cache.py`
- `poetry run isort --check --profile black -v tests/workflows/test_record_update.py imednet/workflows/record_update.py imednet/validation/cache.py`
- `poetry run mypy imednet`
- `poetry run pytest tests/workflows/test_record_update.py -q`


------
https://chatgpt.com/codex/tasks/task_e_689111126d34832c985fa039ebbe1ed9