### PR TITLE
test: surface INFO logs in smoke workflow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - CLI commands now use shared helpers for study arguments and list output to reduce duplication.
 - Deduplicated refresh and validation logic in `SchemaValidator` with helper methods.
 - Added verbose logging to smoke record script with new `-v/--verbose` flag.
+- Smoke-test workflow now streams INFO-level logs for easier debugging.
 - Fixed teardown errors in live tests by using the session event loop for
   `async_sdk` teardown.
 - Added subject and site validation to `RegisterSubjectsWorkflow` and support for

--- a/README.md
+++ b/README.md
@@ -131,6 +131,8 @@ poetry run pytest -q
 The optional [smoke.yml](.github/workflows/smoke.yml) action runs the `tests/live` suite.
 It relies on repository secrets `APIKEY` and `SECURITYKEY` and sets `IMEDNET_RUN_E2E`.
 Use the workflow to confirm real API access on demand or via its nightly schedule.
+INFO-level log messages stream to the terminal during these runs, making it easier to
+debug failures.
 
 ## Building & Publishing
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,2 +1,4 @@
 [pytest]
 asyncio_mode = auto
+log_cli = true
+log_cli_level = INFO

--- a/tests/live/conftest.py
+++ b/tests/live/conftest.py
@@ -1,4 +1,5 @@
 import asyncio
+import logging
 import os
 from typing import Any, AsyncIterator, Callable, Generator, Iterator
 
@@ -12,6 +13,8 @@ API_KEY = os.getenv("IMEDNET_API_KEY")
 SECURITY_KEY = os.getenv("IMEDNET_SECURITY_KEY")
 BASE_URL = os.getenv("IMEDNET_BASE_URL")
 RUN_E2E = os.getenv("IMEDNET_RUN_E2E") == "1"
+
+logger = logging.getLogger(__name__)
 
 
 def _typed_value(var_type: str) -> Any:
@@ -27,6 +30,7 @@ def _check_live_env() -> None:
             "Set IMEDNET_RUN_E2E=1 and provide IMEDNET_API_KEY/IMEDNET_SECURITY_KEY "
             "to run live tests"
         )
+    logger.info("Live test environment configured")
 
 
 @pytest.fixture(scope="session")


### PR DESCRIPTION
## Summary
- ensure pytest outputs INFO-level logs to aid smoke-test debugging
- log live test environment configuration
- document new smoke workflow logging

## Testing
- `poetry run ruff check --fix .`
- `poetry run black --check .`
- `poetry run isort --check --profile black .`
- `poetry run mypy imednet`
- `poetry run pytest -q --log-cli-level=WARNING`

------
