### PR TITLE
[imednet] cast DataFrame columns to strings for Airflow export

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,8 +12,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   non-flattened and empty inputs.
 - Fixed export helpers to cast DataFrame column names to strings before
   case-insensitive de-duplication.
-- Imported Airflow hooks at runtime in export operator to simplify mocking.
-- Guarded Airflow hook against non-string connection extras and ensured sensors module is importable for reloading.
+  - Resolved monkeypatching issues in Airflow export operator by using existing package from `sys.modules`.
+  - Hardened Airflow hook against non-string connection data and simplified package init so the sensors module stays reloadable.
 - Narrowed subject existence validation in `RegisterSubjectsWorkflow` to catch only `ApiError` and `ValueError`.
 - Updated smoke workflow to use `actions/upload-artifact@v4`.
 - Added tests for JsonModel type normalization.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed export helpers to cast DataFrame column names to strings before
   case-insensitive de-duplication.
 - Imported Airflow hooks at runtime in export operator to simplify mocking.
+- Guarded Airflow hook against non-string connection extras and ensured sensors module is importable for reloading.
 - Narrowed subject existence validation in `RegisterSubjectsWorkflow` to catch only `ApiError` and `ValueError`.
 - Updated smoke workflow to use `actions/upload-artifact@v4`.
 - Added tests for JsonModel type normalization.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   non-flattened and empty inputs.
 - Fixed export helpers to cast DataFrame column names to strings before
   case-insensitive de-duplication.
+- Imported Airflow hooks at runtime in export operator to simplify mocking.
 - Narrowed subject existence validation in `RegisterSubjectsWorkflow` to catch only `ApiError` and `ValueError`.
 - Updated smoke workflow to use `actions/upload-artifact@v4`.
 - Added tests for JsonModel type normalization.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added tests for ImednetSDK credential validation.
 - Added tests for `records_to_dataframe` and `export_records_csv` covering
   non-flattened and empty inputs.
+- Fixed export helpers to cast DataFrame column names to strings before
+  case-insensitive de-duplication.
 - Narrowed subject existence validation in `RegisterSubjectsWorkflow` to catch only `ApiError` and `ValueError`.
 - Updated smoke workflow to use `actions/upload-artifact@v4`.
 - Added tests for JsonModel type normalization.

--- a/imednet/integrations/airflow/__init__.py
+++ b/imednet/integrations/airflow/__init__.py
@@ -1,23 +1,14 @@
 from __future__ import annotations
 
-import sys
-from importlib import reload
+from importlib import import_module
 
 from . import export
-
-if "imednet.integrations.airflow.hooks" in sys.modules:
-    reload(sys.modules["imednet.integrations.airflow.hooks"])
-if "imednet.integrations.airflow.operators" in sys.modules:
-    reload(sys.modules["imednet.integrations.airflow.operators"])
-if "imednet.integrations.airflow.sensors" in sys.modules:
-    reload(sys.modules["imednet.integrations.airflow.sensors"])
-
 from .hooks import ImednetHook
 from .operators import ImednetExportOperator, ImednetToS3Operator
 
 try:  # pragma: no cover - optional Airflow dependencies may be missing
-    from . import sensors  # ensure module is available for reloading
-    from .sensors import ImednetJobSensor
+    sensors = import_module("imednet.integrations.airflow.sensors")
+    ImednetJobSensor = sensors.ImednetJobSensor
 except Exception:  # pragma: no cover - sensor requires Airflow extras
     ImednetJobSensor = None  # type: ignore
     sensors = None  # type: ignore

--- a/imednet/integrations/airflow/__init__.py
+++ b/imednet/integrations/airflow/__init__.py
@@ -16,9 +16,11 @@ from .hooks import ImednetHook
 from .operators import ImednetExportOperator, ImednetToS3Operator
 
 try:  # pragma: no cover - optional Airflow dependencies may be missing
+    from . import sensors  # ensure module is available for reloading
     from .sensors import ImednetJobSensor
 except Exception:  # pragma: no cover - sensor requires Airflow extras
     ImednetJobSensor = None  # type: ignore
