### PR TITLE
fix(cli): fallback to long-format on SQLite column limit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added docstrings to private helpers in ``core/_requester.py``.
 - Documented ``SchemaValidator.refresh`` behavior.
 - Added tests covering the default sentinel date in ``parse_datetime``.
+- `export_sql` command now falls back to `--long-format` when SQLite column limit is exceeded.
 - Organized Airflow integration code into ``hooks``, ``operators`` and ``sensors`` subpackages.
 - Grouped CLI commands into dedicated subpackages for easier navigation.
 - Fixed ``ImednetHook`` to import configuration from the correct package.


### PR DESCRIPTION
## Summary
- add automatic long-format fallback to `export sql` when SQLite column limit is hit
- inform users to use `--long-format` in future runs
- test CLI fallback path

## Testing
- `poetry run ruff check --fix imednet/cli/export/__init__.py tests/integration/test_sqlite_export_modes.py tests/live/test_cli_live.py`
- `poetry run black --check .`
- `poetry run isort --check --profile black .`
- `poetry run mypy imednet`
- `poetry run pytest tests/unit/cli/test_cli.py -q`
- `poetry run pytest tests/unit/test_integrations_export.py -q`
- `poetry run pytest tests/integration/test_sqlite_export_modes.py -q`
- `poetry run pytest -q` *(fails: process killed)*

------
