### PR TITLE
docs: fix record revisions filter link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+- Fixed broken ``filter`` cross-reference in record revisions docs.
 - Documented contributor setup and process in docs and README.
 - Expanded architecture overview with component descriptions and new diagrams.
 - Added configuration guide summarizing environment variables and `.env` support.

--- a/docs/endpoints/record_revisions.rst
+++ b/docs/endpoints/record_revisions.rst
@@ -32,7 +32,7 @@ Request Parameters
 ``sort``
     Sort property. Append ``asc`` or ``desc`` for direction. Default is ``recordRevisionId,asc``.
 ``filter``
-    Optional filter criteria. See :ref:`filter` for syntax details.
+    Optional filter criteria. See :ref:`filter_syntax` for syntax details.
 
 Response
 --------

--- a/docs/rest_api_reference.rst
+++ b/docs/rest_api_reference.rst
@@ -76,6 +76,8 @@ Status codes
 ``500``
   Unknown server error.
 
+.. _filter_syntax:
+
 Filtering
 ---------
 


### PR DESCRIPTION
## Summary
- fix broken filter link in record revisions docs
- document filter syntax reference label

## Testing
- `poetry run ruff check --fix .`
- `poetry run black --check .`
- `poetry run isort --check --profile black .`
- `poetry run mypy imednet`
- `poetry run pytest -q` *(fails: test_cli_jobs_wait, process killed)*
- `make docs` *(build succeeded with warnings: toctree references, duplicate object description, pydantic import)*

------
