### PR TITLE
docs: add configuration API reference

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added workflow to sanitize PR bodies and comments of `chatgpt.com/codex` links.
 - Extracted common logic from `Client` and `AsyncClient` into new `HTTPClientBase`.
 - Added `imednet.config` module with `load_config` helper for reading credentials.
+- Documented `imednet.config` module with `Config` dataclass and `load_config` function.
 - Documented long-format SQL export and added example script.
 - Introduced `RetryPolicy` abstraction for configuring request retries.
 - Added tests for retry policy handling of response results and non-RequestError exceptions.

--- a/docs/architecture.rst
+++ b/docs/architecture.rst
@@ -13,7 +13,7 @@ Components
    graph TD
        CLI[CLI] --> |invokes| Workflows
        Workflows --> |coordinate| Endpoints
-       Endpoints --> |use| Client[(HTTP Client)]
+       Endpoints --> |use| Client[HTTP Client]
        Client --> |requests| API
 
 Core Client
@@ -73,7 +73,7 @@ Data Flow
        Workflows --> |call| Endpoints
        Endpoints --> |delegate| Client
        Client --> |talks to| API
-       Client --> |uses| Cache[(Caches)]
+       Client --> |uses| Cache[Caches]
 
 Extension Points
 ----------------

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -107,10 +107,17 @@ autosummary_generate = True
 # Mock heavy optional dependencies so autodoc does not import them
 autodoc_mock_imports = ["pandas", "numpy", "matplotlib", "pydantic", "airflow"]
 
-suppress_warnings = ["ref.ref", "toc.excluded", "autodoc.import", "autodoc", "sphinx_autodoc_typehints"]
+suppress_warnings = [
+    "ref.ref",
+    "toc.excluded",
+    "autodoc.import",
+    "autodoc",
+    "sphinx_autodoc_typehints",
+]
 
 # Ignore noisy pydantic schema generation warnings.
 warnings.filterwarnings("ignore", message="Failed guarded type import", category=UserWarning)
+warnings.filterwarnings("ignore", message="Failed guarded type import", category=ImportWarning)
 
 # Display type hints in the description instead of the signature to keep
 # function signatures concise in the rendered documentation.

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -3,7 +3,9 @@ Configuration
 
 The SDK and CLI read settings from environment variables. They can be set in the
 shell or stored in a ``.env`` file that the CLI loads automatically via
-:func:`dotenv.load_dotenv`.
+:func:`dotenv.load_dotenv`. Load these values into a typed
+:class:`~imednet.config.Config` with :func:`~imednet.config.load_config`—see
+:doc:`imednet.config` for details.
 
 Environment Variables
 ---------------------

--- a/docs/imednet.config.rst
+++ b/docs/imednet.config.rst
@@ -1,0 +1,24 @@
+imednet.config module
+=====================
+
+The :mod:`imednet.config` module provides a simple dataclass for SDK credentials
+and a helper to populate it from environment variables.
+
+Example
+-------
+
+.. code-block:: python
+
+    import os
+    from imednet.config import load_config
+
+    os.environ["IMEDNET_API_KEY"] = "A"
+    os.environ["IMEDNET_SECURITY_KEY"] = "B"
+
+    config = load_config()
+    assert config.api_key == "A"
+
+.. automodule:: imednet.config
+   :members: Config, load_config
+   :undoc-members:
+   :show-inheritance:

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -8,6 +8,7 @@ Welcome to imednet's documentation!
    logging_and_tracing
    quick_start
    configuration
+   imednet.config
    async_quick_start
    api_overview
    rest_api_reference

--- a/docs/modules.rst
+++ b/docs/modules.rst
@@ -5,3 +5,4 @@ imednet
    :maxdepth: 4
 
    imednet
+   imednet.config


### PR DESCRIPTION
## Summary
- document Config dataclass and load_config helper
- link configuration reference into existing docs
- fix mermaid labels and suppress stray doc warnings

## Testing
- `poetry run ruff check --fix .`
- `poetry run black --check .`
- `poetry run isort --check --profile black .`
- `poetry run mypy imednet`
- `IMEDNET_API_KEY=A IMEDNET_SECURITY_KEY=B poetry run pytest -k 'not airflow' -q`
- `make docs`


------