+    sensors = None  # type: ignore
 
 __all__ = [
     "ImednetHook",

--- a/imednet/integrations/airflow/export.py
+++ b/imednet/integrations/airflow/export.py
@@ -2,14 +2,34 @@
 
 from __future__ import annotations
 
+from typing import Any
+
 from .. import export as _base_export
 
-export_to_csv = _base_export.export_to_csv
-export_to_parquet = _base_export.export_to_parquet
-export_to_excel = _base_export.export_to_excel
-export_to_json = _base_export.export_to_json
-export_to_sql = _base_export.export_to_sql
-export_to_sql_by_form = _base_export.export_to_sql_by_form
+
+def export_to_csv(*args: Any, **kwargs: Any) -> None:
+    return _base_export.export_to_csv(*args, **kwargs)
+
+
+def export_to_parquet(*args: Any, **kwargs: Any) -> None:
+    return _base_export.export_to_parquet(*args, **kwargs)
+
+
+def export_to_excel(*args: Any, **kwargs: Any) -> None:
+    return _base_export.export_to_excel(*args, **kwargs)
+
+
+def export_to_json(*args: Any, **kwargs: Any) -> None:
+    return _base_export.export_to_json(*args, **kwargs)
+
+
+def export_to_sql(*args: Any, **kwargs: Any) -> None:
+    return _base_export.export_to_sql(*args, **kwargs)
+
+
+def export_to_sql_by_form(*args: Any, **kwargs: Any) -> None:
+    return _base_export.export_to_sql_by_form(*args, **kwargs)
+
 
 __all__ = [
     "export_to_csv",

--- a/imednet/integrations/airflow/hooks/__init__.py
+++ b/imednet/integrations/airflow/hooks/__init__.py
@@ -27,9 +27,15 @@ class ImednetHook(BaseHook):
         base_url = extras.get("base_url")
         if base_url is not None:
             base_url = str(base_url)
+        login = getattr(conn, "login", None)
+        if not isinstance(login, str):
+            login = None
+        password = getattr(conn, "password", None)
+        if not isinstance(password, str):
+            password = None
         config = load_config(
-            api_key=extras.get("api_key") or conn.login,
-            security_key=extras.get("security_key") or conn.password,
+            api_key=extras.get("api_key") or login,
+            security_key=extras.get("security_key") or password,
             base_url=base_url,
         )
         return ImednetSDK(

--- a/imednet/integrations/airflow/hooks/__init__.py
+++ b/imednet/integrations/airflow/hooks/__init__.py
@@ -21,11 +21,16 @@ class ImednetHook(BaseHook):
             BaseHook = CurrentBaseHook
 
         conn = BaseHook.get_connection(self.imednet_conn_id)
-        extras = conn.extra_dejson
+        extras = getattr(conn, "extra_dejson", {}) or {}
+        if not isinstance(extras, dict):
+            extras = {}
+        base_url = extras.get("base_url")
+        if base_url is not None:
+            base_url = str(base_url)
         config = load_config(
             api_key=extras.get("api_key") or conn.login,
             security_key=extras.get("security_key") or conn.password,
-            base_url=extras.get("base_url"),
+            base_url=base_url,
         )
         return ImednetSDK(
             api_key=config.api_key,

--- a/imednet/integrations/airflow/operators/export.py
+++ b/imednet/integrations/airflow/operators/export.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from importlib import import_module
 from typing import Any, Dict, Iterable, Optional
 
 from airflow.models import BaseOperator
@@ -32,9 +33,8 @@ class ImednetExportOperator(BaseOperator):
         self.imednet_conn_id = imednet_conn_id
 
     def execute(self, context: Dict[str, Any]) -> str:
-        from .. import ImednetHook
-
-        hook = ImednetHook(self.imednet_conn_id)
+        airflow_mod = import_module("imednet.integrations.airflow")
+        hook = airflow_mod.ImednetHook(self.imednet_conn_id)
         sdk = hook.get_conn()
         export_callable = getattr(export, self.export_func)
         export_callable(sdk, self.study_key, self.output_path, **self.export_kwargs)

--- a/imednet/integrations/airflow/operators/export.py
+++ b/imednet/integrations/airflow/operators/export.py
@@ -33,7 +33,11 @@ class ImednetExportOperator(BaseOperator):
         self.imednet_conn_id = imednet_conn_id
 
     def execute(self, context: Dict[str, Any]) -> str:
-        airflow_mod = import_module("imednet.integrations.airflow")
+        import sys
+
+        airflow_mod = sys.modules.get("imednet.integrations.airflow")
+        if airflow_mod is None:  # pragma: no cover - module should already be loaded
+            airflow_mod = import_module("imednet.integrations.airflow")
         hook = airflow_mod.ImednetHook(self.imednet_conn_id)
         sdk = hook.get_conn()
         export_callable = getattr(export, self.export_func)

--- a/imednet/integrations/export.py
+++ b/imednet/integrations/export.py
@@ -57,6 +57,7 @@ def _records_df(
         form_whitelist=form_whitelist,
     )
     if isinstance(df, pd.DataFrame):
+        df.columns = df.columns.astype(str)
         df = df.loc[:, ~df.columns.str.lower().duplicated()]
     return df
 

--- a/tests/unit/test_airflow_integration.py
+++ b/tests/unit/test_airflow_integration.py
@@ -65,6 +65,15 @@ def test_imednet_hook_returns_sdk(monkeypatch):
 def test_export_operator_calls_helper(monkeypatch):
     _setup_airflow(monkeypatch)
 
+    conn = MagicMock()
+    import airflow.hooks.base as hooks_base
+
+    monkeypatch.setattr(
+        hooks_base.BaseHook,
+        "get_connection",
+        classmethod(lambda cls, cid: conn),
+    )
+
     sdk = MagicMock()
     hook_inst = MagicMock(get_conn=MagicMock(return_value=sdk))
 

--- a/tests/unit/test_airflow_operators.py
+++ b/tests/unit/test_airflow_operators.py
@@ -143,8 +143,10 @@ def test_to_s3_operator_missing_list(monkeypatch):
 
 
 def test_job_sensor(monkeypatch):
-    sensors = _import_sensors(monkeypatch)
     ops = _import_operators(monkeypatch)
+    import imednet.integrations.airflow.sensors as sensors
+
+    importlib.reload(sensors)
     _patch_basehook(monkeypatch)
     sdk = MagicMock()
     job = MagicMock(state="COMPLETED")

--- a/tests/unit/test_airflow_operators.py
+++ b/tests/unit/test_airflow_operators.py
@@ -143,7 +143,10 @@ def test_to_s3_operator_missing_list(monkeypatch):
 
 
 def test_job_sensor(monkeypatch):
-    ops = _import_operators(monkeypatch)
+    _setup_airflow(monkeypatch)
+    import imednet.integrations.airflow.operators as ops
+
+    importlib.reload(ops)
     import imednet.integrations.airflow.sensors as sensors
 
     importlib.reload(sensors)


### PR DESCRIPTION
## Summary
- cast DataFrame column names to strings before lowercasing to avoid `.str` failures
- wrap Airflow export helpers so patches reach base implementations
- fix Airflow unit tests to mock connections and ensure proper setup

## Testing
- `poetry run ruff check --fix .`
- `poetry run black --check .`
- `poetry run isort --check --profile black .`
- `poetry run mypy imednet`
- `poetry run pytest tests/integration/test_export_airflow_integration.py::test_imednet_export_operator -q`
- `poetry run pytest tests/unit/test_airflow_integration.py::test_export_operator_calls_helper -q`
- `poetry run pytest tests/unit/test_airflow_operators.py::test_job_sensor -q`
- `poetry run pytest -q` *(fails: tests/live/test_cli_live.py::test_cli_jobs_wait; killed during tests/live/test_cli_live.py::test_cli_export_excel)*

------
