### PR TITLE
docs: add async quick start

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -123,6 +123,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added tests for JSON logging configuration covering formatter import paths.
 - Added unit test for `HTTPClientBase.retry_policy` accessor to ensure executor updates.
 - Added test verifying `ImednetSDK.retry_policy` updates sync and async clients.
+- Added async quick start guide, example script, and README references.
 
 ## [0.1.4]
 

--- a/README.md
+++ b/README.md
@@ -54,6 +54,31 @@ sdk = ImednetSDK(
 print(sdk.studies.list())
 ```
 
+## Asynchronous Example
+
+```python
+import asyncio
+from imednet import AsyncImednetSDK
+from imednet.config import load_config
+from imednet.utils import configure_json_logging
+
+
+async def main() -> None:
+    configure_json_logging()
+    cfg = load_config()
+    async with AsyncImednetSDK(
+        api_key=cfg.api_key,
+        security_key=cfg.security_key,
+        base_url=cfg.base_url,
+    ) as sdk:
+        print(await sdk.studies.async_list())
+
+
+asyncio.run(main())
+```
+
+See [docs/async_quick_start.rst](docs/async_quick_start.rst) for more details.
+
 ## Tech Stack
 
 - Python 3.10–3.12

--- a/docs/async_quick_start.rst
+++ b/docs/async_quick_start.rst
@@ -1,0 +1,44 @@
+Async Quick Start
+=================
+
+This page shows a minimal asynchronous example using ``AsyncImednetSDK``.
+
+Install the package from PyPI:
+
+.. code-block:: console
+
+   pip install imednet
+
+Set your credentials as environment variables:
+
+.. code-block:: bash
+
+   export IMEDNET_API_KEY="your_api_key"
+   export IMEDNET_SECURITY_KEY="your_security_key"
+
+List studies asynchronously and poll a job:
+
+.. code-block:: python
+
+   import asyncio
+   from imednet import AsyncImednetSDK, load_config
+   from imednet.utils import configure_json_logging
+
+   async def main() -> None:
+       configure_json_logging()
+       cfg = load_config()
+       async with AsyncImednetSDK(
+           api_key=cfg.api_key,
+           security_key=cfg.security_key,
+           base_url=cfg.base_url,
+       ) as sdk:
+           studies = await sdk.studies.async_list()
+           print(studies)
+           status = await sdk.async_poll_job("STUDY", "BATCH", interval=2, timeout=60)
+           print(status)
+
+   asyncio.run(main())
+
+The example script :mod:`examples.async_quick_start` provides a runnable version that
+validates required environment variables and optionally polls a job when
+``IMEDNET_JOB_STUDY_KEY`` and ``IMEDNET_BATCH_ID`` are set.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -7,6 +7,7 @@ Welcome to imednet's documentation!
 
    logging_and_tracing
    quick_start
+   async_quick_start
    api_overview
    rest_api_reference
    endpoints/index

--- a/examples/async_quick_start.py
+++ b/examples/async_quick_start.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+import asyncio
+import os
+import sys
+
+from imednet import AsyncImednetSDK
+from imednet.utils import configure_json_logging
+
+"""Async quick start example using environment variables for authentication.
+
+Set ``IMEDNET_API_KEY`` and ``IMEDNET_SECURITY_KEY`` before running this
+script. Optionally set ``IMEDNET_BASE_URL`` for non-default instances.
+Provide ``IMEDNET_JOB_STUDY_KEY`` and ``IMEDNET_BATCH_ID`` to poll a job.
+
+Example::
+
+    export IMEDNET_API_KEY="your_api_key"
+    export IMEDNET_SECURITY_KEY="your_security_key"
+    python examples/async_quick_start.py
+"""
+
+
+async def main() -> None:
+    """Run a minimal async SDK example using environment variables."""
+
+    configure_json_logging()
+
+    missing = [var for var in ("IMEDNET_API_KEY", "IMEDNET_SECURITY_KEY") if not os.getenv(var)]
+    if missing:
+        vars_ = ", ".join(missing)
+        print(f"Missing required environment variable(s): {vars_}", file=sys.stderr)
+        raise SystemExit(1)
+
+    async with AsyncImednetSDK() as sdk:
+        studies = await sdk.studies.async_list()
+        print(studies)
+
+        job_study = os.getenv("IMEDNET_JOB_STUDY_KEY")
+        batch_id = os.getenv("IMEDNET_BATCH_ID")
+        if job_study and batch_id:
+            status = await sdk.async_poll_job(job_study, batch_id, interval=2, timeout=60)
+            print(status)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())


### PR DESCRIPTION
## Summary
- add Async Quick Start guide and runnable example
- link async docs from README and index
- document async list and job polling

## Testing
- `poetry run ruff check --fix .`
- `poetry run black --check .`
- `poetry run isort --check --profile black .`
- `poetry run mypy imednet`
- `poetry run pytest -q --maxfail=1`
- `make docs`
- `poetry run python examples/async_quick_start.py`


------
