### PR TITLE
docs: add long-format SQL export docs and example

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added workflow to sanitize PR bodies and comments of `chatgpt.com/codex` links.
 - Extracted common logic from `Client` and `AsyncClient` into new `HTTPClientBase`.
 - Added `imednet.config` module with `load_config` helper for reading credentials.
+- Documented long-format SQL export and added example script.
 - Introduced `RetryPolicy` abstraction for configuring request retries.
 - Added tests for retry policy handling of response results and non-RequestError exceptions.
 - Documented test suite conventions in `tests/AGENTS.md`.

--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -92,6 +92,9 @@ require more time to insert large datasets.
 
    imednet export sql MY_STUDY table sqlite:///data.db --long-format
 
+See the example script :mod:`examples.export_long_sql` for invoking this option
+via the SDK.
+
 Variable Filters
 ----------------
 

--- a/docs/imednet.integrations.rst
+++ b/docs/imednet.integrations.rst
@@ -1,6 +1,37 @@
 imednet.integrations package
 ============================
 
+Long-format SQL export
+----------------------
+
+The :func:`imednet.integrations.export.export_to_long_sql` helper writes all
+record values into a single normalized SQL table. Each row contains a record
+identifier, form identifier, variable name, value, and timestamp.
+
+Parameters:
+
+``sdk``
+    An initialized :class:`imednet.ImednetSDK` or compatible client.
+``study_key``
+    The study identifier.
+``table_name``
+    Target table for inserted rows.
+``conn_str``
+    SQLAlchemy connection string, such as ``sqlite:///records.db``.
+``chunk_size``
+    Optional batch size for insert operations (default ``1000``).
+
+.. code-block:: python
+
+    from imednet import ImednetSDK
+    from imednet.integrations import export_to_long_sql
+
+    sdk = ImednetSDK()
+    export_to_long_sql(sdk, "STUDY", "records", "sqlite:///records.db")
+
+The example script :mod:`examples.export_long_sql` provides a runnable
+demonstration.
+
 Subpackages
 -----------
 

--- a/examples/export_long_sql.py
+++ b/examples/export_long_sql.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+import os
+import sys
+
+from imednet import ImednetSDK
+from imednet.integrations import export_to_long_sql
+
+"""Export records to a normalized long-format SQL table.
+
+Set ``IMEDNET_API_KEY`` and ``IMEDNET_SECURITY_KEY`` before running this script.
+Optionally set ``IMEDNET_BASE_URL`` for non-default instances.
+
+Usage:
+    python examples/export_long_sql.py STUDY_KEY TABLE_NAME OUTPUT_DB
+
+The ``OUTPUT_DB`` path is used to build the SQLite connection string.
+"""
+
+
+def main() -> None:
+    """Export a study's records in long format to SQLite."""
+
+    if len(sys.argv) != 4:
+        print(
+            "Usage: python examples/export_long_sql.py STUDY_KEY TABLE_NAME OUTPUT_DB",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    study_key, table_name, output_db = sys.argv[1:]
+
+    missing = [var for var in ("IMEDNET_API_KEY", "IMEDNET_SECURITY_KEY") if not os.getenv(var)]
+    if missing:
+        vars_ = ", ".join(missing)
+        print(f"Missing required environment variable(s): {vars_}", file=sys.stderr)
+        sys.exit(1)
+
+    sdk = ImednetSDK()
+    conn_str = f"sqlite:///{output_db}"
+    export_to_long_sql(sdk, study_key, table_name, conn_str)
+    print(f"Exported {study_key} to {output_db} using table '{table_name}'.")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- document `export_to_long_sql` with parameters and code snippet
- link new `examples/export_long_sql.py` from CLI docs
- add runnable long-format export example script

## Testing
- `poetry run ruff check --fix .`
- `poetry run black --check .`
- `poetry run isort --check --profile black .`
- `poetry run mypy imednet`
- `poetry run pytest tests/unit/test_integrations_export.py::test_export_to_long_sql -q`
- `make docs` *(fails: duplicate object description warnings)*
- `IMEDNET_API_KEY=foo IMEDNET_SECURITY_KEY=bar poetry run python examples/export_long_sql.py STUDY tbl out.db`


------
