### PR TITLE
feat(workflows): validate subject registration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Deduplicated refresh and validation logic in `SchemaValidator` with helper methods.
 - Fixed teardown errors in live tests by using the session event loop for
   `async_sdk` teardown.
+- Added subject and site validation to `RegisterSubjectsWorkflow` and support for
+  ``subjectKey`` in ``RegisterSubjectRequest``.
 - Updated `tests/AGENTS.md` to permit hitting the live iMednet API when running the `tests/live` suite.
 - Refactored endpoint initialization in `ImednetSDK` using a registry.
 - Added `_build_record_payload` helper to `RecordUpdateWorkflow` to deduplicate

--- a/docs/imednet.workflows.rst
+++ b/docs/imednet.workflows.rst
@@ -39,6 +39,14 @@ imednet.workflows.record\_update module
 ``RecordUpdateWorkflow`` uses ``SchemaCache`` to validate record data before
 submission when provided.
 
+imednet.workflows.register_subjects module
+-------------------------------------------
+
+.. automodule:: imednet.workflows.register_subjects
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
 imednet.workflows.subject\_data module
 --------------------------------------
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -14,6 +14,7 @@ Welcome to imednet's documentation!
    schema_validation
    cli
    workflow_interactions
+   register_subjects
    caching
    retry_policy
    job_polling

--- a/docs/register_subjects.rst
+++ b/docs/register_subjects.rst
@@ -1,0 +1,19 @@
+Register Subjects Workflow
+==========================
+
+The ``RegisterSubjectsWorkflow`` validates that site names and subject identifiers exist before submitting registration records.
+
+Example
+-------
+
+.. code-block:: python
+
+    from imednet import ImednetSDK
+    from imednet.models.records import RegisterSubjectRequest
+    from imednet.workflows.register_subjects import RegisterSubjectsWorkflow
+
+    sdk = ImednetSDK(api_key="API_KEY", security_key="SECURITY_KEY")
+    workflow = RegisterSubjectsWorkflow(sdk)
+    subjects = [RegisterSubjectRequest(form_key="REG", site_name="SITE", subject_key="SUBJ", data={})]
+    job = workflow.register_subjects(study_key="STUDY", subjects=subjects)
+    print(job)

--- a/examples/post_register_subjects.py
+++ b/examples/post_register_subjects.py
@@ -2,6 +2,7 @@ import json
 import os
 
 from imednet import ImednetSDK
+from imednet.models.records import RegisterSubjectRequest
 from imednet.workflows.register_subjects import RegisterSubjectsWorkflow
 
 """
@@ -26,10 +27,10 @@ Attributes:
     input_path (str): The file path to the JSON file containing the subject data.
 """
 
