### PR TITLE
[imednet] exercise typed variables in smoke record

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -91,6 +91,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   date, radio/dropdown, memo, and checkbox fields.
 - Endpoint smoke tests now post typed records for subject registration,
   scheduled updates, and new record creation.
+- Added unit tests for the smoke record builder to verify typed values and
+  optional identifiers.
 
 ## [0.1.4] 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -84,6 +84,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Record submission now checks form existence after schema refresh and raises
   ``ValueError`` for unknown form keys.
 - Added ``DataDictionaryLoader`` for loading data dictionaries from CSV files or ZIP archives.
+- Added ``typed_values`` helper for deterministic example values and expanded
+  smoke record builder to populate one variable per type and accept optional
+  identifiers.
 
 ## [0.1.4] 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -89,6 +89,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   identifiers.
 - Live tests now reuse ``typed_values`` to submit well-typed record data across
   date, radio/dropdown, memo, and checkbox fields.
+- Endpoint smoke tests now post typed records for subject registration,
+  scheduled updates, and new record creation.
 
 ## [0.1.4] 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -87,6 +87,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added ``typed_values`` helper for deterministic example values and expanded
   smoke record builder to populate one variable per type and accept optional
   identifiers.
+- Live tests now reuse ``typed_values`` to submit well-typed record data across
+  date, radio/dropdown, memo, and checkbox fields.
 
 ## [0.1.4] 
 

