### PR TITLE
docs: add contributor guide

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+- Documented contributor setup and process in docs and README.
 - Added test for initial SDK retry policy propagation to sync and async clients.
 - Added tests for ImednetSDK credential validation.
 - Added tests for `records_to_dataframe` and `export_records_csv` covering

--- a/README.md
+++ b/README.md
@@ -151,8 +151,9 @@ This project follows [Semantic Versioning](https://semver.org). See
 
 ## Contributing
 
-Contributions are welcome! Please read
-[CONTRIBUTING.md](CONTRIBUTING.md) for guidelines.
+Contributions are welcome! See the
+[contributing guide](docs/contributing.rst) and
+[CONTRIBUTING.md](CONTRIBUTING.md) for full details.
 
 ## License
 

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -1,0 +1,38 @@
+Contributing
+============
+
+This guide summarizes how to set up your environment, validate changes, and submit
+pull requests. Please review our `Code of Conduct <../CODE_OF_CONDUCT.md>`__ and
+see `CONTRIBUTING.md <../CONTRIBUTING.md>`__ for complete details.
+
+Setup
+-----
+.. code-block:: bash
+
+   ./scripts/setup.sh
+
+Validation
+----------
+Run these commands and ensure **≥90%** test coverage before opening a pull request:
+
+.. code-block:: bash
+
+   poetry run ruff check --fix .
+   poetry run black --check .
+   poetry run isort --check --profile black .
+   poetry run mypy imednet
+   poetry run pytest -q
+
+Conventions
+-----------
+- Apply DRY and SOLID principles.
+- Limit lines to 100 characters.
+- Use Conventional Commit messages.
+- Update ``[Unreleased]`` in ``CHANGELOG.md``.
+
+Pull request process
+--------------------
+- Include paths changed and validation output in the PR description.
+- Add or update tests with any code change.
+- Update docs and examples for public API or CLI changes.
+

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -23,6 +23,7 @@ Welcome to imednet's documentation!
    test_skip_conditions
    live_test_plan
    live_tests
+   contributing
    modules
 
 


### PR DESCRIPTION
## Summary
- add Sphinx contributing guide summarizing setup, validation commands, and PR steps
- link README to docs guide and document change in changelog
- include guide in documentation index

## Testing
- `poetry run ruff check --fix .`
- `poetry run black --check .`
- `poetry run isort --check --profile black .`
- `poetry run mypy imednet`
- `poetry run pytest -q` *(failed: process killed after partial run)*
- `make docs` *(warnings: duplicate object descriptions; missing toctree docs)*

------
https://chatgpt.com/codex/tasks/task_e_689e9add2e34832cac66908f5474c034