### PR TITLE
docs: centralize environment configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+- Added configuration guide summarizing environment variables and `.env` support.
 - Added test for initial SDK retry policy propagation to sync and async clients.
 - Added tests for ImednetSDK credential validation.
 - Added tests for `records_to_dataframe` and `export_records_csv` covering

--- a/README.md
+++ b/README.md
@@ -87,16 +87,11 @@ into Postman to explore and test the API endpoints. The collection uses the
 
 ## Configuration
 
-Set the following environment variables before using the SDK or CLI:
-
-- `IMEDNET_API_KEY` – your API key
-- `IMEDNET_SECURITY_KEY` – your security key
-- `IMEDNET_BASE_URL` – optional base URL for private deployments
-
-Use `imednet.config.load_config()` to access these values in your code.
-
-Additional variables such as `IMEDNET_STUDY_KEY` are used in the examples and
-test suite. See `docs/test_skip_conditions.rst` for a full list.
+The SDK and CLI read credentials from environment variables such as
+`IMEDNET_API_KEY` and `IMEDNET_SECURITY_KEY`. See
+[configuration](docs/configuration.rst) for the complete list, optional
+settings, and `.env` support. Use `imednet.config.load_config()` to access these
+values in your code.
 
 ## CLI Entry Points
 

--- a/docs/api_overview.rst
+++ b/docs/api_overview.rst
@@ -8,19 +8,20 @@ Base URL
 --------
 
 The SDK communicates with the production API at
-``https://edc.prod.imednetapi.com`` by default. Override this with the
-``IMEDNET_BASE_URL`` environment variable or pass ``base_url`` when calling
-``load_config`` for a private deployment.
+``https://edc.prod.imednetapi.com`` by default. Override this with
+``IMEDNET_BASE_URL`` or the ``base_url`` argument to ``load_config`` for a
+private deployment. See :doc:`configuration` for details.
 
 Authentication
 --------------
 
 All requests must include ``x-api-key`` and ``x-imn-security-key`` headers. The
-:class:`~imednet.core.base_client.BaseClient` handles shared initialization while the
-:class:`~imednet.core.client.Client` and
-:class:`~imednet.core.async_client.AsyncClient` relies on
+:class:`~imednet.core.base_client.BaseClient` handles shared initialization
+while the :class:`~imednet.core.client.Client` and
+:class:`~imednet.core.async_client.AsyncClient` rely on
 :func:`imednet.config.load_config` to read ``IMEDNET_API_KEY`` and
-``IMEDNET_SECURITY_KEY`` from the environment and populate these headers automatically.
+``IMEDNET_SECURITY_KEY`` from the environment and populate these headers
+automatically. See :doc:`configuration` for more information.
 
 HTTP methods and errors
 -----------------------

--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -2,18 +2,9 @@ Command Line Interface (CLI)
 ============================
 
 The package installs an ``imednet`` command that wraps common SDK features. The CLI
-reads authentication details from environment variables:
-
-``IMEDNET_API_KEY``
-    Your API key.
-``IMEDNET_SECURITY_KEY``
-    Your security key.
-``IMEDNET_BASE_URL``
-    Optional base URL if not using the default cloud service.
-
-Set these variables in your shell before invoking the command. You may also create
-an ``.env`` file so the values are loaded automatically.
-The CLI calls :func:`imednet.config.load_config` under the hood to read them.
+reads authentication details from environment variables. See :doc:`configuration`
+for the full list and details on using an ``.env`` file. The CLI calls
+:func:`imednet.config.load_config` under the hood to read these values.
 
 Command Hierarchy
 -----------------

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -1,0 +1,45 @@
+Configuration
+=============
+
+The SDK and CLI read settings from environment variables. They can be set in the
+shell or stored in a ``.env`` file that the CLI loads automatically via
+:func:`dotenv.load_dotenv`.
+
+Environment Variables
+---------------------
+
+``IMEDNET_API_KEY``
+    API key used for authentication.
+
+``IMEDNET_SECURITY_KEY``
+    Security key used for authentication.
+
+``IMEDNET_BASE_URL``
+    Optional base URL for private deployments.
+
+``IMEDNET_STUDY_KEY``
+    Study identifier used by examples and some tests.
+
+``IMEDNET_RUN_E2E``
+    Set to ``1`` to enable end-to-end tests that hit a live environment.
+
+``IMEDNET_BATCH_ID``
+    Batch identifier used by job polling tests. Created automatically if unset.
+
+``IMEDNET_FORM_KEY``
+    Form key for record-creation tests. If unset, the first form is used.
+
+``IMEDNET_ALLOW_MUTATION``
+    Set to ``1`` to allow workflow tests that submit data.
+
+Using a .env File
+-----------------
+
+Create a ``.env`` file in the project root to store the variables above::
+
+    IMEDNET_API_KEY=your_api_key
+    IMEDNET_SECURITY_KEY=your_security_key
+    IMEDNET_BASE_URL=https://example.com
+
+The CLI loads this file automatically. Other scripts can call
+``dotenv.load_dotenv()`` to mimic this behaviour.