-api_key = "XXXXXXXXXX"
-security_key = "XXXXXXXXXX"
-base_url = None  # Or set to your custom base URL if needed
-study_key = "XXXXXXXXXX"
+api_key = os.getenv("IMEDNET_API_KEY", "")
+security_key = os.getenv("IMEDNET_SECURITY_KEY", "")
+base_url = os.getenv("IMEDNET_BASE_URL")
+study_key = os.getenv("IMEDNET_STUDY_KEY", "")
 
 # Path to the sample input file included with this repository
 input_path = os.path.join(
@@ -41,7 +42,9 @@ try:
     workflow = RegisterSubjectsWorkflow(sdk)
 
     with open(input_path, "r", encoding="utf-8") as f:
-        subjects = json.load(f)
+        raw_subjects = json.load(f)
+
+    subjects = [RegisterSubjectRequest(**s) for s in raw_subjects]
 
     # Register all subjects at once
     result = workflow.register_subjects(study_key=study_key, subjects=subjects)

--- a/examples/register_subjects_input/sample_subjects.json
+++ b/examples/register_subjects_input/sample_subjects.json
@@ -2,6 +2,7 @@
   {
     "formKey": "REG",
     "siteName": "Minneapolis",
+    "subjectKey": "999-001",
     "data": {
       "textField": "First subject"
     }
@@ -9,6 +10,7 @@
   {
     "formKey": "REG",
     "siteName": "Chicago",
+    "subjectKey": "999-002",
     "data": {
       "textField": "Second subject",
       "dateField": "2024-01-01",

--- a/imednet/models/records.py
+++ b/imednet/models/records.py
@@ -61,7 +61,12 @@ class BaseRecordRequest(JsonModel):
 
 
 class RegisterSubjectRequest(BaseRecordRequest):
-    site_name: str = Field("", alias="siteName")
+    site_name: str = Field(
+        "", alias="siteName", description="Name of the site where the subject is enrolled"
+    )
+    subject_key: str = Field(
+        "", alias="subjectKey", description="Unique identifier for the subject"
+    )
 
     pass
 

--- a/imednet/workflows/register_subjects.py
+++ b/imednet/workflows/register_subjects.py
@@ -33,6 +33,7 @@ class RegisterSubjectsWorkflow:
     ) -> Job:
         """
         Registers multiple subjects in the specified study.
+        Sites and subject identifiers are validated before submission.
 
         Args:
             study_key: The key identifying the study.
@@ -47,10 +48,29 @@ class RegisterSubjectsWorkflow:
         Raises:
             ApiError: If the API call fails.
         """
-        # Convert Pydantic models to dictionaries for the API call
+        # Validate sites and subjects before posting
+        sites = {s.site_name for s in self._sdk.sites.list(study_key=study_key)}
+        errors: list[str] = []
+        for idx, subj in enumerate(subjects):
+            if not subj.site_name:
+                errors.append(f"Index {idx}: siteName is required")
+            elif subj.site_name not in sites:
+                errors.append(f"Index {idx}: site '{subj.site_name}' not found")
+            if not subj.subject_key:
+                errors.append(f"Index {idx}: subjectKey is required")
+            else:
+                try:
+                    self._sdk.subjects.get(study_key, subj.subject_key)
+                except Exception:
+                    errors.append(
+                        f"Index {idx}: subject with subjectKey {subj.subject_key} not found"
+                    )
+
+        if errors:
+            raise ValueError("; ".join(errors))
+
         subjects_data = [s.model_dump(by_alias=True) for s in subjects]
 
-        # Call the SDK's records endpoint to create (register) the subjects
         response = self._sdk.records.create(
             study_key=study_key, records_data=subjects_data, email_notify=email_notify
         )

--- a/tests/live/test_workflows_live.py
+++ b/tests/live/test_workflows_live.py
@@ -30,14 +30,21 @@ async def test_async_get_study_structure(async_sdk: AsyncImednetSDK, study_key: 
     assert struct.study_key == study_key
 
 
-def test_register_subjects_workflow(sdk: ImednetSDK, study_key: str) -> None:
+def test_register_subjects_workflow(
+    sdk: ImednetSDK, study_key: str, first_subject_key: str
+) -> None:
     if os.getenv("IMEDNET_ALLOW_MUTATION") != "1":
         pytest.skip("Mutating tests are disabled")
     forms = sdk.get_forms(study_key)
     sites = sdk.get_sites(study_key)
     if not forms or not sites:
         pytest.skip("No forms/sites for subject registration")
-    req = RegisterSubjectRequest(form_key=forms[0].form_key, site_name=sites[0].site_name, data={})
+    req = RegisterSubjectRequest(
+        form_key=forms[0].form_key,
+        site_name=sites[0].site_name,
+        subject_key=first_subject_key,
+        data={},
+    )
     wf = RegisterSubjectsWorkflow(sdk)
     job = wf.register_subjects(study_key, [req])
     assert job.batch_id

--- a/tests/workflows/test_register_subjects.py
+++ b/tests/workflows/test_register_subjects.py
@@ -2,6 +2,8 @@ from unittest.mock import MagicMock
 
 from imednet.models.jobs import Job
 from imednet.models.records import RegisterSubjectRequest
+from imednet.models.sites import Site
+from imednet.models.subjects import Subject
 from imednet.testing import fake_data
 from imednet.workflows.register_subjects import RegisterSubjectsWorkflow
 
@@ -10,12 +12,18 @@ def test_register_subjects_passes_records_correctly(schema) -> None:
     sdk = MagicMock()
     job = Job(batch_id="1", state="PROCESSING")
     sdk.records.create.return_value = job
+    sdk.sites.list.return_value = [Site(site_name="SITE")]
+    sdk.subjects.get.return_value = Subject(subject_key="SUBJ", site_name="SITE")
     wf = RegisterSubjectsWorkflow(sdk)
     rec = fake_data.fake_record(schema)
-    req = RegisterSubjectRequest(form_key=rec["formKey"], site_name="SITE", data=rec["recordData"])
+    req = RegisterSubjectRequest(
+        form_key=rec["formKey"], site_name="SITE", subject_key="SUBJ", data=rec["recordData"]
+    )
 
     result = wf.register_subjects("STUDY", [req], email_notify="test@example.com")
 
+    sdk.sites.list.assert_called_once_with(study_key="STUDY")
+    sdk.subjects.get.assert_called_once_with("STUDY", "SUBJ")
     sdk.records.create.assert_called_once_with(
         study_key="STUDY",
         records_data=[req.model_dump(by_alias=True)],


### PR DESCRIPTION
## Summary
- ensure subject registration checks for valid site and subject identifiers
- document RegisterSubjectsWorkflow usage and sample payload

## Testing
- `poetry run ruff check --fix .`
- `poetry run black --check .`
- `poetry run isort --check --profile black .`
- `poetry run mypy imednet`
- `poetry run pytest -q` *(fails: Killed)*
- `make docs` *(warnings: duplicate object descriptions, missing toctree entries)*
- `python examples/post_register_subjects.py` *(fails: ModuleNotFoundError: No module named 'imednet')*

------
