### PR TITLE
docs: document all example scripts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -137,6 +137,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Documented error handling and custom retry strategies with a runnable example
   and cross-links from overview guides.
 - Added async quick start guide, example script, and README references.
+- Expanded examples documentation with pages for all scripts and updated index.
 
 ## [0.1.4]
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -107,7 +107,13 @@ autosummary_generate = True
 # Mock heavy optional dependencies so autodoc does not import them
 autodoc_mock_imports = ["pandas", "numpy", "matplotlib", "pydantic", "airflow"]
 
-suppress_warnings = ["ref.ref", "toc.excluded", "autodoc.import", "autodoc", "sphinx_autodoc_typehints"]
+suppress_warnings = [
+    "ref.ref",
+    "toc.excluded",
+    "autodoc.import",
+    "autodoc",
+    "sphinx_autodoc_typehints",
+]
 
 # Ignore noisy pydantic schema generation warnings.
 warnings.filterwarnings("ignore", message="Failed guarded type import", category=UserWarning)

--- a/docs/examples/async_quick_start.rst
+++ b/docs/examples/async_quick_start.rst
@@ -1,5 +1,27 @@
 Async Quick Start Script
 ========================
 
+Prerequisites
+-------------
+
+* ``imednet`` package installed
+* Access to an iMednet environment
+
+Environment variables
+---------------------
+
+.. code-block:: bash
+
+   export IMEDNET_API_KEY
+   export IMEDNET_SECURITY_KEY
+   export IMEDNET_BASE_URL (optional)
+   export IMEDNET_JOB_STUDY_KEY (optional)
+   export IMEDNET_BATCH_ID (optional)
+
+Description
+-----------
+
+Async example listing studies and optionally polling a job.
+
 .. literalinclude:: ../../examples/async_quick_start.py
    :language: python

--- a/docs/examples/custom_retry.rst
+++ b/docs/examples/custom_retry.rst
@@ -1,5 +1,24 @@
 Custom Retry Script
 ===================
 
+Prerequisites
+-------------
+
+* ``imednet`` package installed
+* Access to an iMednet environment
+
+Environment variables
+---------------------
+
+.. code-block:: bash
+
+   export IMEDNET_API_KEY
+   export IMEDNET_SECURITY_KEY
+
+Description
+-----------
+
+Demonstrate custom retry handling with mock responses.
+
 .. literalinclude:: ../../examples/custom_retry.py
    :language: python

--- a/docs/examples/export_long_sql.rst
+++ b/docs/examples/export_long_sql.rst
@@ -1,5 +1,25 @@
 Export Long SQL Script
 ======================
 
+Prerequisites
+-------------
+
+* ``imednet`` package installed
+* Access to an iMednet environment
+
+Environment variables
+---------------------
+
+.. code-block:: bash
+
+   export IMEDNET_API_KEY
+   export IMEDNET_SECURITY_KEY
+   export IMEDNET_BASE_URL (optional)
+
+Description
+-----------
+
+Export study records to a long-format SQL table.
+
 .. literalinclude:: ../../examples/export_long_sql.py
    :language: python

--- a/docs/examples/get_codings.rst
+++ b/docs/examples/get_codings.rst
@@ -1,5 +1,5 @@
-Quick Start Script
-==================
+List Codings
+============
 
 Prerequisites
 -------------
@@ -14,12 +14,13 @@ Environment variables
 
    export IMEDNET_API_KEY
    export IMEDNET_SECURITY_KEY
+   export IMEDNET_STUDY_KEY
    export IMEDNET_BASE_URL (optional)
 
 Description
 -----------
 
-Minimal example listing studies.
+Retrieve codings for a study.
 
-.. literalinclude:: ../../examples/quick_start.py
+.. literalinclude:: ../../examples/basic/get_codings.py
    :language: python

--- a/docs/examples/get_record_revisions.rst
+++ b/docs/examples/get_record_revisions.rst
@@ -1,5 +1,5 @@
-Quick Start Script
-==================
+List Record Revisions
+=====================
 
 Prerequisites
 -------------
@@ -14,12 +14,13 @@ Environment variables
 
    export IMEDNET_API_KEY
    export IMEDNET_SECURITY_KEY
