### PR TITLE
Add negative-path test for subject data workflow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 - Expanded AGENTS contributor guides with scoped templates across packages and tooling.
+- Added negative-path test for `SubjectDataWorkflow.get_all_subject_data` handling empty responses.
 - Smoke workflow now uploads verbose script logs and runs live tests with full output.
 - Refined contributor guides: mapped project scope, Python 3.10–3.12 support, and
   unified validation for ruff, black, isort, mypy, and pytest across docs,

--- a/tests/workflows/test_subject_data.py
+++ b/tests/workflows/test_subject_data.py
@@ -5,7 +5,7 @@ from imednet.models.records import Record
 from imednet.models.subjects import Subject
 from imednet.models.visits import Visit
 from imednet.testing import fake_data
-from imednet.workflows.subject_data import SubjectDataWorkflow
+from imednet.workflows.subject_data import SubjectComprehensiveData, SubjectDataWorkflow
 
 
 def test_get_all_subject_data_aggregates_across_endpoints(schema) -> None:
@@ -43,3 +43,29 @@ def test_get_all_subject_data_aggregates_across_endpoints(schema) -> None:
     assert result.visits == [visit]
     assert result.records == [record]
     assert result.queries == [query]
+
+
+def test_get_all_subject_data_returns_empty_results() -> None:
+    sdk = MagicMock()
+    sdk.subjects.list.return_value = []
+    sdk.visits.list.return_value = []
+    sdk.records.list.return_value = []
+    sdk.queries.list.return_value = []
+
+    wf = SubjectDataWorkflow(sdk)
+    result = wf.get_all_subject_data("STUDY", "S2")
+
+    sdk.subjects.list.assert_called_once_with("STUDY", subject_key="S2")
+    assert sdk.subjects.list.call_args.kwargs == {"subject_key": "S2"}
+    sdk.visits.list.assert_called_once_with("STUDY", subject_key="S2")
+    assert sdk.visits.list.call_args.kwargs == {"subject_key": "S2"}
+    sdk.records.list.assert_called_once_with("STUDY", subject_key="S2")
+    assert sdk.records.list.call_args.kwargs == {"subject_key": "S2"}
+    sdk.queries.list.assert_called_once_with("STUDY", subject_key="S2")
+    assert sdk.queries.list.call_args.kwargs == {"subject_key": "S2"}
+
+    assert isinstance(result, SubjectComprehensiveData)
+    assert result.subject_details is None
+    assert result.visits == []
+    assert result.records == []
+    assert result.queries == []


### PR DESCRIPTION
## Summary
- test subject data workflow defaults when no subject data is returned
- document SubjectDataWorkflow negative-path coverage

## Testing
- `poetry run ruff check --fix .`
- `poetry run black --check .`
- `poetry run isort --check --profile black .`
- `poetry run mypy imednet`
- `IMEDNET_RUN_E2E=0 poetry run pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689e36974a38832c9c577bc67dae21cd