### PR TITLE
feat: expose smoke timeout and job errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Split wide SQLite exports across multiple tables to avoid the 2000-column limit.
 - Added helpers for live tests and smoke script to auto-discover study and form
   keys, removing the `IMEDNET_FORM_KEY` override.
+- Form discovery now skips disabled and non-subject forms to avoid invalid form
+  key errors during record creation.
 - Decoupled live-data discovery from pytest internals and skip the smoke script
   gracefully when no studies or forms are available.
 - Bump project version to `0.1.4`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Refactored endpoint initialization in `ImednetSDK` using a registry.
 - Added `_build_record_payload` helper to `RecordUpdateWorkflow` to deduplicate
   record dictionary construction.
+- Smoke test script accepts a configurable `--timeout` and reports detailed
+  job failure messages.
 - Live tests now discover the first form key automatically and create a job to
   obtain a batch ID, removing the need for `IMEDNET_FORM_KEY` and
   `IMEDNET_BATCH_ID` secrets.

--- a/imednet/discovery.py
+++ b/imednet/discovery.py
@@ -16,8 +16,9 @@ def discover_study_key(sdk: ImednetSDK) -> str:
 
 
 def discover_form_key(sdk: ImednetSDK, study_key: str) -> str:
-    """Return the first form key for ``study_key``."""
+    """Return the first subject record form key for ``study_key``."""
     forms = sdk.forms.list(study_key=study_key)
-    if not forms:
-        raise NoLiveDataError("No forms available for record creation")
-    return forms[0].form_key
+    for form in forms:
+        if form.subject_record_report and not form.disabled:
+            return form.form_key
+    raise NoLiveDataError("No forms available for record creation")

--- a/tests/unit/test_discovery.py
+++ b/tests/unit/test_discovery.py
@@ -1,0 +1,25 @@
+from unittest.mock import Mock
+
+import pytest
+
+from imednet.discovery import NoLiveDataError, discover_form_key
+from imednet.models.forms import Form
+
+
+def test_discover_form_key_chooses_subject_form() -> None:
+    sdk = Mock()
+    sdk.forms.list.return_value = [
+        Form(study_key="S", form_key="SS", subject_record_report=False),
+        Form(study_key="S", form_key="F1", subject_record_report=True, disabled=True),
+        Form(study_key="S", form_key="F2", subject_record_report=True, disabled=False),
+    ]
+
+    assert discover_form_key(sdk, "S") == "F2"
+
+
+def test_discover_form_key_raises_when_no_valid_forms() -> None:
+    sdk = Mock()
+    sdk.forms.list.return_value = [Form(study_key="S", form_key="SS", subject_record_report=False)]
+
+    with pytest.raises(NoLiveDataError):
+        discover_form_key(sdk, "S")

--- a/tests/unit/test_post_smoke_record.py
+++ b/tests/unit/test_post_smoke_record.py
@@ -1,5 +1,6 @@
 from unittest.mock import Mock
 
+import pytest
 import scripts.post_smoke_record as smoke
 
 
@@ -8,7 +9,21 @@ def test_submit_record_uses_configured_timeout() -> None:
     sdk.records.create.return_value = Mock(batch_id="B1")
     sdk.poll_job.return_value = Mock(state="COMPLETED", batch_id="B1")
 
-    batch_id = smoke.submit_record(sdk, "ST", {"data": {}})
+    batch_id = smoke.submit_record(sdk, "ST", {"data": {}}, timeout=123)
 
     assert batch_id == "B1"
-    sdk.poll_job.assert_called_once_with("ST", "B1", interval=1, timeout=smoke.POLL_TIMEOUT)
+    sdk.poll_job.assert_called_once_with("ST", "B1", interval=1, timeout=123)
+
+
+def test_submit_record_reports_failure_details() -> None:
+    sdk = Mock()
+    sdk.records.create.return_value = Mock(batch_id="B1")
+    sdk.poll_job.return_value = Mock(state="FAILED", batch_id="B1", result_url="https://x")
+    response = Mock(text="Form with formKey of SS not found.")
+    response.json.side_effect = ValueError()
+    sdk._client.get.return_value = response
+
+    with pytest.raises(RuntimeError, match="FAILED: Form with formKey"):
+        smoke.submit_record(sdk, "ST", {"data": {}}, timeout=1)
+
+    sdk._client.get.assert_called_once_with("https://x")


### PR DESCRIPTION
## Summary
- allow customizing smoke record polling timeout
- surface job failure details for easier troubleshooting

## Testing
- `poetry run ruff check --fix scripts/post_smoke_record.py tests/unit/test_post_smoke_record.py`
- `poetry run black --check scripts/post_smoke_record.py tests/unit/test_post_smoke_record.py`
- `poetry run isort --check --profile black scripts/post_smoke_record.py tests/unit/test_post_smoke_record.py`
- `poetry run mypy imednet`
- `poetry run pytest tests/unit/test_post_smoke_record.py -q`
- `poetry run pytest -q` *(fails: KeyboardInterrupt during live CLI tests)*

------
