### PR TITLE
Add tests for JSON logging configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -104,6 +104,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   optional identifiers.
 - Added unit tests for discovery helpers covering study, form, site, subject,
   and interval lookups.
+- Added tests for JSON logging configuration covering formatter import paths.
 
 ## [0.1.4] 
 

--- a/tests/unit/utils/test_json_logging.py
+++ b/tests/unit/utils/test_json_logging.py
@@ -1,0 +1,66 @@
+import importlib
+import json
+import logging
+import sys
+import types
+
+import pytest
+
+MODULE_PATH = "imednet.utils.json_logging"
+
+
+def _install_formatter(monkeypatch: pytest.MonkeyPatch, submodule: str) -> type[logging.Formatter]:
+    """Insert a dummy JsonFormatter under the given pythonjsonlogger submodule."""
+    for name in (
+        "pythonjsonlogger",
+        "pythonjsonlogger.json",
+        "pythonjsonlogger.jsonlogger",
+    ):
+        monkeypatch.delitem(sys.modules, name, raising=False)
+
+    package = types.ModuleType("pythonjsonlogger")
+    package.__path__ = []  # mark as package so missing submodules raise ModuleNotFoundError
+    monkeypatch.setitem(sys.modules, "pythonjsonlogger", package)
+
+    module = types.ModuleType(f"pythonjsonlogger.{submodule}")
+
+    class DummyFormatter(logging.Formatter):
+        def format(self, record: logging.LogRecord) -> str:  # type: ignore[override]
+            return json.dumps({"message": record.getMessage(), "levelname": record.levelname})
+
+    module.JsonFormatter = DummyFormatter  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, f"pythonjsonlogger.{submodule}", module)
+    return DummyFormatter
+
+
+def _configure_and_log(json_logging, caplog: pytest.LogCaptureFixture) -> logging.Handler:
+    root = logging.getLogger()
+    old_handlers, old_level = root.handlers[:], root.level
+    with caplog.at_level(logging.INFO, logger=""):
+        json_logging.configure_json_logging()
+        logging.getLogger().addHandler(caplog.handler)
+        logging.getLogger().info("hello")
+        record = caplog.records[0]
+    handler = logging.getLogger().handlers[0]
+    formatted = handler.format(record)
+    data = json.loads(formatted)
+    assert data == {"message": "hello", "levelname": "INFO"}
+    root.handlers = old_handlers
+    root.setLevel(old_level)
+    return handler
+
+
+def test_configure_json_logging_uses_json_import(monkeypatch, caplog):
+    formatter_cls = _install_formatter(monkeypatch, "json")
+    monkeypatch.delitem(sys.modules, MODULE_PATH, raising=False)
+    json_logging = importlib.import_module(MODULE_PATH)
+    handler = _configure_and_log(json_logging, caplog)
+    assert isinstance(handler.formatter, formatter_cls)
+
+
+def test_configure_json_logging_uses_jsonlogger_import(monkeypatch, caplog):
+    formatter_cls = _install_formatter(monkeypatch, "jsonlogger")
+    monkeypatch.delitem(sys.modules, MODULE_PATH, raising=False)
+    json_logging = importlib.import_module(MODULE_PATH)
+    handler = _configure_and_log(json_logging, caplog)
+    assert isinstance(handler.formatter, formatter_cls)


### PR DESCRIPTION
## Summary
- test json logging helper to ensure JsonFormatter import paths work
- document JSON logging test in changelog

## Testing
- `poetry run ruff check --fix .`
- `poetry run black --check .`
- `poetry run isort --check --profile black .`
- `poetry run mypy imednet`
- `poetry run pytest -q tests/unit/utils/test_json_logging.py`
- `poetry run pytest -q` *(fails: Killed)*

------
