### PR TITLE
test: extend poll_job timeout in live tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added docstrings to private helpers in ``core/_requester.py``.
 - Documented ``SchemaValidator.refresh`` behavior.
 - Added tests covering the default sentinel date in ``parse_datetime``.
+- Increased timeout in live ``poll_job`` tests to reduce flakiness.
 - Organized Airflow integration code into ``hooks``, ``operators`` and ``sensors`` subpackages.
 - Grouped CLI commands into dedicated subpackages for easier navigation.
 - Fixed ``ImednetHook`` to import configuration from the correct package.

--- a/tests/live/test_cli_live.py
+++ b/tests/live/test_cli_live.py
@@ -40,7 +40,7 @@ def test_cli_jobs_status(runner: CliRunner, study_key: str, generated_batch_id: 
 def test_cli_jobs_wait(runner: CliRunner, study_key: str, generated_batch_id: str) -> None:
     result = runner.invoke(
         cli.app,
-        ["jobs", "wait", study_key, generated_batch_id],
+        ["jobs", "wait", study_key, generated_batch_id, "--interval", "1", "--timeout", "60"],
     )
     assert result.exit_code == 0
 

--- a/tests/live/test_sdk_utilities_live.py
+++ b/tests/live/test_sdk_utilities_live.py
@@ -66,5 +66,5 @@ def test_get_job(sdk: ImednetSDK, study_key: str, generated_batch_id: str) -> No
 
 
 def test_poll_job(sdk: ImednetSDK, study_key: str, generated_batch_id: str) -> None:
-    job = sdk.poll_job(study_key, generated_batch_id, interval=1, timeout=5)
+    job = sdk.poll_job(study_key, generated_batch_id, interval=1, timeout=60)
     assert job.batch_id == generated_batch_id


### PR DESCRIPTION
## Summary
- extend poll_job timeout in sdk utilities live test to 60s
- pass interval and timeout options to CLI jobs wait live test
- document timeout increase in changelog

## Testing
- `poetry run ruff check --fix .`
- `poetry run black --check .`
- `poetry run isort --check --profile black .`
- `poetry run mypy imednet`
- `poetry run pytest -q` *(killed)*
- `poetry run pytest tests/live/test_sdk_utilities_live.py::test_poll_job tests/live/test_cli_live.py::test_cli_jobs_wait -q` *(failed: JobTimeoutError)*

------
