### PR TITLE
docs: expand retry policy guide with error handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -123,6 +123,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added tests for JSON logging configuration covering formatter import paths.
 - Added unit test for `HTTPClientBase.retry_policy` accessor to ensure executor updates.
 - Added test verifying `ImednetSDK.retry_policy` updates sync and async clients.
+- Documented error handling and custom retry strategies with a runnable example
+  and cross-links from overview guides.
 
 ## [0.1.4]
 

--- a/docs/api_overview.rst
+++ b/docs/api_overview.rst
@@ -35,6 +35,9 @@ codes raise typed exceptions:
 * ``429`` – :class:`~imednet.core.exceptions.RateLimitError`
 * ``5xx`` – :class:`~imednet.core.exceptions.ServerError`
 
+See :doc:`retry_policy` for examples of handling these errors and configuring
+custom retry logic.
+
 Filtering
 ---------
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -124,6 +124,10 @@ exclude_patterns: list[str] = [
     "imednet.validation.rst",
     "imednet.integrations.airflow.rst",
     "imednet.testing.rst",
+    "imednet.auth.rst",
+    "imednet.errors.rst",
+    "imednet.http.rst",
+    "imednet.pagination.rst",
 ]  # annotated per mypy requirement
 html_static_path: list[str] = ["_static"]
 

--- a/docs/quick_start.rst
+++ b/docs/quick_start.rst
@@ -50,3 +50,6 @@ Custom retry logic can be provided via a ``RetryPolicy``:
            return isinstance(state.exception, ServerError)
 
    sdk = ImednetSDK(retry_policy=ServerRetry())
+
+See :doc:`retry_policy` for more guidance on error handling and exponential
+backoff.

--- a/docs/retry_policy.rst
+++ b/docs/retry_policy.rst
@@ -1,21 +1,71 @@
-Retry Policy
-============
+Retry Policy and Error Handling
+===============================
 
 ``RetryPolicy`` decouples retry decisions from the underlying tenacity logic.
 The default implementation only retries for network errors raised by ``httpx``.
 You can implement your own strategy by inspecting :class:`imednet.core.retry.RetryState`.
 
-Example
--------
+Handling exceptions
+-------------------
+
+Use typed exceptions to respond to different failure modes:
+
+.. code-block:: python
+
+   from imednet import ImednetSDK
+   from imednet.core.exceptions import RateLimitError, ServerError, NotFoundError
+
+   sdk = ImednetSDK()
+   try:
+       sdk.studies.list()
+   except RateLimitError:
+       print("Too many requests, try again later")
+   except NotFoundError as exc:
+       print(f"Missing resource: {exc}")
+   except ServerError as exc:
+       print(f"Server error: {exc}")
+
+Custom strategies
+-----------------
+
+Retry policies decide if a request should be retried. To retry on
+``RateLimitError`` and ``ServerError``:
 
 .. code-block:: python
 
    from imednet.core.client import Client
    from imednet.core.retry import RetryPolicy, RetryState
-   from imednet.core.exceptions import ServerError
+   from imednet.core.exceptions import RateLimitError, ServerError
 
-   class ServerRetry(RetryPolicy):
+   class RateLimitServerRetry(RetryPolicy):
        def should_retry(self, state: RetryState) -> bool:
-           return isinstance(state.exception, ServerError)
+           return isinstance(state.exception, (RateLimitError, ServerError))
 
-   client = Client("A", "B", retry_policy=ServerRetry())
+   client = Client(
+       api_key="A",
+       security_key="B",
+       retries=5,
+       backoff_factor=0.5,
+       retry_policy=RateLimitServerRetry(),
+   )
+
+Logging and exponential backoff
+-------------------------------
+
+Each attempt is logged with JSON formatting. Configure logging globally via
+:func:`imednet.utils.configure_json_logging` or by supplying ``log_level`` when
+constructing the client. Retries use exponential backoff with delays controlled
+by ``retries`` and ``backoff_factor``. With ``retries=5`` and ``backoff_factor=0.5``
+the wait times are 0.5 s, 1 s, 2 s, 4 s, and 8 s.
+
+Example script
+--------------
+
+The :mod:`examples.custom_retry` script demonstrates these concepts using a mock
+transport:
+
+.. code-block:: console
+
+   export IMEDNET_API_KEY=dummy
+   export IMEDNET_SECURITY_KEY=dummy
+   python examples/custom_retry.py

