### PR TITLE
test: expand retry policy coverage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Extracted common logic from `Client` and `AsyncClient` into new `HTTPClientBase`.
 - Added `imednet.config` module with `load_config` helper for reading credentials.
 - Introduced `RetryPolicy` abstraction for configuring request retries.
+- Added tests for retry policy handling of response results and non-RequestError exceptions.
 - Documented test suite conventions in `tests/AGENTS.md`.
   `Client`, `AsyncClient` and `ImednetSDK` accept a `retry_policy` parameter.
 - Added long-format SQL export via `export_to_long_sql` and the `--long-format` CLI option.

--- a/tests/core/test_retry_policy.py
+++ b/tests/core/test_retry_policy.py
@@ -1,4 +1,5 @@
 import httpx
+import pytest
 
 from imednet.core.client import Client
 from imednet.core.exceptions import ServerError
@@ -14,6 +15,28 @@ def test_default_policy_request_error():
     assert not policy.should_retry(RetryState(1))
 
 
+def test_default_policy_non_retryable_response_and_exception():
+    policy = DefaultRetryPolicy()
+    assert not policy.should_retry(RetryState(1, result=httpx.Response(500)))
+    assert not policy.should_retry(RetryState(1, exception=RuntimeError("boom")))
+
+
+def test_default_policy_non_request_exception(monkeypatch):
+    client = Client("k", "s", base_url="https://api.test", retries=3)
+    calls = {"count": 0}
+
+    def request(method: str, url: str, **kwargs: object) -> httpx.Response:
+        calls["count"] += 1
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(client._executor, "send", request)
+
+    with pytest.raises(RuntimeError):
+        client.get("/x")
+
+    assert calls["count"] == 1
+
+
 def test_custom_policy(monkeypatch):
     class ServerPolicy:
         def should_retry(self, state: RetryState) -> bool:
@@ -26,6 +49,29 @@ def test_custom_policy(monkeypatch):
         calls["count"] += 1
         if calls["count"] < 3:
             raise ServerError({}, status_code=500)
+        return httpx.Response(200, json={"ok": True})
+
+    monkeypatch.setattr(client._executor, "send", request)
+
+    resp = client.get("/x")
+
+    assert resp.status_code == 200
+    assert calls["count"] == 3
+
+
+def test_custom_policy_based_on_result(monkeypatch):
+    class ResponsePolicy:
+        def should_retry(self, state: RetryState) -> bool:
+            resp = state.result
+            return isinstance(resp, httpx.Response) and resp.status_code >= 500
+
+    client = Client("k", "s", base_url="https://api.test", retries=3, retry_policy=ResponsePolicy())
+    calls = {"count": 0}
+
+    def request(method: str, url: str, **kwargs: object) -> httpx.Response:
+        calls["count"] += 1
+        if calls["count"] < 3:
+            return httpx.Response(500)
         return httpx.Response(200, json={"ok": True})
 
     monkeypatch.setattr(client._executor, "send", request)


### PR DESCRIPTION
## Summary
- extend DefaultRetryPolicy tests to cover non-retryable responses and non-RequestError exceptions
- add result-aware retry policy tests
- document retry policy test coverage in changelog

## Testing
- `poetry run ruff check --fix tests/core/test_retry_policy.py`
- `poetry run black --check tests/core/test_retry_policy.py`
- `poetry run isort --check --profile black tests/core/test_retry_policy.py`
- `poetry run mypy imednet`
- `poetry run pytest tests/core/test_retry_policy.py -q`
- `poetry run pytest -q` *(failed: Killed)*


------
