### PR TITLE
test: add JsonModel type normalization coverage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+- Added tests for JsonModel type normalization.
 - Expanded AGENTS contributor guides with scoped templates across packages and tooling.
 - Smoke workflow now uploads verbose script logs and runs live tests with full output.
 - Refined contributor guides: mapped project scope, Python 3.10–3.12 support, and

--- a/tests/unit/test_json_model_normalization.py
+++ b/tests/unit/test_json_model_normalization.py
@@ -1,0 +1,27 @@
+from datetime import datetime, timezone
+
+from imednet.models.json_base import JsonModel
+
+
+class SampleModel(JsonModel):
+    flag: bool
+    count: int
+    timestamp: datetime
+    names: list[str]
+    mapping: dict[str, int]
+
+
+def test_json_model_normalization() -> None:
+    model = SampleModel(
+        flag="true",
+        count="5",
+        timestamp="2024-01-02T03:04:05Z",
+        names="alice",
+        mapping={"one": "1"},
+    )
+
+    assert model.flag is True
+    assert model.count == 5
+    assert model.timestamp == datetime(2024, 1, 2, 3, 4, 5, tzinfo=timezone.utc)
+    assert model.names == ["alice"]
+    assert model.mapping == {"one": 1}


### PR DESCRIPTION
## Summary
- add unit test verifying JsonModel type coercion for primitive fields
- document change in changelog

## Testing
- `poetry run ruff check --fix .`
- `poetry run black --check .`
- `poetry run isort --check --profile black .`
- `poetry run mypy imednet`
- `poetry run pytest -q` *(fails: process killed at ~7% progress)*
- `poetry run pytest tests/unit/test_json_model_normalization.py -q`


------
