### PR TITLE
fix: extend smoke test polling timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Live tests now discover the first form key automatically and create a job to
   obtain a batch ID, removing the need for `IMEDNET_FORM_KEY` and
   `IMEDNET_BATCH_ID` secrets.
+- Extended smoke test job polling timeout to 90 seconds.
 - Renamed ``models._base`` to ``models.json_base`` to avoid import confusion.
 - Documented the sentinel return value in ``parse_datetime``.
 - Replaced placeholder description in ``workflows/record_update.py``.

--- a/scripts/post_smoke_record.py
+++ b/scripts/post_smoke_record.py
@@ -10,6 +10,9 @@ from imednet.discovery import NoLiveDataError, discover_form_key, discover_study
 from imednet.sdk import ImednetSDK
 
 
+POLL_TIMEOUT = 90
+
+
 def authenticate() -> ImednetSDK:
     """Build an ``ImednetSDK`` using environment credentials."""
     api_key = os.environ["IMEDNET_API_KEY"]
@@ -37,7 +40,7 @@ def build_record(sdk: ImednetSDK, study_key: str, form_key: str) -> Dict[str, An
 def submit_record(sdk: ImednetSDK, study_key: str, record: Dict[str, Any]) -> str:
     """Create ``record`` and return the resulting batch ID."""
     job = sdk.records.create(study_key, [record])
-    status = sdk.poll_job(study_key, job.batch_id, interval=1, timeout=30)
+    status = sdk.poll_job(study_key, job.batch_id, interval=1, timeout=POLL_TIMEOUT)
     if status.state != "COMPLETED":
         raise RuntimeError(f"Record creation failed: {status.state}")
     return status.batch_id

--- a/tests/unit/test_post_smoke_record.py
+++ b/tests/unit/test_post_smoke_record.py
@@ -1,0 +1,14 @@
+from unittest.mock import Mock
+
+import scripts.post_smoke_record as smoke
+
+
+def test_submit_record_uses_configured_timeout() -> None:
+    sdk = Mock()
+    sdk.records.create.return_value = Mock(batch_id="B1")
+    sdk.poll_job.return_value = Mock(state="COMPLETED", batch_id="B1")
+
+    batch_id = smoke.submit_record(sdk, "ST", {"data": {}})
+
+    assert batch_id == "B1"
+    sdk.poll_job.assert_called_once_with("ST", "B1", interval=1, timeout=smoke.POLL_TIMEOUT)


### PR DESCRIPTION
## Summary
- expand smoke record job polling timeout to 90s
- cover smoke script timeout behavior with unit test

## Testing
- `poetry run ruff check --fix .`
- `poetry run black --check .`
- `poetry run isort --check --profile black .`
- `poetry run mypy imednet`
- `IMEDNET_RUN_E2E=0 poetry run pytest -q`


------