+   export IMEDNET_STUDY_KEY
    export IMEDNET_BASE_URL (optional)
 
 Description
 -----------
 
-Minimal example listing studies.
+Fetch record revisions for a study.
 
-.. literalinclude:: ../../examples/quick_start.py
+.. literalinclude:: ../../examples/basic/get_record_revisions.py
    :language: python

--- a/docs/examples/get_records.rst
+++ b/docs/examples/get_records.rst
@@ -1,5 +1,5 @@
-Quick Start Script
-==================
+List Records
+============
 
 Prerequisites
 -------------
@@ -14,12 +14,13 @@ Environment variables
 
    export IMEDNET_API_KEY
    export IMEDNET_SECURITY_KEY
+   export IMEDNET_STUDY_KEY
    export IMEDNET_BASE_URL (optional)
 
 Description
 -----------
 
-Minimal example listing studies.
+Fetch records for a study.
 
-.. literalinclude:: ../../examples/quick_start.py
+.. literalinclude:: ../../examples/basic/get_records.py
    :language: python

--- a/docs/examples/get_records_async.rst
+++ b/docs/examples/get_records_async.rst
@@ -1,5 +1,5 @@
-Quick Start Script
-==================
+List Records Asynchronously
+===========================
 
 Prerequisites
 -------------
@@ -19,7 +19,7 @@ Environment variables
 Description
 -----------
 
-Minimal example listing studies.
+Demonstrate asynchronous record retrieval.
 
-.. literalinclude:: ../../examples/quick_start.py
+.. literalinclude:: ../../examples/async/get_records_async.py
    :language: python

--- a/docs/examples/get_sites.rst
+++ b/docs/examples/get_sites.rst
@@ -1,5 +1,5 @@
-Quick Start Script
-==================
+List Sites
+==========
 
 Prerequisites
 -------------
@@ -14,12 +14,13 @@ Environment variables
 
    export IMEDNET_API_KEY
    export IMEDNET_SECURITY_KEY
+   export IMEDNET_STUDY_KEY
    export IMEDNET_BASE_URL (optional)
 
 Description
 -----------
 
-Minimal example listing studies.
+Fetch sites for a study.
 
-.. literalinclude:: ../../examples/quick_start.py
+.. literalinclude:: ../../examples/basic/get_sites.py
    :language: python

--- a/docs/examples/get_studies.rst
+++ b/docs/examples/get_studies.rst
@@ -1,5 +1,5 @@
-Quick Start Script
-==================
+List Studies
+============
 
 Prerequisites
 -------------
@@ -19,7 +19,7 @@ Environment variables
 Description
 -----------
 
-Minimal example listing studies.
+List studies available to your account.
 
-.. literalinclude:: ../../examples/quick_start.py
+.. literalinclude:: ../../examples/basic/get_studies.py
    :language: python

--- a/docs/examples/get_study_structure.rst
+++ b/docs/examples/get_study_structure.rst
@@ -1,5 +1,5 @@
-Quick Start Script
-==================
+Get Study Structure
+===================
 
 Prerequisites
 -------------
@@ -14,12 +14,13 @@ Environment variables
 
    export IMEDNET_API_KEY
    export IMEDNET_SECURITY_KEY
+   export IMEDNET_STUDY_KEY
    export IMEDNET_BASE_URL (optional)
 
 Description
 -----------
 
-Minimal example listing studies.
+Export study structure to JSON and CSV.
 
-.. literalinclude:: ../../examples/quick_start.py
+.. literalinclude:: ../../examples/get_study_structure.py
    :language: python

--- a/docs/examples/get_subjects.rst
+++ b/docs/examples/get_subjects.rst
@@ -1,5 +1,5 @@
-Quick Start Script
-==================
+List Subjects
+=============
 
 Prerequisites
 -------------
@@ -14,12 +14,13 @@ Environment variables
 
    export IMEDNET_API_KEY
    export IMEDNET_SECURITY_KEY
+   export IMEDNET_STUDY_KEY
    export IMEDNET_BASE_URL (optional)
 
 Description
 -----------
 
-Minimal example listing studies.
+Fetch subjects for a study.
 
