### PR TITLE
docs: document schema cache

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -107,7 +107,11 @@ autosummary_generate = True
 # Mock heavy optional dependencies so autodoc does not import them
 autodoc_mock_imports = ["pandas", "numpy", "matplotlib", "pydantic", "airflow"]
 
-suppress_warnings = ["ref.ref", "autodoc.*"]
+# Silence Sphinx warnings for excluded docs and autodoc duplicates/imports.
+suppress_warnings = ["ref.ref", "toc.excluded", "autodoc", "autodoc.import"]
+
+# Ignore noisy pydantic schema generation warnings.
+warnings.filterwarnings("ignore", message="Failed guarded type import", category=UserWarning)
 
 # Display type hints in the description instead of the signature to keep
 # function signatures concise in the rendered documentation.
@@ -121,7 +125,6 @@ exclude_patterns: list[str] = [
     "imednet.cli.*.rst",
     "imednet.integrations.rst",
     "imednet.integrations.*.rst",
-    "imednet.validation.rst",
     "imednet.integrations.airflow.rst",
     "imednet.testing.rst",
     "imednet.auth.rst",

--- a/docs/imednet.core.rst
+++ b/docs/imednet.core.rst
@@ -57,6 +57,7 @@ HTTPX requests used by the SDK:
    :members:
    :undoc-members:
    :show-inheritance:
+   :noindex:
 
 imednet.core.exceptions module
 ------------------------------

--- a/docs/imednet.rst
+++ b/docs/imednet.rst
@@ -21,6 +21,7 @@ Subpackages
    imednet.models
    imednet.pagination
    imednet.utils
+   imednet.validation
    imednet.workflows
 
 Submodules


### PR DESCRIPTION
## Summary
- include schema cache module in Sphinx build
- load validation docs so SchemaCache cross references resolve
- silence noisy doc build warnings

## Testing
- `poetry run ruff check --fix docs/conf.py`
- `poetry run black --check docs/conf.py`
- `poetry run isort --check --profile black docs/conf.py`
- `poetry run mypy imednet`
- `poetry run pytest tests/live/test_cli_live.py::test_cli_jobs_wait -q` (fails: `assert result.exit_code == 0`)
- `make docs`

------
