### PR TITLE
test: add sanitize_base_url unit tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -104,8 +104,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   optional identifiers.
 - Added unit tests for discovery helpers covering study, form, site, subject,
   and interval lookups.
+- Added unit tests for `sanitize_base_url` to ensure trailing slash and `/api`
+  removal.
 
-## [0.1.4] 
+## [0.1.4]
 
 ## [Released]
 

--- a/tests/unit/utils/test_url.py
+++ b/tests/unit/utils/test_url.py
@@ -1,0 +1,16 @@
+import pytest
+
+from imednet.utils.url import sanitize_base_url
+
+
+@pytest.mark.parametrize(
+    ("url", "expected"),
+    [
+        ("https://x/api", "https://x"),
+        ("https://x/api/", "https://x"),
+        ("https://x//", "https://x"),
+        ("https://x", "https://x"),
+    ],
+)
+def test_sanitize_base_url(url: str, expected: str) -> None:
+    assert sanitize_base_url(url) == expected


### PR DESCRIPTION
## Summary
- add direct tests for sanitize_base_url
- note sanitize_base_url tests in changelog

## Testing
- `poetry run ruff check --fix .`
- `poetry run black --check .`
- `poetry run isort --check --profile black .`
- `poetry run mypy imednet`
- `poetry run pytest -q` *(fails: Killed)*
- `poetry run pytest tests/unit/utils/test_url.py -q`


------
