### PR TITLE
test: cover CLI output helpers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Bump project version to `0.1.4`.
 - Added tests for unknown form validation errors.
 - Added async schema validation tests covering cache refresh and batch validation.
+- Added unit tests for CLI output helpers `echo_fetch` and `display_list`.
 - ISO datetime parser now pads fractional seconds shorter than six digits to
    microsecond precision.
 - Added workflow to sanitize PR bodies and comments of `chatgpt.com/codex` links.

--- a/tests/unit/cli/test_utils_output.py
+++ b/tests/unit/cli/test_utils_output.py
@@ -1,0 +1,27 @@
+import pytest
+
+from imednet.cli.utils import display_list, echo_fetch
+
+
+def test_echo_fetch_records(capfd: pytest.CaptureFixture[str]) -> None:
+    """echo_fetch prints study-specific fetching message."""
+    echo_fetch("records", "ST")
+    captured = capfd.readouterr()
+    assert captured.out == "Fetching records for study 'ST'...\n"
+    assert captured.err == ""
+
+
+def test_display_list_non_empty(capfd: pytest.CaptureFixture[str]) -> None:
+    """display_list shows count and items for non-empty lists."""
+    display_list([1, 2], "items")
+    captured = capfd.readouterr()
+    assert captured.out == "Found 2 items:\n[1, 2]\n"
+    assert captured.err == ""
+
+
+def test_display_list_empty(capfd: pytest.CaptureFixture[str]) -> None:
+    """display_list prints default message for empty lists."""
+    display_list([], "items")
+    captured = capfd.readouterr()
+    assert captured.out == "No items found.\n"
+    assert captured.err == ""


### PR DESCRIPTION
## Summary
- add tests for `echo_fetch` and `display_list`
- document new tests

## Testing
- `poetry run ruff check --fix .`
- `poetry run black --check .`
- `poetry run isort --check --profile black .`
- `poetry run mypy imednet`
- `IMEDNET_RUN_E2E=0 poetry run pytest -q`


------
