### PR TITLE
feat: populate smoke record with typed values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   obtain a batch ID, removing the need for `IMEDNET_FORM_KEY` and
   `IMEDNET_BATCH_ID` secrets.
 - Extended smoke test job polling timeout to 90 seconds.
+- Smoke script now populates record data using typed examples to exercise API validation.
 - Renamed ``models._base`` to ``models.json_base`` to avoid import confusion.
 - Documented the sentinel return value in ``parse_datetime``.
 - Replaced placeholder description in ``workflows/record_update.py``.

--- a/tests/unit/test_post_smoke_record.py
+++ b/tests/unit/test_post_smoke_record.py
@@ -3,6 +3,8 @@ from unittest.mock import Mock
 import pytest
 import scripts.post_smoke_record as smoke
 
+from imednet.models.variables import Variable
+
 
 def test_submit_record_uses_configured_timeout() -> None:
     sdk = Mock()
@@ -27,3 +29,28 @@ def test_submit_record_reports_failure_details() -> None:
         smoke.submit_record(sdk, "ST", {"data": {}}, timeout=1)
 
     sdk._client.get.assert_called_once_with("https://x")
+
+
+def _var(name: str, var_type: str) -> Variable:
+    return Variable(variable_name=name, variable_type=var_type, form_id=1, form_key="F1")
+
+
+def test_build_record_populates_example_values() -> None:
+    sdk = Mock()
+    sdk.variables.list.return_value = [
+        _var("i", "integer"),
+        _var("d", "date"),
+        _var("t", "string"),
+        _var("i2", "integer"),
+    ]
+
+    record = smoke.build_record(sdk, "ST", "F1")
+
+    assert record == {
+        "formKey": "F1",
+        "data": {
+            "i": smoke.EXAMPLE_VALUES["integer"],
+            "d": smoke.EXAMPLE_VALUES["date"],
+            "t": smoke.EXAMPLE_VALUES["string"],
+        },
+    }


### PR DESCRIPTION
## Summary
- exercise variable types in smoke test by mapping variable types to example values
- test build_record populates sample values per variable type

## Testing
- `poetry run ruff check --fix scripts/post_smoke_record.py tests/unit/test_post_smoke_record.py`
- `poetry run black --check scripts/post_smoke_record.py tests/unit/test_post_smoke_record.py`
- `poetry run isort --check --profile black scripts/post_smoke_record.py tests/unit/test_post_smoke_record.py`
- `poetry run mypy imednet`
- `poetry run pytest tests/unit/test_post_smoke_record.py -q`
- `poetry run pytest -q` *(fails: Killed)*

------
https://chatgpt.com/codex/tasks/task_e_689ceb645ba0832ca9597d7ee374fd50