-.. literalinclude:: ../../examples/quick_start.py
+.. literalinclude:: ../../examples/basic/get_subjects.py
    :language: python

--- a/docs/examples/get_users.rst
+++ b/docs/examples/get_users.rst
@@ -1,5 +1,5 @@
-Quick Start Script
-==================
+List Users
+==========
 
 Prerequisites
 -------------
@@ -14,12 +14,13 @@ Environment variables
 
    export IMEDNET_API_KEY
    export IMEDNET_SECURITY_KEY
+   export IMEDNET_STUDY_KEY
    export IMEDNET_BASE_URL (optional)
 
 Description
 -----------
 
-Minimal example listing studies.
+Retrieve users in a study.
 
-.. literalinclude:: ../../examples/quick_start.py
+.. literalinclude:: ../../examples/basic/get_users.py
    :language: python

--- a/docs/examples/get_variables.rst
+++ b/docs/examples/get_variables.rst
@@ -1,5 +1,5 @@
-Quick Start Script
-==================
+List Variables
+==============
 
 Prerequisites
 -------------
@@ -14,12 +14,13 @@ Environment variables
 
    export IMEDNET_API_KEY
    export IMEDNET_SECURITY_KEY
+   export IMEDNET_STUDY_KEY
    export IMEDNET_BASE_URL (optional)
 
 Description
 -----------
 
-Minimal example listing studies.
+Retrieve variables and save to files.
 
-.. literalinclude:: ../../examples/quick_start.py
+.. literalinclude:: ../../examples/basic/get_variables.py
    :language: python

--- a/docs/examples/get_visits.rst
+++ b/docs/examples/get_visits.rst
@@ -1,5 +1,5 @@
-Quick Start Script
-==================
+List Visits
+===========
 
 Prerequisites
 -------------
@@ -14,12 +14,13 @@ Environment variables
 
    export IMEDNET_API_KEY
    export IMEDNET_SECURITY_KEY
+   export IMEDNET_STUDY_KEY
    export IMEDNET_BASE_URL (optional)
 
 Description
 -----------
 
-Minimal example listing studies.
+Retrieve visits for a study.
 
-.. literalinclude:: ../../examples/quick_start.py
+.. literalinclude:: ../../examples/basic/get_visits.py
    :language: python

--- a/docs/examples/index.rst
+++ b/docs/examples/index.rst
@@ -1,10 +1,39 @@
 Examples
 ========
 
+Quick start
+-----------
+
 .. toctree::
    :maxdepth: 1
 
    quick_start
    async_quick_start
+
+Basic endpoints
+---------------
+
+.. toctree::
+   :maxdepth: 1
+
+   get_studies
+   get_sites
+   get_subjects
+   get_records
+   get_record_revisions
+   get_codings
+   get_users
+   get_variables
+   get_visits
+
+Advanced
+--------
+
+.. toctree::
+   :maxdepth: 1
+
+   get_records_async
+   post_register_subjects
+   get_study_structure
    custom_retry
    export_long_sql

--- a/docs/examples/post_register_subjects.rst
+++ b/docs/examples/post_register_subjects.rst
@@ -1,5 +1,5 @@
-Quick Start Script
-==================
+Register Subjects
+=================
 
 Prerequisites
 -------------
@@ -14,12 +14,13 @@ Environment variables
 
    export IMEDNET_API_KEY
    export IMEDNET_SECURITY_KEY
+   export IMEDNET_STUDY_KEY
    export IMEDNET_BASE_URL (optional)
 
 Description
 -----------
 
-Minimal example listing studies.
+Register subjects from a JSON file.
 
-.. literalinclude:: ../../examples/quick_start.py
+.. literalinclude:: ../../examples/post_register_subjects.py
    :language: python


### PR DESCRIPTION
## Summary
- reference all example scripts from the examples index
- add one-page docs for each script with environment and usage notes
- tidy Sphinx config warning line length

## Testing
- `poetry run ruff check --fix .`
- `poetry run black --check .`
- `poetry run isort --check --profile black .`
- `poetry run mypy imednet`
- `poetry run pytest -q` *(fails: NotFoundError)*
- `make docs` *(warning: 1 warning)*
- ran example scripts *(NotFoundError with dummy credentials)*

------
