### PR TITLE
test: cover pandas helpers edge cases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+- Added tests for `records_to_dataframe` and `export_records_csv` covering
+  non-flattened and empty inputs.
 - Updated smoke workflow to use `actions/upload-artifact@v4`.
 - Added tests for JsonModel type normalization.
 - Expanded AGENTS contributor guides with scoped templates across packages and tooling.

--- a/tests/unit/test_utils_pandas.py
+++ b/tests/unit/test_utils_pandas.py
@@ -1,3 +1,4 @@
+import ast
 from unittest.mock import MagicMock
 
 import pandas as pd
@@ -24,6 +25,18 @@ def test_records_to_dataframe_flatten() -> None:
     assert df.loc[0, "AGE"] == 30
 
 
+def test_records_to_dataframe_no_flatten() -> None:
+    rec = _sample_record()
+    df = records_to_dataframe([rec], flatten=False)
+    assert "record_data" in df.columns
+    assert df.loc[0, "record_data"] == {"AGE": 30}
+
+
+def test_records_to_dataframe_empty() -> None:
+    df = records_to_dataframe([], flatten=False)
+    assert df.empty
+
+
 def test_export_records_csv(tmp_path) -> None:
     sdk = MagicMock()
     sdk.records.list.return_value = [_sample_record()]
@@ -34,4 +47,18 @@ def test_export_records_csv(tmp_path) -> None:
     assert out_path.exists()
     df = pd.read_csv(out_path)
     assert df.loc[0, "AGE"] == 30
+    sdk.records.list.assert_called_once_with(study_key="STUDY")
+
+
+def test_export_records_csv_no_flatten(tmp_path) -> None:
+    sdk = MagicMock()
+    sdk.records.list.return_value = [_sample_record()]
+    out_path = tmp_path / "records.csv"
+
+    export_records_csv(sdk, "STUDY", str(out_path), flatten=False)
+
+    assert out_path.exists()
+    df = pd.read_csv(out_path)
+    assert "record_data" in df.columns
+    assert ast.literal_eval(str(df.loc[0, "record_data"])) == {"AGE": 30}
     sdk.records.list.assert_called_once_with(study_key="STUDY")


### PR DESCRIPTION
## Summary
- add tests for records_to_dataframe non-flattened and empty inputs
- verify export_records_csv preserves record_data when flatten is disabled

## Testing
- `poetry run ruff check --fix .`
- `poetry run black --check .`
- `poetry run isort --check --profile black .`
- `poetry run mypy imednet`
- `poetry run pytest tests/unit/test_utils_pandas.py -q`
- `poetry run pytest -q` *(fails: Killed)*

------
