### PR TITLE
test: expand retry policy coverage

### DIFF
--- a/tests/core/test_retry_policy.py
+++ b/tests/core/test_retry_policy.py
@@ -18,7 +18,8 @@ def test_default_policy_request_error():
 def test_default_policy_non_retryable_response_and_exception():
     policy = DefaultRetryPolicy()
     assert not policy.should_retry(RetryState(1, result=httpx.Response(500)))
-    assert not policy.should_retry(RetryState(1, exception=RuntimeError("boom")))
+    assert not policy.should_retry(RetryState(1, exception=Exception("boom")))
+    assert not policy.should_retry(RetryState(1, result=httpx.Response(200), exception=None))
 
 
 def test_default_policy_non_request_exception(monkeypatch):


### PR DESCRIPTION
## Summary
- add coverage ensuring DefaultRetryPolicy doesn't retry on generic exceptions
- verify retries stop when a successful response exists

## Testing
- `poetry run ruff check --fix .`
- `poetry run black --check .`
- `poetry run isort --check --profile black .`
- `poetry run mypy imednet`
- `poetry run pytest -q` *(fails: tests/live/test_cli_live.py::test_cli_jobs_wait)*

------
