### PR TITLE
feat: validate form key after schema refresh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Ensured live schema validation tests verify the schema is populated to avoid
   false negatives when the server returns an empty schema.
 - ``validate_record_data`` now raises ``ValidationError`` when provided an unknown form key.
+- Record submission now checks form existence after schema refresh and raises
+  ``ValueError`` for unknown form keys.
 
 ## [0.1.4] 
 

--- a/imednet/validation/cache.py
+++ b/imednet/validation/cache.py
@@ -66,6 +66,11 @@ class BaseSchemaCache(Generic[_TClient]):
     def form_key_from_id(self, form_id: int) -> Optional[str]:
         return self._form_id_to_key.get(form_id)
 
+    @property
+    def forms(self) -> Dict[str, Dict[str, Variable]]:
+        """Return cached variables grouped by form key."""
+        return self._form_variables
+
 
 class SchemaCache(BaseSchemaCache["ImednetSDK"]):
     def __init__(self) -> None:

--- a/imednet/workflows/record_update.py
+++ b/imednet/workflows/record_update.py
@@ -91,6 +91,8 @@ class RecordUpdateWorkflow:
                 result = self._validator.refresh(study_key)
                 if inspect.isawaitable(result):
                     await result
+                if first_ref not in self._schema.forms:
+                    raise ValueError(f"Form key '{first_ref}' not found")
 
         result = self._validator.validate_batch(study_key, records_data)
         if inspect.isawaitable(result):


### PR DESCRIPTION
## Summary
- ensure form key exists after schema refresh in record submissions
- expose cached forms via `SchemaCache.forms`
- test invalid form key raises early before API calls

## Testing
- `poetry run ruff check --fix imednet/workflows/record_update.py imednet/validation/cache.py tests/workflows/test_record_update.py`
- `poetry run black --check .`
- `poetry run isort --check --profile black .`
- `poetry run mypy imednet`
- `IMEDNET_RUN_E2E=0 poetry run pytest --cov=imednet --cov-fail-under=90 -q`

------
