### PR TITLE
docs: refine contributor guides

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,18 +1,10 @@
 # AGENTS.md — Contributor Guide
 
-## Where to work
-`imednet/`, `imednet/workflows/`, `tests/`, `docs/`, `examples/`, `scripts/`, `.github/`.
+## Scope
+Python 3.10–3.12. Work in `imednet/`, `imednet/workflows/`, `tests/`, `docs/`,
+`examples/`, `scripts/`, `.github/`.
 
-## Style
-DRY + SOLID. Line length 100. Conventional Commits. Update `[Unreleased]` in `CHANGELOG.md`.
-
-## One-time
-```bash
-./scripts/setup.sh
-```
-
-## Validate before commit
-
+## Validate
 ```bash
 poetry run ruff check --fix .
 poetry run black --check .
@@ -20,18 +12,23 @@ poetry run isort --check --profile black .
 poetry run mypy imednet
 poetry run pytest -q
 ```
-
 Coverage ≥ 90%.
 
-## How agents should work
+## Contribute
+DRY + SOLID. Line length 100. Conventional Commits. Update `[Unreleased]` in
+`CHANGELOG.md`.
 
 * Read nearby code, tests, and docs first.
 * Add or update tests with any code change.
 * Update docs and an example for any public API or CLI change.
 * In PR, include paths changed and validation output.
 
-## Release
+## Setup
+```bash
+./scripts/setup.sh
+```
 
+## Release
 1. Update CHANGELOG.
 2. `poetry version <bump>`
 3. `make docs`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 - Expanded AGENTS contributor guides with scoped templates across packages and tooling.
+- Refined contributor guides: mapped project scope, Python 3.10–3.12 support, and
+  unified validation for ruff, black, isort, mypy, and pytest across docs,
+  tests, examples, and workflows.
 - CLI now closes the SDK after each command to free resources and avoid
   interrupt-driven exit codes in repeated invocations.
 - Fixed generated batch fixture in live tests to submit valid record data by

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,62 +1,38 @@
-# Contributing to iMednet Python SDK
+# Contributing
 
-We love your input! We want to make contributing to this project as easy and transparent as possible, whether it's:
+## Project scope
+The SDK targets Python 3.10–3.12 and includes:
 
-- Reporting a bug
-- Discussing the current state of the codebase
-- Submitting a fix or new feature
+- Core client and models under `imednet/`
+- Workflows in `imednet/workflows/`
+- Docs, tests, examples, and tooling in their directories
 
