### PR TITLE
docs: link examples and resolve warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+- Fixed unresolved example script references in documentation.
 - Documented contributor setup and process in docs and README.
 - Expanded architecture overview with component descriptions and new diagrams.
 - Added configuration guide summarizing environment variables and `.env` support.

--- a/docs/async_quick_start.rst
+++ b/docs/async_quick_start.rst
@@ -39,6 +39,6 @@ List studies asynchronously and poll a job:
 
    asyncio.run(main())
 
-The example script :mod:`examples.async_quick_start` provides a runnable version that
+The example script :doc:`examples/async_quick_start` provides a runnable version that
 validates required environment variables and optionally polls a job when
 ``IMEDNET_JOB_STUDY_KEY`` and ``IMEDNET_BATCH_ID`` are set.

--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -83,7 +83,7 @@ require more time to insert large datasets.
 
    imednet export sql MY_STUDY table sqlite:///data.db --long-format
 
-See the example script :mod:`examples.export_long_sql` for invoking this option
+See the example script :doc:`examples/export_long_sql` for invoking this option
 via the SDK.
 
 Variable Filters

--- a/docs/examples/async_quick_start.rst
+++ b/docs/examples/async_quick_start.rst
@@ -1,0 +1,5 @@
+Async Quick Start Script
+========================
+
+.. literalinclude:: ../../examples/async_quick_start.py
+   :language: python

--- a/docs/examples/custom_retry.rst
+++ b/docs/examples/custom_retry.rst
@@ -1,0 +1,5 @@
+Custom Retry Script
+===================
+
+.. literalinclude:: ../../examples/custom_retry.py
+   :language: python

--- a/docs/examples/export_long_sql.rst
+++ b/docs/examples/export_long_sql.rst
@@ -1,0 +1,5 @@
+Export Long SQL Script
+======================
+
+.. literalinclude:: ../../examples/export_long_sql.py
+   :language: python

--- a/docs/examples/index.rst
+++ b/docs/examples/index.rst
@@ -1,0 +1,10 @@
+Examples
+========
+
+.. toctree::
+   :maxdepth: 1
+
+   quick_start
+   async_quick_start
+   custom_retry
+   export_long_sql

--- a/docs/examples/quick_start.rst
+++ b/docs/examples/quick_start.rst
@@ -1,0 +1,5 @@
+Quick Start Script
+==================
+
+.. literalinclude:: ../../examples/quick_start.py
+   :language: python

--- a/docs/imednet.integrations.rst
+++ b/docs/imednet.integrations.rst
@@ -29,7 +29,7 @@ Parameters:
     sdk = ImednetSDK()
     export_to_long_sql(sdk, "STUDY", "records", "sqlite:///records.db")
 
-The example script :mod:`examples.export_long_sql` provides a runnable
+The example script :doc:`examples/export_long_sql` provides a runnable
 demonstration.
 
 Subpackages

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -25,6 +25,7 @@ Welcome to imednet's documentation!
    test_skip_conditions
    live_test_plan
    live_tests
+   examples/index
    contributing
    modules
 

--- a/docs/quick_start.rst
+++ b/docs/quick_start.rst
@@ -33,7 +33,7 @@ Enable structured logging and list studies:
    studies = sdk.studies.list()
    print(studies)
 
-The example script :mod:`examples.quick_start` provides a runnable version that
+The example script :doc:`examples/quick_start` provides a runnable version that
 validates required environment variables.
 
 Cached endpoints can be refreshed with ``refresh=True``. The caches are not thread safe so long running applications should recreate the SDK when needed.

--- a/docs/retry_policy.rst
+++ b/docs/retry_policy.rst
@@ -61,7 +61,7 @@ the wait times are 0.5 s, 1 s, 2 s, 4 s, and 8 s.
 Example script
 --------------
 
-The :mod:`examples.custom_retry` script demonstrates these concepts using a mock
+The :doc:`examples/custom_retry` script demonstrates these concepts using a mock
 transport:
 
 .. code-block:: console


### PR DESCRIPTION
## Summary
- document example scripts and reference them via :doc: links
- add docs/examples section and include it in index
- note fix in changelog

## Testing
- `poetry run ruff check --fix .`
- `poetry run black --check .`
- `poetry run isort --check --profile black .`
- `poetry run mypy imednet`
- `poetry run pytest -q` *(fails: test_cli_jobs_wait et al.)*
- `make docs` *(warnings: toctree references, duplicate object description)*

------
https://chatgpt.com/codex/tasks/task_e_689f5df83d4c832c932a361f6922f0ff