### PR TITLE
test: cover airflow shim deprecation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 - Updated smoke workflow to use `actions/upload-artifact@v4`.
 - Added tests for JsonModel type normalization.
+- Added tests for deprecated `imednet.airflow` shim ensuring warning and re-exports.
 - Expanded AGENTS contributor guides with scoped templates across packages and tooling.
 - Added negative-path test for `SubjectDataWorkflow.get_all_subject_data` handling empty responses.
 - Smoke workflow now uploads verbose script logs and runs live tests with full output.

--- a/tests/unit/test_airflow_deprecation.py
+++ b/tests/unit/test_airflow_deprecation.py
@@ -1,0 +1,56 @@
+import sys
+from types import ModuleType
+
+import pytest
+
+
+def _setup_airflow(monkeypatch):
+    airflow_mod = ModuleType("airflow")
+    hooks_pkg = ModuleType("airflow.hooks")
+    hooks_mod = ModuleType("airflow.hooks.base")
+    models_mod = ModuleType("airflow.models")
+
+    class DummyBaseHook:
+        @classmethod
+        def get_connection(cls, conn_id):  # pragma: no cover
+            raise NotImplementedError
+
+    class DummyBaseOperator:
+        template_fields = ()
+
+        def __init__(self, **kwargs):  # pragma: no cover
+            pass
+
+    hooks_mod.BaseHook = DummyBaseHook
+    models_mod.BaseOperator = DummyBaseOperator
+
+    hooks_pkg.base = hooks_mod
+    airflow_mod.hooks = hooks_pkg
+    airflow_mod.models = models_mod
+
+    monkeypatch.setitem(sys.modules, "airflow", airflow_mod)
+    monkeypatch.setitem(sys.modules, "airflow.hooks", hooks_pkg)
+    monkeypatch.setitem(sys.modules, "airflow.hooks.base", hooks_mod)
+    monkeypatch.setitem(sys.modules, "airflow.models", models_mod)
+
+
+def test_airflow_shim_warns_and_re_exports(monkeypatch):
+    _setup_airflow(monkeypatch)
+    for mod in [
+        "imednet.airflow",
+        "imednet.integrations.airflow",
+        "imednet.integrations.airflow.hooks",
+        "imednet.integrations.airflow.operators",
+        "imednet.integrations.airflow.sensors",
+    ]:
+        monkeypatch.delitem(sys.modules, mod, raising=False)
+
+    with pytest.warns(DeprecationWarning):
+        import imednet.airflow as shim
+
+    from imednet.integrations import airflow as new
+
+    assert shim.ImednetHook is new.ImednetHook
+    assert shim.ImednetJobSensor is new.ImednetJobSensor
+    assert shim.ImednetExportOperator is new.ImednetExportOperator
+    assert shim.ImednetToS3Operator is new.ImednetToS3Operator


### PR DESCRIPTION
## Summary
- test deprecated `imednet.airflow` shim warns and re-exports integration classes
- document deprecated Airflow shim coverage

## Testing
- `poetry run ruff check .`
- `poetry run black --check .`
- `poetry run isort -v --check --profile black tests/unit/test_airflow_deprecation.py`
- `poetry run mypy imednet`
- `poetry run pytest tests/unit -q`
- `poetry run pytest -q` *(failed: tests/live/test_cli_live.py::test_cli_jobs_wait FAILED; tests/live/test_cli_live.py::test_cli_export_excel FAILED; tests/live/test_cli_live.py::test_cli_export_json FAILED)*

------
https://chatgpt.com/codex/tasks/task_e_689e426d45ec832cbd6000f91b3bdaa6