--- a/examples/custom_retry.py
+++ b/examples/custom_retry.py
@@ -1,0 +1,95 @@
+from __future__ import annotations
+
+import os
+import sys
+from collections.abc import Iterator
+
+import httpx
+
+from imednet.core.client import Client
+from imednet.core.exceptions import RateLimitError, ServerError
+from imednet.core.retry import RetryPolicy, RetryState
+from imednet.utils import configure_json_logging
+
+"""Demonstrate custom retry logic with simulated rate limit and server errors.
+
+The script uses a mock transport that returns a 429, then a 500, before
+succeeding. Set ``IMEDNET_API_KEY`` and ``IMEDNET_SECURITY_KEY`` to any value
+before running this script.
+
+Example:
+
+    export IMEDNET_API_KEY="dummy"
+    export IMEDNET_SECURITY_KEY="dummy"
+    python examples/custom_retry.py
+"""
+
+
+class RateLimitServerRetry(RetryPolicy):
+    def should_retry(self, state: RetryState) -> bool:
+        if isinstance(state.exception, (RateLimitError, ServerError)):
+            return True
+        if isinstance(state.result, httpx.Response):
+            status = state.result.status_code
+            return status == 429 or 500 <= status < 600
+        return False
+
+
+responses: Iterator[httpx.Response] = iter(
+    [
+        httpx.Response(429, json={"metadata": {"status": "TOO_MANY_REQUESTS"}}),
+        httpx.Response(500, json={"metadata": {"status": "SERVER_ERROR"}}),
+        httpx.Response(200, json={"data": "ok"}),
+    ]
+)
+
+
+def responder(_: httpx.Request) -> httpx.Response:
+    return next(responses)
+
+
+class MockClient(Client):
+    def _create_client(self, api_key: str, security_key: str) -> httpx.Client:  # type: ignore[override]
+        return httpx.Client(
+            base_url=self.base_url,
+            headers={
+                "Accept": "application/json",
+                "Content-Type": "application/json",
+                "x-api-key": api_key,
+                "x-imn-security-key": security_key,
+            },
+            timeout=self.timeout,
+            transport=httpx.MockTransport(responder),
+        )
+
+
+def main() -> None:
+    """Run a request with custom retry logic."""
+    configure_json_logging()
+
+    missing = [var for var in ("IMEDNET_API_KEY", "IMEDNET_SECURITY_KEY") if not os.getenv(var)]
+    if missing:
+        vars_ = ", ".join(missing)
+        print(f"Missing required environment variable(s): {vars_}", file=sys.stderr)
+        sys.exit(1)
+
+    client = MockClient(
+        os.environ["IMEDNET_API_KEY"],
+        os.environ["IMEDNET_SECURITY_KEY"],
+        retries=3,
+        backoff_factor=0.01,
+        retry_policy=RateLimitServerRetry(),
+    )
+
+    try:
+        client.get("/studies")
+    except RateLimitError:
+        print("Request failed with rate limit error", file=sys.stderr)
+    except ServerError:
+        print("Request failed with server error", file=sys.stderr)
+    else:
+        print("Request succeeded")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- expand retry policy guide with error-handling examples
- link retry policy from overview and quick start
- add runnable custom retry example

## Testing
- `poetry run ruff check --fix .`
- `poetry run black --check .`
- `poetry run isort --check --profile black .`
- `poetry run mypy imednet`
- `poetry run pytest -q` *(killed)*
- `poetry run python examples/custom_retry.py`
- `make docs` *(warnings: duplicate object descriptions)*

------
https://chatgpt.com/codex/tasks/task_e_689e9aae1870832c865306ec033e00ff