### PR TITLE
test: cover SDK retry policy initialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+- Added test for initial SDK retry policy propagation to sync and async clients.
 - Updated smoke workflow to use `actions/upload-artifact@v4`.
 - Added tests for JsonModel type normalization.
 - Expanded AGENTS contributor guides with scoped templates across packages and tooling.

--- a/tests/unit/test_sdk_retry_policy.py
+++ b/tests/unit/test_sdk_retry_policy.py
@@ -22,6 +22,21 @@ def sdk() -> ImednetSDK:
     )
 
 
+def test_initial_retry_policy_propagates_to_clients() -> None:
+    policy = NamedPolicy("init")
+    sdk = ImednetSDK(
+        api_key="key",
+        security_key="secret",
+        base_url="https://example.com",
+        enable_async=True,
+        retry_policy=policy,
+    )
+
+    assert sdk._client.retry_policy is policy
+    assert sdk._async_client is not None
+    assert sdk._async_client.retry_policy is policy
+
+
 def test_retry_policy_propagates_to_clients(sdk: ImednetSDK) -> None:
     assert sdk._async_client is not None
 


### PR DESCRIPTION
## Summary
- test that retry policy given at SDK construction propagates to sync and async clients
- document retry policy test in changelog

## Testing
- `poetry run ruff check --fix .`
- `poetry run black --check .`
- `poetry run isort --check --profile black .`
- `poetry run mypy imednet`
- `poetry run pytest -q` *(fails: tests/live/test_cli_live.py::test_cli_jobs_wait FAILED; process killed later)*
- `poetry run pytest tests/unit/test_sdk_retry_policy.py -q`


------
https://chatgpt.com/codex/tasks/task_e_689e429e3fd4832c9eaa6faf3faef016