### PR TITLE
docs: document utility helpers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+- Documented json logging, URL, and validator helpers with examples and cross references.
 - Documented pagination utilities to fix missing toctree reference.
 - Fixed broken ``filter`` cross-reference in record revisions docs.
 - Fixed unresolved example script references in documentation.

--- a/docs/architecture.rst
+++ b/docs/architecture.rst
@@ -13,7 +13,7 @@ Components
    graph TD
        CLI[CLI] --> |invokes| Workflows
        Workflows --> |coordinate| Endpoints
-       Endpoints --> |use| Client[(HTTP Client)]
+       Endpoints --> |use| Client(["HTTP Client"])
        Client --> |requests| API
 
 Core Client
@@ -73,7 +73,7 @@ Data Flow
        Workflows --> |call| Endpoints
        Endpoints --> |delegate| Client
        Client --> |talks to| API
-       Client --> |uses| Cache[(Caches)]
+       Client --> |uses| Cache(["Caches"])
 
 Extension Points
 ----------------

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -107,7 +107,13 @@ autosummary_generate = True
 # Mock heavy optional dependencies so autodoc does not import them
 autodoc_mock_imports = ["pandas", "numpy", "matplotlib", "pydantic", "airflow"]
 
-suppress_warnings = ["ref.ref", "toc.excluded", "autodoc.import", "autodoc", "sphinx_autodoc_typehints"]
+suppress_warnings = [
+    "ref.ref",
+    "toc.excluded",
+    "autodoc.import",
+    "autodoc",
+    "sphinx_autodoc_typehints",
+]
 
 # Ignore noisy pydantic schema generation warnings.
 warnings.filterwarnings("ignore", message="Failed guarded type import", category=UserWarning)

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -15,7 +15,8 @@ Environment Variables
     Security key used for authentication.
 
 ``IMEDNET_BASE_URL``
-    Optional base URL for private deployments.
+    Optional base URL for private deployments. Sanitize with
+    :func:`imednet.utils.url.sanitize_base_url`.
 
 ``IMEDNET_STUDY_KEY``
     Study identifier used by examples and some tests.
@@ -43,3 +44,38 @@ Create a ``.env`` file in the project root to store the variables above::
 
 The CLI loads this file automatically. Other scripts can call
 ``dotenv.load_dotenv()`` to mimic this behaviour.
+
+Parsing Values
+--------------
+
+When reading environment variables or other untyped values, use helpers from
+:mod:`imednet.utils.validators` such as
+:func:`imednet.utils.validators.parse_bool`,
+:func:`imednet.utils.validators.parse_datetime`,
+:func:`imednet.utils.validators.parse_int_or_default`,
+:func:`imednet.utils.validators.parse_str_or_default`,
+:func:`imednet.utils.validators.parse_list_or_default`, and
+:func:`imednet.utils.validators.parse_dict_or_default`.
+
+.. code-block:: python
+
+   >>> from imednet.utils.validators import (
+   ...     parse_bool,
+   ...     parse_datetime,
+   ...     parse_int_or_default,
+   ...     parse_str_or_default,
+   ...     parse_list_or_default,
+   ...     parse_dict_or_default,
+   ... )
+   >>> parse_bool("yes")
+   True
+   >>> parse_datetime("2020-01-01T00:00:00Z").year
+   2020
+   >>> parse_int_or_default("bad", default=5)
+   5
+   >>> parse_str_or_default(1.23)
+   '1.23'
+   >>> parse_list_or_default("x")
+   ['x']
+   >>> parse_dict_or_default(None)
+   {}

--- a/docs/imednet.utils.rst
+++ b/docs/imednet.utils.rst
@@ -35,6 +35,76 @@ imednet.utils.typing module
    :undoc-members:
    :show-inheritance:
 
+imednet.utils.json_logging module
+---------------------------------
+
+.. automodule:: imednet.utils.json_logging
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Example
+-------
+
+.. code-block:: python
+
+   >>> from imednet.utils.json_logging import configure_json_logging
+   >>> configure_json_logging()
+   >>> import logging
+   >>> logging.getLogger(__name__).warning("hi")  # doctest: +ELLIPSIS
+   {"message": "hi", "level": "warning", ...}
+
+imednet.utils.url module
+------------------------
+
+.. automodule:: imednet.utils.url
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Example
+-------
+
+.. code-block:: python
+
+   >>> from imednet.utils.url import sanitize_base_url
+   >>> sanitize_base_url("https://example.com/api/")
+   'https://example.com'
+
+imednet.utils.validators module
+-------------------------------
+
+.. automodule:: imednet.utils.validators
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Examples
+--------
+
+.. code-block:: python
+
+   >>> from imednet.utils.validators import (
+   ...     parse_bool,
+   ...     parse_datetime,
+   ...     parse_int_or_default,
+   ...     parse_str_or_default,
+   ...     parse_list_or_default,
+   ...     parse_dict_or_default,
+   ... )
+   >>> parse_bool("true")
+   True
+   >>> parse_datetime("2020-01-02T03:04:05Z").year
+   2020
+   >>> parse_int_or_default("bad", default=2)
+   2
+   >>> parse_str_or_default(123)
+   '123'
+   >>> parse_list_or_default("a")
+   ['a']
+   >>> parse_dict_or_default(None)
+   {}
+
 Module contents
 ---------------
 

--- a/docs/logging_and_tracing.rst
+++ b/docs/logging_and_tracing.rst
@@ -3,8 +3,8 @@ Logging and Tracing
 
 The :class:`imednet.core.client.Client` configures JSON formatted logging when it
 is instantiated. You can adjust the log level with the ``log_level`` parameter or
-call :func:`imednet.utils.configure_json_logging` in your application to apply the
-same format globally.
+call :func:`imednet.utils.json_logging.configure_json_logging` in your application
+to apply the same format globally.
 
 If `opentelemetry` is installed, the client can record spans around each HTTP
 request. Installing ``opentelemetry-instrumentation-httpx`` will automatically


### PR DESCRIPTION
## Summary
- document json logging, URL, and validator helpers with runnable snippets
- link configuration and logging guides to new API sections
- fix mermaid labels in architecture diagram

## Testing
- `poetry run ruff check --fix .`
- `poetry run black --check .`
- `poetry run isort --check --profile black .`
- `poetry run mypy imednet`
- `poetry run pytest -q` *(fails: expected call not found / module not in sys.modules)*
- `make docs`


------
