### PR TITLE
docs: remove unused errors toctree

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   updated the smoke record script to use them.
 - Smoke record script now validates site and subject availability before posting
   records.
+- Removed `imednet.errors` from package docs to avoid build warning.
 - Form discovery now skips disabled and non-subject forms to avoid invalid form
   key errors during record creation.
 - Decoupled live-data discovery from pytest internals and skip the smoke script

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -124,10 +124,7 @@ exclude_patterns: list[str] = [
     "imednet.validation.rst",
     "imednet.integrations.airflow.rst",
     "imednet.testing.rst",
-    "imednet.auth.rst",
     "imednet.errors.rst",
-    "imednet.http.rst",
-    "imednet.pagination.rst",
 ]  # annotated per mypy requirement
 html_static_path: list[str] = ["_static"]
 

--- a/docs/imednet.rst
+++ b/docs/imednet.rst
@@ -16,7 +16,6 @@ Subpackages
    imednet.auth
    imednet.core
    imednet.endpoints
-   imednet.errors
    imednet.http
    imednet.models
    imednet.pagination

--- a/imednet/core/context.py
+++ b/imednet/core/context.py
@@ -8,12 +8,7 @@ from typing import Optional
 
 @dataclass
 class Context:
-    """
-    Holds default values for SDK calls, such as default study key.
-
-    Attributes:
-        default_study_key: Optional[str] - default study key for API calls.
-    """
+    """Holds default values for SDK calls, such as default study key."""
 
     #: Default study key for API calls.
     #: :noindex:


### PR DESCRIPTION
## Summary
- drop `imednet.errors` from package toctree to avoid missing page
- slim Sphinx exclude list and tidy context docs

## Testing
- `poetry run ruff check --fix .`
- `poetry run black --check .`
- `poetry run isort --check --profile black .`
- `poetry run mypy imednet`
- `poetry run pytest -q` *(fails: Killed)*
- `make docs`


------
