### PR TITLE
chore: validate smoke record prerequisites

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   keys, removing the `IMEDNET_FORM_KEY` override.
 - Added helpers to discover active site, subject, and interval identifiers and
   updated the smoke record script to use them.
+- Smoke record script now validates site and subject availability before posting
+  records.
 - Form discovery now skips disabled and non-subject forms to avoid invalid form
   key errors during record creation.
 - Decoupled live-data discovery from pytest internals and skip the smoke script

--- a/tests/unit/test_post_smoke_record.py
+++ b/tests/unit/test_post_smoke_record.py
@@ -116,3 +116,23 @@ def test_discover_identifiers_returns_all() -> None:
     sdk.sites.list.assert_called_once_with(study_key="S")
     sdk.subjects.list.assert_called_once_with(study_key="S")
     sdk.intervals.list.assert_called_once_with(study_key="S")
+
+
+def test_discover_identifiers_reports_missing(monkeypatch, capsys) -> None:
+    monkeypatch.setattr(
+        smoke, "discover_site_name", Mock(side_effect=smoke.NoLiveDataError("no site"))
+    )
+    monkeypatch.setattr(
+        smoke, "discover_subject_key", Mock(side_effect=smoke.NoLiveDataError("no subject"))
+    )
+    monkeypatch.setattr(
+        smoke, "discover_interval_name", Mock(side_effect=smoke.NoLiveDataError("no int"))
+    )
+
+    identifiers = smoke.discover_identifiers(Mock(), "S")
+
+    assert identifiers == (None, None, None)
+    out = capsys.readouterr().out
+    assert "no site" in out
+    assert "no subject" in out
+    assert "no int" in out


### PR DESCRIPTION
## Summary
- skip smoke posts when site or subject identifiers are missing
- test smoke identifier discovery handling

## Testing
- `poetry run ruff check --fix .`
- `poetry run black --check .`
- `poetry run isort --check --profile black .`
- `poetry run mypy imednet`
- `poetry run pytest -q` *(failed: Killed)*
- `poetry run pytest -q tests/unit/test_post_smoke_record.py`


------
