### PR TITLE
test(core): cover retry_policy accessor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -109,6 +109,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added unit tests for `sanitize_base_url` to ensure trailing slash and `/api`
   removal.
 - Added tests for JSON logging configuration covering formatter import paths.
+- Added unit test for `HTTPClientBase.retry_policy` accessor to ensure executor updates.
 
 ## [0.1.4]
 

--- a/tests/unit/test_core_client.py
+++ b/tests/unit/test_core_client.py
@@ -6,6 +6,7 @@ import pytest
 from imednet.core import exceptions
 from imednet.core.base_client import BaseClient
 from imednet.core.client import Client
+from imednet.core.retry import RetryPolicy
 
 
 class DummyResponse:
@@ -92,3 +93,13 @@ def test_tracer_records_span(monkeypatch) -> None:
 def test_base_url_sanitized() -> None:
     client = Client(api_key="A", security_key="B", base_url="https://host/api/")
     assert client.base_url == "https://host"
+
+
+def test_retry_policy_accessor_updates_executor() -> None:
+    client = Client(api_key="A", security_key="B")
+    policy = MagicMock(spec=RetryPolicy)
+
+    client.retry_policy = policy
+
+    assert client.retry_policy is policy
+    assert client._executor.retry_policy is policy


### PR DESCRIPTION
## Summary
- test HTTPClientBase.retry_policy property updates RequestExecutor
- note coverage test in changelog

## Testing
- `poetry run ruff check --fix .`
- `poetry run black --check .`
- `poetry run isort --check --profile black .`
- `poetry run mypy imednet`
- `poetry run pytest tests/unit/test_core_client.py::test_retry_policy_accessor_updates_executor -q`
- `poetry run pytest -q` *(fails: Killed)*

------
