### PR TITLE
test: cover async schema validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   gracefully when no studies or forms are available.
 - Bump project version to `0.1.4`.
 - Added tests for unknown form validation errors.
+- Added async schema validation tests covering cache refresh and batch validation.
 - ISO datetime parser now pads fractional seconds shorter than six digits to
    microsecond precision.
 - Added workflow to sanitize PR bodies and comments of `chatgpt.com/codex` links.

--- a/tests/unit/test_utils_schema_async.py
+++ b/tests/unit/test_utils_schema_async.py
@@ -1,0 +1,60 @@
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from imednet.core.exceptions import ValidationError
+from imednet.models.forms import Form
+from imednet.models.variables import Variable
+from imednet.validation.cache import SchemaValidator
+
+
+def _make_var(name: str, form_id: int = 1, form_key: str = "F1") -> Variable:
+    return Variable(variable_name=name, variable_type="integer", form_id=form_id, form_key=form_key)
+
+
+@pytest.mark.asyncio
+async def test_async_schema_cache_refresh() -> None:
+    forms = MagicMock()
+    forms.list.return_value = [Form(form_id=1, form_key="F1")]
+    variables = MagicMock()
+    var = _make_var("age")
+    variables.async_list = AsyncMock(return_value=[var])
+
+    sdk = MagicMock()
+    sdk.forms = forms
+    sdk.variables = variables
+    validator = SchemaValidator(sdk)
+
+    await validator.schema.refresh(forms, variables, study_key="ST")
+
+    assert validator.schema.form_key_from_id(1) == "F1"
+    assert validator.schema.variables_for_form("F1")["age"] is var
+    variables.async_list.assert_awaited_once_with(study_key="ST", refresh=True)
+
+
+@pytest.mark.asyncio
+async def test_validate_record_and_batch_async() -> None:
+    var = _make_var("age")
+    sdk = MagicMock()
+    sdk.variables.async_list = AsyncMock(return_value=[var])
+    validator = SchemaValidator(sdk)
+
+    record = {"formKey": "F1", "data": {"age": 1}}
+    await validator.validate_record("ST", record)
+    sdk.variables.async_list.assert_awaited_once_with(study_key="ST", refresh=True)
+
+    validator.validate_record = AsyncMock()  # type: ignore[assignment]
+    await validator.validate_batch("ST", [record, record])
+    assert validator.validate_record.await_count == 2
+
+
+@pytest.mark.asyncio
+async def test_unknown_form_refreshes_and_raises() -> None:
+    var = _make_var("age")
+    sdk = MagicMock()
+    sdk.variables.async_list = AsyncMock(return_value=[var])
+    validator = SchemaValidator(sdk)
+
+    with pytest.raises(ValidationError, match="Unknown form BAD"):
+        await validator.validate_record("ST", {"formKey": "BAD", "data": {}})
+    sdk.variables.async_list.assert_awaited_once_with(study_key="ST", refresh=True)


### PR DESCRIPTION
## Summary
- add async schema cache tests
- document async schema test coverage

## Testing
- `poetry run ruff check --fix .`
- `poetry run black --check tests/unit/test_utils_schema_async.py`
- `poetry run isort --check --profile black tests/unit/test_utils_schema_async.py`
- `poetry run mypy imednet`
- `poetry run pytest tests/unit/test_utils_schema_async.py -q`
- `poetry run pytest -q` *(failed: command killed)*

------