--- a/docs/imednet.rst
+++ b/docs/imednet.rst
@@ -13,9 +13,13 @@ Subpackages
 .. toctree::
    :maxdepth: 4
 
+   imednet.auth
    imednet.core
    imednet.endpoints
+   imednet.errors
+   imednet.http
    imednet.models
+   imednet.pagination
    imednet.utils
    imednet.workflows
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -7,6 +7,7 @@ Welcome to imednet's documentation!
 
    logging_and_tracing
    quick_start
+   configuration
    api_overview
    rest_api_reference
    endpoints/index

--- a/docs/live_test_plan.rst
+++ b/docs/live_test_plan.rst
@@ -2,8 +2,9 @@ Live (End-to-End) Test Plan
 ===========================
 
 These tests execute against a real iMednet environment. They are skipped by default
-and require ``IMEDNET_RUN_E2E=1`` with valid credentials. Each item below should be
-covered by a dedicated test case so failures are easy to diagnose.
+and require ``IMEDNET_RUN_E2E=1`` with valid credentials (see
+:doc:`configuration`). Each item below should be covered by a dedicated test case
+so failures are easy to diagnose.
 
 Endpoints
 ---------

--- a/docs/live_tests.rst
+++ b/docs/live_tests.rst
@@ -2,10 +2,10 @@ Live Test Overview
 ==================
 
 This document summarizes the end-to-end tests located in ``tests/live``. These tests
-execute against a real iMednet environment and are skipped unless the environment
-variable ``IMEDNET_RUN_E2E=1`` is set along with valid credentials (``IMEDNET_API_KEY``
-and ``IMEDNET_SECURITY_KEY``). Each test verifies that the SDK behaves correctly
-when interacting with a running server.
+execute against a real iMednet environment and are skipped unless
+``IMEDNET_RUN_E2E=1`` is set along with valid credentials (see
+:doc:`configuration`). Each test verifies that the SDK behaves correctly when
+interacting with a running server.
 
 See :doc:`test_skip_conditions` for a summary of all variables and optional
 dependencies that control skipping.

--- a/docs/quick_start.rst
+++ b/docs/quick_start.rst
@@ -9,7 +9,7 @@ Install the package from PyPI:
 
    pip install imednet
 
-Set your credentials as environment variables:
+Set your credentials as environment variables (see :doc:`configuration` for details):
 
 .. code-block:: bash
 

--- a/docs/test_skip_conditions.rst
+++ b/docs/test_skip_conditions.rst
@@ -8,11 +8,10 @@ runs match the behaviour seen in CI.
 End-to-End Tests
 ----------------
 The files under ``tests/live`` exercise the SDK against a real iMednet
-environment. All of these tests are skipped unless ``IMEDNET_RUN_E2E=1`` and valid
-credentials are supplied via ``IMEDNET_API_KEY`` and ``IMEDNET_SECURITY_KEY``
-(optionally ``IMEDNET_BASE_URL``).
+environment. All of these tests are skipped unless ``IMEDNET_RUN_E2E=1`` and
+valid credentials are supplied (see :doc:`configuration`).
 
-Additional variables may be required:
+Additional variables may be required (see :doc:`configuration` for a full list):
 
 - ``IMEDNET_BATCH_ID`` — used for job polling tests. When unset, the suite
   creates a record to generate a batch ID automatically.

--- a/imednet/sdk.py
+++ b/imednet/sdk.py
@@ -91,9 +91,6 @@ class ImednetSDK:
 
     Attributes:
         ctx: Context object for storing state across SDK calls.
-        studies: Access to study-related endpoints.
-        forms: Access to form-related endpoints.
-        subjects: Access to subject-related endpoints.
         etc...
     """
 


### PR DESCRIPTION
## Summary
- add configuration guide summarizing environment variables and .env usage
- cross-link configuration guide from quick start, CLI docs, and README
- clean up duplicate env var explanations and tidy SDK docs to remove build warnings

## Testing
- `make docs`
- `poetry run ruff check --fix .`
- `poetry run black --check .`
- `poetry run isort --check --profile black .`
- `poetry run mypy imednet`
- `IMEDNET_RUN_E2E=0 poetry run pytest -q` *(fails: 3 failed, 485 passed, 95 skipped)*


------
