### PR TITLE
feat: add data dictionary loader

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - ``validate_record_data`` now raises ``ValidationError`` when provided an unknown form key.
 - Record submission now checks form existence after schema refresh and raises
   ``ValueError`` for unknown form keys.
+- Added ``DataDictionaryLoader`` for loading data dictionaries from CSV files or ZIP archives.
 
 ## [0.1.4] 
 

--- a/imednet/validation/__init__.py
+++ b/imednet/validation/__init__.py
@@ -5,6 +5,7 @@ from .cache import (
     SchemaValidator,
     validate_record_data,
 )
+from .data_dictionary import DataDictionary, DataDictionaryLoader
 
 __all__ = [
     "BaseSchemaCache",
@@ -12,4 +13,6 @@ __all__ = [
     "AsyncSchemaCache",
     "SchemaValidator",
     "validate_record_data",
+    "DataDictionary",
+    "DataDictionaryLoader",
 ]

--- a/imednet/validation/data_dictionary.py
+++ b/imednet/validation/data_dictionary.py
@@ -1,0 +1,83 @@
+from __future__ import annotations
+
+import csv
+import io
+import zipfile
+from contextlib import contextmanager
+from dataclasses import dataclass
+from pathlib import Path
+from typing import BinaryIO, Iterator, TextIO
+
+
+@dataclass
+class DataDictionary:
+    """Container for data dictionary CSV content."""
+
+    business_logic: list[dict[str, str]]
+    choices: list[dict[str, str]]
+    forms: list[dict[str, str]]
+    questions: list[dict[str, str]]
+
+
+class DataDictionaryLoader:
+    """Load data dictionary files from various sources."""
+
+    REQUIRED_FILES = {
+        "BUSINESS_LOGIC.csv": "business_logic",
+        "CHOICES.csv": "choices",
+        "FORMS.csv": "forms",
+        "QUESTIONS.csv": "questions",
+    }
+
+    @staticmethod
+    @contextmanager
+    def _open_text(source: Path | TextIO) -> Iterator[TextIO]:
+        if isinstance(source, (str, Path)):
+            with open(source, encoding="utf-8", newline="") as f:
+                yield f
+        else:
+            yield source
+
+    @classmethod
+    def _load_csv(cls, source: Path | TextIO) -> list[dict[str, str]]:
+        with cls._open_text(source) as f:
+            reader = csv.DictReader(f)
+            return list(reader)
+
+    @classmethod
+    def from_files(
+        cls,
+        *,
+        business_logic: Path | TextIO,
+        choices: Path | TextIO,
+        forms: Path | TextIO,
+        questions: Path | TextIO,
+    ) -> DataDictionary:
+        """Load a data dictionary from individual CSV files."""
+
+        return DataDictionary(
+            business_logic=cls._load_csv(business_logic),
+            choices=cls._load_csv(choices),
+            forms=cls._load_csv(forms),
+            questions=cls._load_csv(questions),
+        )
+
+    @classmethod
+    def from_directory(cls, directory: Path | str) -> DataDictionary:
+        """Load all required CSV files from ``directory``."""
+
+        dir_path = Path(directory)
+        paths = {attr: dir_path / name for name, attr in cls.REQUIRED_FILES.items()}
+        return cls.from_files(**paths)
+
+    @classmethod
+    def from_zip(cls, source: Path | BinaryIO) -> DataDictionary:
+        """Load a data dictionary from a ZIP archive containing the required CSVs."""
+
+        with zipfile.ZipFile(source) as zf:
+            data: dict[str, list[dict[str, str]]] = {}
+            for name, attr in cls.REQUIRED_FILES.items():
+                with zf.open(name) as fh:
+                    with io.TextIOWrapper(fh, encoding="utf-8") as text_fh:
+                        data[attr] = cls._load_csv(text_fh)
+        return DataDictionary(**data)

--- a/tests/fixtures/data_dictionary/BUSINESS_LOGIC.csv
+++ b/tests/fixtures/data_dictionary/BUSINESS_LOGIC.csv
@@ -1,0 +1,4 @@
+Type,Name,Status,ID,Form
+Form,Auto-Sequence AENUM,Active,101712,AE
+Form,Remove DEE KW,Active,101891,AE
+Form,Disable AENUM,Active,101713,AE

--- a/tests/fixtures/data_dictionary/CHOICES.csv
+++ b/tests/fixtures/data_dictionary/CHOICES.csv
@@ -1,0 +1,4 @@
+Form,Variable Type,Variable Name,Choice Text,Choice Value,Position
+AE,Radio,AESEV,Grade 1,1,1
+AE,Radio,AESEV,Grade 2,2,2
+AE,Radio,AESEV,Grade 3,3,3

--- a/tests/fixtures/data_dictionary/FORMS.csv
+++ b/tests/fixtures/data_dictionary/FORMS.csv
@@ -1,0 +1,4 @@
+Form ID,Form Key,Form Type,Form Name
+10202,AE,Patient,Adverse Event
+10265,AEACTEL,Patient,Adverse Event Action EL
+10305,AESDC,Patient,Adverse Event SDC

--- a/tests/fixtures/data_dictionary/QUESTIONS.csv
+++ b/tests/fixtures/data_dictionary/QUESTIONS.csv
@@ -1,0 +1,4 @@
+Form,Variable Type,Variable Name,Label
+AE,Date/Time Precision,AESTDAT,Date of event onset:
+AE,Date/Time Precision,AEENDAT,Date of resolution or death:
+AE,Number,AENUM,AE number:

--- a/tests/unit/test_data_dictionary.py
+++ b/tests/unit/test_data_dictionary.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+import io
+import zipfile
+from pathlib import Path
+
+from imednet.validation import DataDictionary, DataDictionaryLoader
+
+FIXTURES = Path(__file__).parent.parent / "fixtures" / "data_dictionary"
+
+
+def _expected() -> DataDictionary:
+    return DataDictionaryLoader.from_directory(FIXTURES)
+
+
+def test_from_directory() -> None:
+    dd = DataDictionaryLoader.from_directory(FIXTURES)
+    assert isinstance(dd, DataDictionary)
+    assert len(dd.forms) == 3
+    assert dd.forms[0]["Form Key"] == "AE"
+
+
+def test_from_zip() -> None:
+    buffer = io.BytesIO()
+    with zipfile.ZipFile(buffer, "w") as zf:
+        for name in DataDictionaryLoader.REQUIRED_FILES:
+            zf.write(FIXTURES / name, arcname=name)
+    buffer.seek(0)
+    dd = DataDictionaryLoader.from_zip(buffer)
+    expected = _expected()
+    assert dd == expected


### PR DESCRIPTION
## Summary
- add DataDictionaryLoader to read data dictionaries from CSV files or ZIP archives
- expose data dictionary utilities from validation package
- add unit tests for CSV and ZIP loading

## Testing
- `poetry run ruff check --fix .`
- `poetry run black --check .`
- `poetry run isort --check --profile black .`
- `poetry run mypy imednet`
- `poetry run pytest tests/unit/test_data_dictionary.py -q`


------
https://chatgpt.com/codex/tasks/task_e_689b54f4f590832c87020536a1b29797