### PR TITLE
test: cover retry policy propagation to async client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -109,6 +109,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added unit tests for `sanitize_base_url` to ensure trailing slash and `/api`
   removal.
 - Added tests for JSON logging configuration covering formatter import paths.
+- Added test verifying `ImednetSDK.retry_policy` updates sync and async clients.
 
 ## [0.1.4]
 

--- a/tests/unit/test_sdk_retry_policy.py
+++ b/tests/unit/test_sdk_retry_policy.py
@@ -1,0 +1,37 @@
+import pytest
+
+from imednet.core.retry import RetryPolicy, RetryState
+from imednet.sdk import ImednetSDK
+
+
+class NamedPolicy(RetryPolicy):
+    def __init__(self, name: str) -> None:
+        self.name = name
+
+    def should_retry(self, state: RetryState) -> bool:  # pragma: no cover - simple
+        return False
+
+
+@pytest.fixture()
+def sdk() -> ImednetSDK:
+    return ImednetSDK(
+        api_key="key",
+        security_key="secret",
+        base_url="https://example.com",
+        enable_async=True,
+    )
+
+
+def test_retry_policy_propagates_to_clients(sdk: ImednetSDK) -> None:
+    assert sdk._async_client is not None
+
+    client_policy = NamedPolicy("client")
+    async_policy = NamedPolicy("async")
+    sdk._client.retry_policy = client_policy
+    sdk._async_client.retry_policy = async_policy
+
+    new_policy = NamedPolicy("new")
+    sdk.retry_policy = new_policy
+
+    assert sdk._client.retry_policy is new_policy
+    assert sdk._async_client.retry_policy is new_policy


### PR DESCRIPTION
## Summary
- add unit test for ImednetSDK.retry_policy propagation
- document retry policy propagation test in changelog

## Testing
- `poetry run ruff check --fix .`
- `poetry run black --check .`
- `poetry run isort --check --profile black .`
- `poetry run mypy imednet`
- `poetry run pytest tests/unit/test_sdk_retry_policy.py -q`
- `poetry run pytest -q` *(fails: command killed)*

------
