### PR TITLE
fix(cli): close SDK after command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+- CLI now closes the SDK after each command to free resources and avoid
+  interrupt-driven exit codes in repeated invocations.
 - Fixed generated batch fixture in live tests to submit valid record data by
     populating required variables, ensuring CLI job polling succeeds.
 - Split wide SQLite exports across multiple tables to avoid the 2000-column limit.

--- a/imednet/cli/decorators.py
+++ b/imednet/cli/decorators.py
@@ -35,6 +35,10 @@ def with_sdk(func: Callable[Concatenate[ImednetSDK, P], R]) -> Callable[P, R]:
         except Exception as exc:  # pragma: no cover - defensive
             print(f"[bold red]Unexpected error:[/bold red] {exc}")
             raise typer.Exit(code=1)
+        finally:
+            close = getattr(sdk, "close", None)
+            if callable(close):
+                close()
 
     wrapper.__signature__ = sig.replace(parameters=wrapper_params)  # type: ignore[attr-defined]
 

--- a/tests/unit/cli/test_cli.py
+++ b/tests/unit/cli/test_cli.py
@@ -61,6 +61,14 @@ def test_sdk_closed_after_command(runner: CliRunner, sdk: MagicMock) -> None:
     sdk.close.assert_called_once()
 
 
+def test_multiple_invocations_close_sdk(runner: CliRunner, sdk: MagicMock) -> None:
+    sdk.studies.list.return_value = []
+    first = runner.invoke(cli.app, ["studies", "list"])
+    second = runner.invoke(cli.app, ["studies", "list"])
+    assert first.exit_code == 0 and second.exit_code == 0
+    assert sdk.close.call_count == 2
+
+
 def test_sites_list_success(runner: CliRunner, sdk: MagicMock) -> None:
     sdk.sites.list.return_value = ["site1"]
     result = runner.invoke(cli.app, ["sites", "list", "STUDY"])

--- a/tests/unit/cli/test_cli.py
+++ b/tests/unit/cli/test_cli.py
@@ -54,6 +54,13 @@ def test_studies_list_api_error(runner: CliRunner, sdk: MagicMock) -> None:
     assert "API Error" in result.stdout
 
 
+def test_sdk_closed_after_command(runner: CliRunner, sdk: MagicMock) -> None:
+    sdk.studies.list.return_value = []
+    result = runner.invoke(cli.app, ["studies", "list"])
+    assert result.exit_code == 0
+    sdk.close.assert_called_once()
+
+
 def test_sites_list_success(runner: CliRunner, sdk: MagicMock) -> None:
     sdk.sites.list.return_value = ["site1"]
     result = runner.invoke(cli.app, ["sites", "list", "STUDY"])


### PR DESCRIPTION
## Summary
- ensure CLI closes SDK after each command
- test CLI invokes SDK close

## Testing
- `poetry run ruff check --fix .`
- `poetry run black --check .`
- `poetry run isort --check --profile black .`
- `poetry run mypy imednet`
- `poetry run pytest -q` *(fails: Killed)*

------