-## How to Contribute
-
-1. Fork the repository.
-2. Create a new branch: `git checkout -b feature/my-feature` or `git checkout -b fix/my-bug`.
-3. Write tests for your change (`pytest`).
-4. Ensure code style with `black`, `ruff`, and type checks with `mypy`.
-5. Commit your changes following Conventional Commits:
-   - `feat: add new endpoint for X`
-   - `fix: correct pagination logic`
-6. Push to your fork: `git push origin feature/my-feature`.
-7. Open a Pull Request.
-
-Please adhere to the [Code of Conduct](CODE_OF_CONDUCT.md).
-
-## Reporting Bugs
-
-Use the [bug report template](.github/ISSUE_TEMPLATE/bug_report.md) and provide:
-
-- Version of the SDK
-- Python version
-- Steps to reproduce
-- Expected vs actual behavior
-
-## Suggesting Enhancements
-
-Use the [feature request template](.github/ISSUE_TEMPLATE/feature_request.md).
-
-## Style Guides
-
-- Follow [PEP 8](https://peps.python.org/pep-0008/).
-- Use `black` for formatting.
-- No trailing whitespace.
-
-## Documentation
-
-Documentation is built locally using Sphinx. There is no longer a CI workflow for automatic documentation deployment. To build the docs, run:
-
+## Setup
 ```bash
 ./scripts/setup.sh
-poetry run sphinx-build -b html docs docs/_build/html
 ```
 
-Open `docs/_build/html/index.html` in your browser to view the documentation.
-
-## Tests
-
-Run tests locally:
+## Validation
+Run before committing:
 
 ```bash
-poetry run pytest
+poetry run ruff check --fix .
+poetry run black --check .
+poetry run isort --check --profile black .
+poetry run mypy imednet
+poetry run pytest -q
 ```
+Coverage must stay ≥ 90%.
 
-Run `./scripts/setup.sh` before running tests to ensure all development
-dependencies are installed and pre-commit hooks are set up.
+## Conventions
+- DRY + SOLID. Line length 100.
+- Use Conventional Commits.
+- Update `[Unreleased]` in `CHANGELOG.md`.
+- Add tests, docs, and examples for any public change.
+
+## Pull requests
+1. Fork the repository and create a feature branch.
+2. Include validation output in the PR description.
+3. Keep PRs scoped; one change per PR.
+4. Please follow the [Code of Conduct](CODE_OF_CONDUCT.md).
+

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -1,18 +1,18 @@
 # AGENTS.md — docs/
 
-## Build
+## Scope
+Sphinx docs.
+
+## Validate
 ```bash
 make docs
 ```
+No warnings.
 
-Docs must build clean with no warnings.
-
-## Content rules
-
-* Each public API: purpose, params, return, example.
-* CLI: commands, flags, examples.
-* Keep README quickstart in sync.
+## Content
+- Each public API: purpose, params, return, example.
+- CLI: commands, flags, examples.
+- Keep README quickstart in sync.
 
 ## PR
-
-Link to updated pages. Include one runnable snippet per new feature.
+Link to updated pages and include one runnable snippet per new feature.

--- a/examples/AGENTS.md
+++ b/examples/AGENTS.md
@@ -1,6 +1,6 @@
 # AGENTS.md — examples/
 
-## Goal
+## Scope
 Runnable scripts that mirror docs and tests.
 
 ## Rules

--- a/imednet/AGENTS.md
+++ b/imednet/AGENTS.md
@@ -1,14 +1,14 @@
 # AGENTS.md — imednet/ (SDK core)
 
-## Purpose
-Core client, models, and CLI. Keep public API stable.
+## Scope
+Core client, models, and CLI. Keep the public API stable.
 
-## Edit here
-- New endpoints → typed client methods + small helpers.
+## Change policy
+- New endpoints → typed client methods with small helpers.
 - Shared logic → utilities, not copy-paste.
 - Breaking changes → major bump only.
 
-## Required checks (run at repo root)
+## Validate
 ```bash
 poetry run ruff check --fix .
 poetry run black --check .
@@ -16,16 +16,13 @@ poetry run isort --check --profile black .
 poetry run mypy imednet
 poetry run pytest -q
 ```
-
 Coverage ≥ 90%. Max line length 100.
 
-## Context to read first
-
-`README.md`, `CONTRIBUTING.md`, `tests/`, `docs/`.
+## Docs
+Document any public surface (docstrings + docs page) and update examples.
 
 ## PR checklist
-
-* Scope: `[imednet] ...`
-* API surface documented (docstrings + docs page).
-* Tests added/updated.
-* Changelog updated under `[Unreleased]`.
+- Scope: `[imednet] ...`
+- Tests added/updated.
+- Docs updated.
+- Changelog entry under `[Unreleased]`.

--- a/imednet/workflows/AGENTS.md
+++ b/imednet/workflows/AGENTS.md
@@ -1,17 +1,26 @@
 # AGENTS.md — imednet/workflows/
 
-## Purpose
+## Scope
 Higher-level orchestration over SDK: batching, pagination, retries, transforms.
 
-## Rules
+## Guardrails
 - Fail loud with clear custom errors; preserve server payloads.
 - Keep I/O pluggable via interfaces; avoid hard-coded paths.
 - No hidden network calls; accept an injected client.
 
 ## Validate
-- Unit tests for success and error paths.
-- Example script under `examples/`.
-- Same root checks as core.
+```bash
+poetry run ruff check --fix .
+poetry run black --check .
+poetry run isort --check --profile black .
+poetry run mypy imednet
+poetry run pytest -q
+```
+Coverage ≥ 90%.
+
+## Tests
+Unit tests cover success and error paths.
 
 ## Docs
-Add a short how-to page with minimal runnable snippet.
+Each multi-step job needs a short how-to page with a runnable snippet and an
+example under `examples/`.

--- a/tests/AGENTS.md
+++ b/tests/AGENTS.md
@@ -1,7 +1,16 @@
 # AGENTS.md — tests/
 
-## Policy
-All code changes require tests. Target coverage ≥ 90%.
+## Scope
+Test suite. All code changes require tests. Coverage ≥ 90%.
+
+## Validate
+```bash
+poetry run ruff check --fix .
+poetry run black --check .
+poetry run isort --check --profile black .
+poetry run mypy imednet
+poetry run pytest -q
+```
 
 ## Layout
 - `tests/unit/` for pure, fast tests.
@@ -11,8 +20,3 @@ All code changes require tests. Target coverage ≥ 90%.
 - Use fixtures for setup.
 - Mock HTTP at unit level.
 - Assert types and values.
-
-## Run
-```bash
-poetry run pytest -q
-```


### PR DESCRIPTION
## Summary
- map project scope and Python 3.10–3.12 support in root guidelines
- unify validation steps in tests, docs, examples, core SDK and workflow guides
- log AGENTS alignment in the changelog

## Testing
- `poetry run ruff check --fix .`
- `poetry run black --check .`
- `poetry run isort --check --profile black .`
- `poetry run mypy imednet`
- `poetry run pytest -q` *(fails: command did not complete in allotted time)*

------
https://chatgpt.com/codex/tasks/task_e_689ba8cbcc34832cb533ddb071c6f891