### PR TITLE
[ci] use upload-artifact v4 in smoke workflow

### DIFF
--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -27,7 +27,7 @@ jobs:
           poetry run python scripts/post_smoke_record.py --verbose 2>&1 | tee smoke.log
       - name: Upload smoke log
         if: always()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: smoke-log
           path: smoke.log

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+- Updated smoke workflow to use `actions/upload-artifact@v4`.
 - Added tests for JsonModel type normalization.
 - Expanded AGENTS contributor guides with scoped templates across packages and tooling.
 - Added negative-path test for `SubjectDataWorkflow.get_all_subject_data` handling empty responses.


### PR DESCRIPTION
## Summary
- use actions/upload-artifact v4 in smoke workflow
- document artifact action update

## Testing
- `poetry run ruff check --fix .`
- `poetry run black --check .`
- `poetry run isort --check --profile black .`
- `poetry run mypy imednet`
- `poetry run pytest -q` *(fails: tests/live/test_cli_live.py::test_cli_jobs_wait FAILED; command killed)*

------
https://chatgpt.com/codex/tasks/task_e_689e3f263904832ca9faa4fa616d1021