### PR TITLE
feat: add verbose logging to smoke script

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added long-format SQL export via `export_to_long_sql` and the `--long-format` CLI option.
 - CLI commands now use shared helpers for study arguments and list output to reduce duplication.
 - Deduplicated refresh and validation logic in `SchemaValidator` with helper methods.
+- Added verbose logging to smoke record script with new `-v/--verbose` flag.
 - Fixed teardown errors in live tests by using the session event loop for
   `async_sdk` teardown.
 - Added subject and site validation to `RegisterSubjectsWorkflow` and support for


### PR DESCRIPTION
## Summary
- add --verbose flag and detailed logging to smoke record script
- redact payload data and log job polling status
- test verbose mode logging behavior

## Testing
- `poetry run ruff check --fix scripts/post_smoke_record.py tests/unit/test_post_smoke_record.py`
- `poetry run black --check .`
- `poetry run isort --check --profile black .`
- `poetry run mypy imednet`
- `poetry run pytest tests/unit/test_post_smoke_record.py -q`
- `poetry run pytest -q` *(fails: Killed)*

------
