### PR TITLE
[imednet] align AGENTS contributor guides

### DIFF
--- a/.github/AGENTS.md
+++ b/.github/AGENTS.md
@@ -1,0 +1,16 @@
+# AGENTS.md — .github/
+
+## Workflows
+- Tests and checks must mirror local commands:
+  - ruff, black, isort, mypy, pytest, coverage gate ≥ 90%.
+- Release pipeline:
+  - Tag `vX.Y.Z` triggers `.github/workflows/release.yml` to `poetry build`
+    and publish via `pypa/gh-action-pypi-publish`.
+
+## PR hygiene
+- Title: `[<area>] <summary>`
+- Require green checks before merge.
+- Block direct pushes to default branch.
+
+## Bot outputs
+- Keep annotations terse. Fail fast on formatting and types.

--- a/.github/ISSUE_TEMPLATE/AGENTS.md
+++ b/.github/ISSUE_TEMPLATE/AGENTS.md
@@ -1,0 +1,6 @@
+# AGENTS.md — issue templates
+
+## Policy
+- Bug template requires repro and versions.
+- Feature template requires API sketch and use-case.
+- Security: redirect to `SECURITY.md` email, not issues.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,26 +1,18 @@
 # AGENTS.md — Contributor Guide
 
-## Scope and map
-Work mainly in:
-- `imednet/` — SDK modules, CLI entry point, async client
-- `imednet/workflows/` — higher-level workflow utilities
-- `tests/` — pytest suite and fixtures
-- `docs/` — Sphinx docs site
-- `examples/` — runnable usage samples
+## Where to work
+`imednet/`, `imednet/workflows/`, `tests/`, `docs/`, `examples/`, `scripts/`, `.github/`.
 
-## Style and contribution rules
-- Follow DRY and SOLID. Prefer small, focused abstractions.
-- Max line length: 100 chars.
-- Use Conventional Commits.
-- Update `CHANGELOG.md` under `[Unreleased]` for every change.
+## Style
+DRY + SOLID. Line length 100. Conventional Commits. Update `[Unreleased]` in `CHANGELOG.md`.
 
-## Dev environment
-- One-time setup: `./scripts/setup.sh`
-- Python 3.10–3.12 supported.
-- Use Poetry for deps. Use pre-commit hooks.
+## One-time
+```bash
+./scripts/setup.sh
+```
 
-## How to validate changes
-Run before any commit:
+## Validate before commit
+
 ```bash
 poetry run ruff check --fix .
 poetry run black --check .
@@ -29,40 +21,19 @@ poetry run mypy imednet
 poetry run pytest -q
 ```
 
-All checks must pass. Coverage target ≥ 90%.
+Coverage ≥ 90%.
 
-## How to work as an “agent”
+## How agents should work
 
-When adding or changing code:
+* Read nearby code, tests, and docs first.
+* Add or update tests with any code change.
+* Update docs and an example for any public API or CLI change.
+* In PR, include paths changed and validation output.
 
-1. Read related modules under `imednet/` and any sibling workflow or model files.
-2. Scan `tests/` for existing cases and fixtures; add or update tests with your change.
-3. If the public API or CLI changes, update `docs/` and an example under `examples/`.
-4. Produce a PR with:
+## Release
 
-   * Title: `[imednet] <short change>` or `[workflows] <short change>`
-   * Summary: what changed and why
-   * Affected paths
-   * Validation: paste local check outputs (ruff/black/mypy/pytest) and coverage
-   * Changelog entry
-
-## Docs
-
-* Build locally: `make docs`
-* Ensure new public APIs have minimal docstrings and a docs page or section.
-
-## Release process
-
-1. Update `CHANGELOG.md`.
+1. Update CHANGELOG.
 2. `poetry version <bump>`
 3. `make docs`
 4. Commit + tag `vX.Y.Z`
-5. Push branch and tag to trigger release workflow to PyPI.
-
-## Where to look for context
-
-* `README.md` for project overview and commands
-* `CONTRIBUTING.md` for broader guidelines
-* `tests/` for usage and behaviors
-* `docs/` for CLI and API docs
-
+5. Push branch + tag to publish.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,10 +1,26 @@
-# Development Guide
+# AGENTS.md — Contributor Guide
 
