### PR TITLE
docs: document discovery helpers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 - Documented pagination utilities to fix missing toctree reference.
+- Documented runtime discovery utilities and linked them from the live test guide.
 - Fixed broken ``filter`` cross-reference in record revisions docs.
 - Fixed unresolved example script references in documentation.
 - Documented contributor setup and process in docs and README.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -107,7 +107,13 @@ autosummary_generate = True
 # Mock heavy optional dependencies so autodoc does not import them
 autodoc_mock_imports = ["pandas", "numpy", "matplotlib", "pydantic", "airflow"]
 
-suppress_warnings = ["ref.ref", "toc.excluded", "autodoc.import", "autodoc", "sphinx_autodoc_typehints"]
+suppress_warnings = [
+    "ref.ref",
+    "toc.excluded",
+    "autodoc.import",
+    "autodoc",
+    "sphinx_autodoc_typehints",
+]
 
 # Ignore noisy pydantic schema generation warnings.
 warnings.filterwarnings("ignore", message="Failed guarded type import", category=UserWarning)

--- a/docs/imednet.discovery.rst
+++ b/docs/imednet.discovery.rst
@@ -1,0 +1,95 @@
+imednet.discovery module
+========================
+
+Runtime helpers that locate study metadata for tests and scripts.
+When required identifiers are not provided, these utilities query the
+first available study, form, site, subject, or interval.
+
+
+discover_study_key
+------------------
+
+.. function:: discover_study_key(sdk: ImednetSDK) -> str
+
+   Return the first study key available for the provided SDK.
+
+   :param sdk: Authenticated :class:`~imednet.sdk.ImednetSDK` instance.
+   :return: Study key of the first available study.
+   :raises imednet.discovery.NoLiveDataError: When no studies exist.
+
+   .. code-block:: python
+
+      from imednet import ImednetSDK
+      from imednet.discovery import discover_study_key
+
+      sdk = ImednetSDK(base_url, (username, token))
+      study_key = discover_study_key(sdk)
+
+
+discover_form_key
+-----------------
+
+.. function:: discover_form_key(sdk: ImednetSDK, study_key: str) -> str
+
+   Return the first subject record form key for ``study_key``.
+
+   :param sdk: Authenticated SDK.
+   :param study_key: Identifier of the study to query.
+   :return: First form key supporting subject records.
+   :raises imednet.discovery.NoLiveDataError: When no suitable forms exist.
+
+   .. code-block:: python
+
+      form_key = discover_form_key(sdk, study_key)
+
+
+discover_site_name
+------------------
+
+.. function:: discover_site_name(sdk: ImednetSDK, study_key: str) -> str
+
+   Return the first active site name for ``study_key``.
+
+   :param sdk: Authenticated SDK.
+   :param study_key: Identifier of the study to query.
+   :return: Name of the first active site.
+   :raises imednet.discovery.NoLiveDataError: When no active sites exist.
+
+   .. code-block:: python
+
+      site_name = discover_site_name(sdk, study_key)
+
+
+discover_subject_key
+--------------------
+
+.. function:: discover_subject_key(sdk: ImednetSDK, study_key: str) -> str
+
+   Return the first active subject key for ``study_key``.
+
+   :param sdk: Authenticated SDK.
+   :param study_key: Identifier of the study to query.
+   :return: Key for the first active subject.
+   :raises imednet.discovery.NoLiveDataError: When no active subjects exist.
+
+   .. code-block:: python
+
+      subject_key = discover_subject_key(sdk, study_key)
+
+
+discover_interval_name
+----------------------
+
+.. function:: discover_interval_name(sdk: ImednetSDK, study_key: str) -> str
+
+   Return the first non-disabled interval name for ``study_key``.
+
+   :param sdk: Authenticated SDK.
+   :param study_key: Identifier of the study to query.
+   :return: Name of the first active interval.
+   :raises imednet.discovery.NoLiveDataError: When no active intervals exist.
+
+   .. code-block:: python
+
+      interval_name = discover_interval_name(sdk, study_key)
+

--- a/docs/imednet.rst
+++ b/docs/imednet.rst
@@ -15,6 +15,7 @@ Subpackages
 
    imednet.auth
    imednet.core
+   imednet.discovery
    imednet.endpoints
    imednet.http
    imednet.models

--- a/docs/live_tests.rst
+++ b/docs/live_tests.rst
@@ -7,6 +7,10 @@ execute against a real iMednet environment and are skipped unless
 :doc:`configuration`). Each test verifies that the SDK behaves correctly when
 interacting with a running server.
 
+The suite can auto-discover required IDs when environment variables are unset.
+See :doc:`imednet.discovery` for details on locating study, form, site, subject,
+and interval identifiers at runtime.
+
 See :doc:`test_skip_conditions` for a summary of all variables and optional
 dependencies that control skipping.
 


### PR DESCRIPTION
## Summary
- add discovery utilities page and link from live test guide
- include discovery module in main package docs
- clarify runtime discovery usage for contributors

## Testing
- `poetry run ruff check --fix .`
- `poetry run black --check .`
- `poetry run isort --check --profile black .`
- `poetry run mypy imednet`
- `poetry run pytest -q` *(fails: CLI live tests require real environment)*
- `PYTHONWARNINGS=ignore make docs`


------
