### PR TITLE
[imednet] expose airflow helpers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Bump project version to `0.1.4`.
 - Added tests for unknown form validation errors.
 - Added async schema validation tests covering cache refresh and batch validation.
+- Exposed export helpers in `imednet.integrations.airflow.export` and consolidated job sensor into a module for easier Airflow imports.
 - Added unit tests for CLI output helpers `echo_fetch` and `display_list`.
 - ISO datetime parser now pads fractional seconds shorter than six digits to
    microsecond precision.

--- a/imednet/integrations/airflow/__init__.py
+++ b/imednet/integrations/airflow/__init__.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import sys
 from importlib import reload
 
-from .. import export
+from . import export
 
 if "imednet.integrations.airflow.hooks" in sys.modules:
     reload(sys.modules["imednet.integrations.airflow.hooks"])

--- a/imednet/integrations/airflow/export.py
+++ b/imednet/integrations/airflow/export.py
@@ -1,0 +1,21 @@
+"""Airflow-facing export helpers."""
+
+from __future__ import annotations
+
+from .. import export as _base_export
+
+export_to_csv = _base_export.export_to_csv
+export_to_parquet = _base_export.export_to_parquet
+export_to_excel = _base_export.export_to_excel
+export_to_json = _base_export.export_to_json
+export_to_sql = _base_export.export_to_sql
+export_to_sql_by_form = _base_export.export_to_sql_by_form
+
+__all__ = [
+    "export_to_csv",
+    "export_to_parquet",
+    "export_to_excel",
+    "export_to_json",
+    "export_to_sql",
+    "export_to_sql_by_form",
+]

--- a/imednet/integrations/airflow/sensors.py
+++ b/imednet/integrations/airflow/sensors.py
@@ -1,3 +1,5 @@
+"""Airflow sensors for iMednet operations."""
+
 from __future__ import annotations
 
 from typing import Any, Dict, Iterable
@@ -15,7 +17,8 @@ except Exception:  # pragma: no cover - placeholder fallback
             pass
 
 
-from ....sdk import ImednetSDK
+from ...sdk import ImednetSDK
+from .hooks import ImednetHook
 
 TERMINAL_STATES = {"COMPLETED", "FAILED", "CANCELLED"}
 
@@ -40,8 +43,6 @@ class ImednetJobSensor(BaseSensorOperator):
         self.imednet_conn_id = imednet_conn_id
 
     def _get_sdk(self) -> ImednetSDK:
-        from . import ImednetHook
-
         return ImednetHook(self.imednet_conn_id).get_conn()
 
     def poke(self, context: Dict[str, Any]) -> bool:
@@ -50,11 +51,11 @@ class ImednetJobSensor(BaseSensorOperator):
         state = job.state.upper()
         if state in TERMINAL_STATES:
             if state != "COMPLETED":
-                from ..operators import AirflowException
+                from .operators import AirflowException
 
                 raise AirflowException(f"Job {self.batch_id} ended in state {state}")
             return True
         return False
 
 
-__all__ = ["ImednetJobSensor"]
+__all__ = ["ImednetJobSensor", "ImednetHook"]

--- a/imednet/integrations/airflow/sensors/__init__.py
+++ b/imednet/integrations/airflow/sensors/__init__.py
@@ -1,6 +1,0 @@
-"""Airflow sensors for iMednet operations."""
-
-from ..hooks import ImednetHook
-from .job import ImednetJobSensor
-
-__all__ = ["ImednetJobSensor", "ImednetHook"]


### PR DESCRIPTION
## Summary
- re-export generic export utilities under `imednet.integrations.airflow.export`
- flatten job sensor into `imednet.integrations.airflow.sensors`
- document Airflow helper availability

## Testing
- `poetry run ruff check .`
- `poetry run black --check .`
- `poetry run isort --check --profile black .`
- `poetry run mypy imednet`
- `pytest tests/unit/test_airflow_integration.py::test_export_operator_calls_helper -q`
- `pytest tests/unit/test_airflow_operators.py::test_job_sensor -q`
- `poetry run pytest -q` *(fails: tests/live/test_cli_live.py::test_cli_jobs_wait)*

------