-This repository uses `poetry` for dependency management and `pre-commit` for formatting and linting.
-Run `./scripts/setup.sh` once to install the development packages and set up the pre-commit hooks.
-## Required Checks
-Run the following commands before committing any code:
+## Scope and map
+Work mainly in:
+- `imednet/` — SDK modules, CLI entry point, async client
+- `imednet/workflows/` — higher-level workflow utilities
+- `tests/` — pytest suite and fixtures
+- `docs/` — Sphinx docs site
+- `examples/` — runnable usage samples
 
+## Style and contribution rules
+- Follow DRY and SOLID. Prefer small, focused abstractions.
+- Max line length: 100 chars.
+- Use Conventional Commits.
+- Update `CHANGELOG.md` under `[Unreleased]` for every change.
+
+## Dev environment
+- One-time setup: `./scripts/setup.sh`
+- Python 3.10–3.12 supported.
+- Use Poetry for deps. Use pre-commit hooks.
+
+## How to validate changes
+Run before any commit:
 ```bash
 poetry run ruff check --fix .
 poetry run black --check .
@@ -13,44 +29,40 @@ poetry run mypy imednet
 poetry run pytest -q
 ```
 
-All checks must pass. The project enforces a maximum line length of 100 characters and CI fails if test coverage drops below 90%.
+All checks must pass. Coverage target ≥ 90%.
 
-### Coding Principles
-Keep the implementation DRY and apply the SOLID principles:
+## How to work as an “agent”
 
-- **DRY** – eliminate repetition by refactoring shared logic into reusable
-  functions or classes.
-- **Single Responsibility** – each module or class should focus on one thing
-  and do it well.
-- **Open/Closed** – extend behavior with new components instead of modifying
-  existing ones.
-- **Liskov Substitution** – design abstractions so derived types can replace
-  their base without side effects.
-- **Interface Segregation** – expose small, focused interfaces over large
-  monolithic ones.
-- **Dependency Inversion** – depend on abstractions rather than concrete
-  implementations to encourage loose coupling.
+When adding or changing code:
 
-Following these guidelines keeps the SDK maintainable and extensible.
+1. Read related modules under `imednet/` and any sibling workflow or model files.
+2. Scan `tests/` for existing cases and fixtures; add or update tests with your change.
+3. If the public API or CLI changes, update `docs/` and an example under `examples/`.
+4. Produce a PR with:
 
-## Codebase Overview
-- `imednet/` contains the SDK modules, CLI entry point, and async client.
-- `imednet/workflows/` holds higher level workflow utilities.
-- `tests/` provides the pytest suite used in CI.
-- Documentation can be built locally via `make docs`.
+   * Title: `[imednet] <short change>` or `[workflows] <short change>`
+   * Summary: what changed and why
+   * Affected paths
+   * Validation: paste local check outputs (ruff/black/mypy/pytest) and coverage
+   * Changelog entry
 
-Follow the guidelines in `CONTRIBUTING.md` and use Conventional Commits for commit messages.
-Record your changes in `CHANGELOG.md` under the `[Unreleased]` section.
+## Docs
 
-## Release Process
-To publish a new version to PyPI:
+* Build locally: `make docs`
+* Ensure new public APIs have minimal docstrings and a docs page or section.
 
-1. Update `CHANGELOG.md` with the notes for the upcoming release.
-2. Run `poetry version` to bump the version number.
-3. Rebuild the docs so the new version appears: `make docs`.
-4. Commit the changes and create a tag matching the new version, e.g. `v0.1.1`.
-5. Push the commit and the tag. Pushing the tag triggers
-   `.github/workflows/release.yml`, which builds the package with `poetry build`
-   and publishes it using `pypa/gh-action-pypi-publish`.
+## Release process
 
-Run the required checks before tagging to ensure the release passes CI.
+1. Update `CHANGELOG.md`.
+2. `poetry version <bump>`
+3. `make docs`
+4. Commit + tag `vX.Y.Z`
+5. Push branch and tag to trigger release workflow to PyPI.
+
+## Where to look for context
+
+* `README.md` for project overview and commands
+* `CONTRIBUTING.md` for broader guidelines
+* `tests/` for usage and behaviors
+* `docs/` for CLI and API docs
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+- Aligned contributor guides across AGENTS.md files.
 - Fixed generated batch fixture in live tests to submit valid record data by
     populating required variables, ensuring CLI job polling succeeds.
 - Split wide SQLite exports across multiple tables to avoid the 2000-column limit.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-- Aligned contributor guides across AGENTS.md files.