--- a/imednet/testing/typed_values.py
+++ b/imednet/testing/typed_values.py
@@ -1,0 +1,52 @@
+"""Deterministic example values for variable types.
+
+Used in tests and smoke scripts to exercise typed fields.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, Optional
+
+# Maps variable type synonyms to example values.
+_TYPED_VALUES: Dict[str, Any] = {
+    "string": "example",
+    "text": "example",
+    "memo": "example memo",
+    "date": "2024-01-01",
+    "number": 1,
+    "int": 1,
+    "integer": 1,
+    "float": 1.0,
+    "decimal": 1.0,
+    "radio": "1",
+    "dropdown": "1",
+    "checkbox": True,
+}
+
+# Maps variable type synonyms to canonical categories.
+_CANONICAL_TYPES: Dict[str, str] = {
+    "string": "string",
+    "text": "string",
+    "memo": "memo",
+    "date": "date",
+    "number": "number",
+    "int": "number",
+    "integer": "number",
+    "float": "number",
+    "decimal": "number",
+    "radio": "radio",
+    "dropdown": "dropdown",
+    "checkbox": "checkbox",
+}
+
+
+def canonical_type(var_type: str) -> Optional[str]:
+    """Return the canonical type for ``var_type`` or ``None`` if unsupported."""
+
+    return _CANONICAL_TYPES.get(var_type.lower())
+
+
+def value_for(var_type: str) -> Optional[Any]:
+    """Return a deterministic example value for ``var_type`` if supported."""
+
+    return _TYPED_VALUES.get(var_type.lower())

--- a/tests/live/test_endpoints_async_live.py
+++ b/tests/live/test_endpoints_async_live.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 import pytest
 
 from imednet.sdk import AsyncImednetSDK
@@ -103,12 +105,16 @@ async def test_async_codings(async_sdk: AsyncImednetSDK, study_key: str) -> None
 
 
 @pytest.mark.asyncio(scope="session")
+@pytest.mark.parametrize(
+    "record_payload",
+    ["register", "scheduled", "new"],
+    indirect=True,
+)
 async def test_async_create_and_poll(
     async_sdk: AsyncImednetSDK,
     study_key: str,
-    first_form_key: str,
+    record_payload: dict[str, Any],
 ) -> None:
-    record = {"formKey": first_form_key, "data": {}}
-    job = await async_sdk.records.async_create(study_key, [record])
+    job = await async_sdk.records.async_create(study_key, [record_payload])
     polled = await async_sdk.jobs.async_get(study_key, job.batch_id)
     assert polled.batch_id == job.batch_id

--- a/tests/live/test_endpoints_sync_live.py
+++ b/tests/live/test_endpoints_sync_live.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 import pytest
 
 from imednet.core.exceptions import ServerError
@@ -129,9 +131,17 @@ def test_job_get_known_batch(sdk: ImednetSDK, study_key: str, generated_batch_id
     assert job.batch_id == generated_batch_id
 
 
-def test_create_record_and_poll_job(sdk: ImednetSDK, study_key: str, first_form_key: str) -> None:
-    record = {"formKey": first_form_key, "data": {}}
-    job = sdk.records.create(study_key, [record])
+@pytest.mark.parametrize(
+    "record_payload",
+    ["register", "scheduled", "new"],
+    indirect=True,
+)
+def test_create_record_and_poll_job(
+    sdk: ImednetSDK,
+    study_key: str,
+    record_payload: dict[str, Any],
+) -> None:
+    job = sdk.records.create(study_key, [record_payload])
     assert job.batch_id
     polled = sdk.jobs.get(study_key, job.batch_id)
     assert polled.batch_id == job.batch_id

--- a/tests/unit/test_post_smoke_record.py
+++ b/tests/unit/test_post_smoke_record.py
@@ -3,6 +3,9 @@ from unittest.mock import Mock
 import pytest
 import scripts.post_smoke_record as smoke
 
+from imednet.models.variables import Variable
+from imednet.testing import typed_values
+
 
 def test_submit_record_uses_configured_timeout() -> None:
     sdk = Mock()
@@ -27,3 +30,43 @@ def test_submit_record_reports_failure_details() -> None:
         smoke.submit_record(sdk, "ST", {"data": {}}, timeout=1)
 
     sdk._client.get.assert_called_once_with("https://x")
+
+
+def _var(name: str, var_type: str) -> Variable:
+    return Variable(variable_name=name, variable_type=var_type, form_id=1, form_key="F1")
+
+
+def test_build_record_populates_typed_values() -> None:
+    sdk = Mock()
+    sdk.variables.list.return_value = [
+        _var("text", "text"),
+        _var("date", "date"),
+        _var("num", "integer"),
+        _var("rad", "radio"),
+        _var("drop", "dropdown"),
+        _var("memo", "memo"),
+        _var("check", "checkbox"),
+        _var("extra", "text"),
+    ]
+
+    record = smoke.build_record(
+        sdk, "ST", "F1", site_name="S", subject_key="SUB", interval_name="INT"
+    )
+
+    expected = {
+        "text": typed_values.value_for("text"),
+        "date": typed_values.value_for("date"),
+        "num": typed_values.value_for("integer"),
+        "rad": typed_values.value_for("radio"),
+        "drop": typed_values.value_for("dropdown"),
+        "memo": typed_values.value_for("memo"),
+        "check": typed_values.value_for("checkbox"),
+    }
+    assert record == {
+        "formKey": "F1",
+        "data": expected,
+        "siteName": "S",
+        "subjectKey": "SUB",
+        "intervalName": "INT",
+    }
+    sdk.variables.list.assert_called_once_with(study_key="ST", formKey="F1")

--- a/tests/unit/test_typed_values.py
+++ b/tests/unit/test_typed_values.py
@@ -1,0 +1,16 @@
+from imednet.testing import typed_values
+
+
+def test_value_for_each_type() -> None:
+    assert typed_values.value_for("text") == "example"
+    assert typed_values.value_for("date") == "2024-01-01"
+    assert typed_values.value_for("integer") == 1
+    assert typed_values.value_for("radio") == "1"
+    assert typed_values.value_for("dropdown") == "1"
+    assert typed_values.value_for("memo") == "example memo"
+    assert typed_values.value_for("checkbox") is True
+
+
+def test_canonical_type_synonyms() -> None:
+    assert typed_values.canonical_type("Text") == "string"
+    assert typed_values.canonical_type("int") == "number"


### PR DESCRIPTION
## Summary
- add typed_values helper mapping variable types to deterministic samples
- build smoke-record payload with one variable per type and optional identifiers
- cover typed values and record builder in tests

## Testing
- `poetry run ruff check --fix .`
- `poetry run black --check .`
- `poetry run isort --check --profile black .`
- `poetry run mypy imednet`
- `IMEDNET_RUN_E2E=0 poetry run pytest -q`

------