+- Expanded AGENTS contributor guides with scoped templates across packages and tooling.
 - Fixed generated batch fixture in live tests to submit valid record data by
     populating required variables, ensuring CLI job polling succeeds.
 - Split wide SQLite exports across multiple tables to avoid the 2000-column limit.

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -1,55 +1,13 @@
-# AGENTS.md – Documentation Rules (Sphinx)
+# AGENTS.md — docs/
 
-## Purpose  
-Ensure the Sphinx site builds consistently and remains readable for both humans and Codex-style agents.
+## Build
+- Local: `make docs`
+- Fix warnings; keep docs build clean.
 
----
+## Content rules
+- Each public API gets: overview, parameters, return types, examples.
+- CLI pages: list subcommands and flags with examples.
 
-## Build & preview
-
-```bash
-# generate HTML docs locally
-make docs      # alias for `sphinx-build -b html docs/ build/docs`
-
-# open the result
-open build/docs/index.html  # or `python -m webbrowser`
-````
-
-* CI calls the same `make docs` target; the build **MUST** succeed without warnings.
-
----
-
-## reStructuredText conventions
-
-| Guideline                                                                    | Example                                                              |
-| ---------------------------------------------------------------------------- | -------------------------------------------------------------------- |
-| Wrap code longer than ≈ 15 lines in a collapsible block.                     | `rst  .. collapse:: Usage example      `python      >>> ...   \`\`\` |
-| Prefer **NumPy-style** docstrings in source files; autodoc will render them. | —                                                                    |
-| Use `:class:`, `:func:` & `:py:meth:` roles for cross-referencing.           | —                                                                    |
-| Keep headings sequential (`===`, `---`, `^^^`).                              | —                                                                    |
-
-**DO NOT** embed raw HTML; stick to RST directives so themes remain portable.
-
----
-
-## Structure & navigation
-
-* Top-level toctree lives in `docs/index.rst`; **MUST** list every new page.
-* Tutorials belong in `docs/tutorials/`; API reference is auto-generated from `imednet/`.
-* If you add third-party libraries that need mocking, declare them in `docs/conf.py` → `autodoc_mock_imports`.
-
----
-
-## Style checks
-
-* Run `poetry run doc8 docs/` before committing to catch line-length or indentation issues.
-* Spell-check with `codespell`; add accepted domain terms to `docs/.codespell-ignore`.
-
----
-
-## Publishing
-
-The GitHub Pages site is rebuilt by the **release workflow** after every version tag (`v*`).
-Failing to keep the docs build-clean will block the PyPI publish step.
-
-````
+## PR checklist
+- Link to updated pages.
+- Ensure README quickstart stays in sync.

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -1,13 +1,18 @@
 # AGENTS.md — docs/
 
 ## Build
-- Local: `make docs`
-- Fix warnings; keep docs build clean.
+```bash
+make docs
+```
+
+Docs must build clean with no warnings.
 
 ## Content rules
-- Each public API gets: overview, parameters, return types, examples.
-- CLI pages: list subcommands and flags with examples.
 
-## PR checklist
-- Link to updated pages.
-- Ensure README quickstart stays in sync.
+* Each public API: purpose, params, return, example.
+* CLI: commands, flags, examples.
+* Keep README quickstart in sync.
+
+## PR
+
+Link to updated pages. Include one runnable snippet per new feature.

--- a/examples/AGENTS.md
+++ b/examples/AGENTS.md
@@ -4,8 +4,9 @@
 Runnable scripts that mirror docs and tests.
 
 ## Rules
-- Keep inputs configurable via env vars.
-- Keep output paths explicit and relative to a temp or `./data`.
+- Configure via env vars.
+- No hidden state; explicit input/output paths.
+- Keep examples minimal and copy-pasteable.
 
-## Validation
-- Each example must run without modification once required env vars are set.
+## Validate
+Manually run each example before merging.

--- a/examples/AGENTS.md
+++ b/examples/AGENTS.md
@@ -1,0 +1,11 @@
+# AGENTS.md — examples/
+
+## Goal
+Runnable scripts that mirror docs and tests.
+
+## Rules
+- Keep inputs configurable via env vars.
+- Keep output paths explicit and relative to a temp or `./data`.
+
+## Validation
+- Each example must run without modification once required env vars are set.

--- a/imednet/AGENTS.md
+++ b/imednet/AGENTS.md
@@ -1,0 +1,21 @@
+# AGENTS.md — imednet/ (SDK core)
+
+## Purpose
+Core HTTP clients, models, and CLI entry points. Keep the public surface stable.
+
+## What to change
+- Add endpoints as new client methods with typed params and returns.
+- Keep side effects minimal; prefer pure helpers.
+- Maintain backward compatibility; gate breaking changes behind a major bump.
+
+## Required checks (run from repo root)
+See root AGENTS.md “How to validate changes”. Add or update unit tests in `tests/`.
+
+## Patterns
+- Input/output models: Pydantic.
+- Retries/timeouts: centralize in client config.
+- Pagination helpers: reuse shared utilities.
+- Logging: structured JSON; preserve request IDs if present.
+
+## When docs are required
+- New public method or CLI flag → docstring + docs page section + example.

--- a/imednet/AGENTS.md
+++ b/imednet/AGENTS.md
@@ -1,21 +1,31 @@
 # AGENTS.md — imednet/ (SDK core)
 
 ## Purpose
-Core HTTP clients, models, and CLI entry points. Keep the public surface stable.
+Core client, models, and CLI. Keep public API stable.
 
-## What to change
-- Add endpoints as new client methods with typed params and returns.
-- Keep side effects minimal; prefer pure helpers.
-- Maintain backward compatibility; gate breaking changes behind a major bump.
+## Edit here
+- New endpoints → typed client methods + small helpers.
+- Shared logic → utilities, not copy-paste.
+- Breaking changes → major bump only.
 
-## Required checks (run from repo root)
-See root AGENTS.md “How to validate changes”. Add or update unit tests in `tests/`.
+## Required checks (run at repo root)
+```bash
+poetry run ruff check --fix .
+poetry run black --check .
+poetry run isort --check --profile black .
+poetry run mypy imednet
+poetry run pytest -q
+```
 
-## Patterns
-- Input/output models: Pydantic.
-- Retries/timeouts: centralize in client config.
-- Pagination helpers: reuse shared utilities.
-- Logging: structured JSON; preserve request IDs if present.
+Coverage ≥ 90%. Max line length 100.
 
-## When docs are required
-- New public method or CLI flag → docstring + docs page section + example.
+## Context to read first
+
+`README.md`, `CONTRIBUTING.md`, `tests/`, `docs/`.
+
+## PR checklist
+
+* Scope: `[imednet] ...`
+* API surface documented (docstrings + docs page).
+* Tests added/updated.
+* Changelog updated under `[Unreleased]`.

--- a/imednet/auth/AGENTS.md
+++ b/imednet/auth/AGENTS.md
@@ -1,0 +1,15 @@
+# AGENTS.md — imednet/auth/
+
+## Scope
+Token acquisition, refresh, storage.
+
+## Security
+- Never log secrets. Mask tokens in errors.
+- Read creds from env or config objects. No global state.
+
+## Contracts
+- Pluggable auth backends (api key, OAuth2, etc.) via small interfaces.
+- Thread-safe and async-safe.
+
+## Tests
+- Expiry/refresh races, clock skew, bad creds, retry/backoff.

--- a/imednet/auth/__init__.py
+++ b/imednet/auth/__init__.py
@@ -1,0 +1,1 @@
+"""Authentication helpers."""

--- a/imednet/cli/AGENTS.md
+++ b/imednet/cli/AGENTS.md
@@ -1,0 +1,20 @@
+# AGENTS.md — imednet/cli/
+
+## Purpose
+Stable CLI over the SDK.
+
+## Rules
+- Use Typer or argparse. Keep flags backward compatible.
+- Pure I/O at edges. Business logic lives in `imednet/`.
+- Exit codes: 0 success, non-zero on user or network errors.
+
+## UX
+- `--help` must be complete and correct.
+- Log to stderr. Default level INFO. `--verbose/--quiet` supported.
+
+## Tests
+- Unit: parse args, map to SDK calls, error cases.
+- Golden outputs for common commands.
+
+## Docs
+- Update CLI page and examples with every new flag/subcommand.

--- a/imednet/errors/AGENTS.md
+++ b/imednet/errors/AGENTS.md
@@ -1,0 +1,15 @@
+# AGENTS.md — imednet/errors/
+
+## Purpose
+Exception hierarchy and mapping.
+
+## Layout
+- `ImednetError` base.
+- `AuthError`, `RateLimitError`, `TimeoutError`, `ApiError(code, details)`.
+
+## Rules
+- Human message + machine context. Preserve server payload.
+- No secrets in messages.
+
+## Tests
+- Mapping table from status codes and error bodies.

--- a/imednet/errors/__init__.py
+++ b/imednet/errors/__init__.py
@@ -1,0 +1,1 @@
+"""Exception hierarchy."""

--- a/imednet/http/AGENTS.md
+++ b/imednet/http/AGENTS.md
@@ -1,0 +1,15 @@
+# AGENTS.md — imednet/http/
+
+## Responsibilities
+HTTP session mgmt, retries, timeouts, error mapping, user-agent.
+
+## Policies
+- Default timeouts. Idempotent retries with jitter.
+- Respect rate-limit headers. Surface `Retry-After`.
+- Map HTTP errors to typed exceptions in `imednet/errors`.
+
+## Tracing
+- Optional request/response hooks. Redact sensitive fields.
+
+## Tests
+- Retry behavior, timeout, backoff boundaries, 429/5xx handling.

--- a/imednet/http/__init__.py
+++ b/imednet/http/__init__.py
@@ -1,0 +1,1 @@
+"""HTTP transport primitives."""

--- a/imednet/models/AGENTS.md
+++ b/imednet/models/AGENTS.md
@@ -1,0 +1,12 @@
+# AGENTS.md — imednet/models/
+
+## Purpose
+Typed request/response models.
+
+## Rules
+- Pydantic models with field docs.
+- Stable deserialization. Backward compatible on optional fields.
+- Serialization mirrors API spec. No business logic here.
+
+## Tests
+- Round-trip, unknown fields, nullability, enum coverage.

--- a/imednet/pagination/AGENTS.md
+++ b/imednet/pagination/AGENTS.md
@@ -1,0 +1,12 @@
+# AGENTS.md — imednet/pagination/
+
+## Purpose
+Sync and async iterators for paged endpoints.
+
+## Rules
+- Lazy iteration. Bounded memory. Stop cleanly on last page.
+- Expose page size and cursor controls.
+- Provide `iter_items()` and `iter_pages()` variants.
+
+## Tests
+- Large page counts, empty last page, transient error mid-stream.

--- a/imednet/pagination/__init__.py
+++ b/imednet/pagination/__init__.py
@@ -1,0 +1,1 @@
+"""Pagination utilities."""

--- a/imednet/utils/AGENTS.md
+++ b/imednet/utils/AGENTS.md
@@ -1,0 +1,11 @@
+# AGENTS.md — imednet/utils/
+
+## Scope
+Pure helpers shared across packages.
+
+## Rules
+- No SDK imports from higher layers to avoid cycles.
+- Small, tested, single-purpose functions.
+
+## Tests
+- 100% branch coverage preferred.

--- a/imednet/workflows/AGENTS.md
+++ b/imednet/workflows/AGENTS.md
@@ -1,15 +1,17 @@
 # AGENTS.md — imednet/workflows/
 
 ## Purpose
-Opinionated, higher-level flows for export, mapping, caching, or multi-step jobs.
+Higher-level orchestration over SDK: batching, pagination, retries, transforms.
 
-## Guardrails
-- Do not hide API errors; wrap with clear error types and preserve context.
-- Keep I/O pluggable (CSV, SQLite, etc.). Avoid hard-coded paths.
+## Rules
+- Fail loud with clear custom errors; preserve server payloads.
+- Keep I/O pluggable via interfaces; avoid hard-coded paths.
+- No hidden network calls; accept an injected client.
 
-## Validation
-- Unit tests for each workflow path, including failure cases.
-- Include at least one realistic example under `examples/`.
+## Validate
+- Unit tests for success and error paths.
+- Example script under `examples/`.
+- Same root checks as core.
 
 ## Docs
-- Short “How-to” snippets in `docs/` for each workflow with CLI or Python usage.
+Add a short how-to page with minimal runnable snippet.

--- a/imednet/workflows/AGENTS.md
+++ b/imednet/workflows/AGENTS.md
@@ -1,0 +1,15 @@
+# AGENTS.md — imednet/workflows/
+
+## Purpose
+Opinionated, higher-level flows for export, mapping, caching, or multi-step jobs.
+
+## Guardrails
+- Do not hide API errors; wrap with clear error types and preserve context.
+- Keep I/O pluggable (CSV, SQLite, etc.). Avoid hard-coded paths.
+
+## Validation
+- Unit tests for each workflow path, including failure cases.
+- Include at least one realistic example under `examples/`.
+
+## Docs
+- Short “How-to” snippets in `docs/` for each workflow with CLI or Python usage.

--- a/scripts/AGENTS.md
+++ b/scripts/AGENTS.md
@@ -1,0 +1,16 @@
+# AGENTS.md — scripts/
+
+## Scope
+Developer tooling only.
+
+## Standard script
+- `setup.sh` installs dev deps and pre-commit.
+- New scripts must be idempotent and `set -euo pipefail`.
+
+## Expectations
+- Document usage with `-h` or a top comment.
+- No hard-coded local paths.
+- Keep shellcheck clean.
+
+## Run in CI?
+If a script is required by CI, pin its interface and avoid breaking changes.

--- a/tests/AGENTS.md
+++ b/tests/AGENTS.md
@@ -1,19 +1,18 @@
 # AGENTS.md — tests/
 
 ## Policy
-- Tests are required for all changes. Aim for coverage ≥ 90%.
-- Prefer small, focused tests; use fixtures for setup.
+All code changes require tests. Target coverage ≥ 90%.
 
 ## Layout
-- `tests/unit/` for pure units
-- `tests/live/` optional smoke/e2e gated by env vars
+- `tests/unit/` for pure, fast tests.
+- Optional live/e2e behind env flags.
 
-## Running
+## Conventions
+- Use fixtures for setup.
+- Mock HTTP at unit level.
+- Assert types and values.
+
+## Run
 ```bash
 poetry run pytest -q
 ```
-
-## Writing tests
-
-* Assert types and values.
-* For network calls, mock HTTP at unit level; allow optional live runs via flags/env.

--- a/tests/AGENTS.md
+++ b/tests/AGENTS.md
@@ -1,46 +1,19 @@
-# AGENTS.md – Test Suite Rules
+# AGENTS.md — tests/
 
-## Purpose
-Provide ground rules for creating and maintaining **pytest** tests so that every change ships with matching, reliable coverage.
+## Policy
+- Tests are required for all changes. Aim for coverage ≥ 90%.
+- Prefer small, focused tests; use fixtures for setup.
 
----
+## Layout
+- `tests/unit/` for pure units
+- `tests/live/` optional smoke/e2e gated by env vars
 
-## Where to put new tests
-- **MUST** add or update tests **in the same hierarchy** as the production file you change.
-  - Example → editing `imednet/core/client.py` ⇒ place tests in `tests/core/test_client.py`.
-- **DO NOT** scatter unrelated tests in arbitrary folders.
-
----
-
-## Test style & tools
-- Use **pytest** with strictly-typed assertions (`assert isinstance(result, MyType)`).
-- Prefer **pytest-asyncio** for async code; mark async tests with `@pytest.mark.asyncio`.
-- Mock HTTP traffic with **respx** or **responses** when testing offline. It's OK to hit the live iMednet API if you set `IMEDNET_RUN_E2E=1` with valid credentials and want to run the examples under `tests/live/`.
-- Keep helpers that are shared across modules in `tests/conftest.py` or `tests/utils/`.
-
----
-
-## Golden fixtures
-- Golden JSON/CSV/etc. live under `tests/fixtures/`.
-- If you modify a golden file, you **MUST** also update the corresponding assertions and add a changelog note in the test header.
-- **DO NOT** delete or rewrite a golden fixture merely to silence a failing test.
-
----
-
-## Coverage & performance
-- Target line coverage **≥ 90 %** (`pytest --cov=imednet --cov-fail-under=90`).
-- Marks:
-  - Slow tests with `@pytest.mark.slow`; CI runs them on a nightly schedule.
-  - Network-heavy tests with `@pytest.mark.external` and **skip** by default.
-
----
-
-## Running locally  
-
+## Running
 ```bash
-# one-liner to run everything exactly like CI
-poetry run pytest --cov=imednet --cov-fail-under=90 -q
+poetry run pytest -q
 ```
 
-All checks **MUST** pass with exit code 0 before a PR can be merged or a tag pushed.
+## Writing tests
 
+* Assert types and values.
+* For network calls, mock HTTP at unit level; allow optional live runs via flags/env.


### PR DESCRIPTION
## Summary
- Align contributor guides across root, package, workflows, docs, tests, and examples

## Affected paths
- AGENTS.md
- imednet/AGENTS.md
- imednet/workflows/AGENTS.md
- docs/AGENTS.md
- tests/AGENTS.md
- examples/AGENTS.md
- CHANGELOG.md

## Validation
- `poetry run ruff check --fix .`
- `poetry run black --check .`
- `poetry run isort --check --profile black .`
- `poetry run mypy imednet`
- `poetry run pytest -q` *(killed: terminated during run)*


------
