### PR TITLE
Refactor CLI to reduce duplicate list and filter logic

### DIFF
--- a/imednet/cli/subjects/__init__.py
+++ b/imednet/cli/subjects/__init__.py
@@ -1,31 +1,16 @@
 from __future__ import annotations
 
-from typing import List, Optional
-
 import typer
 
-from ...sdk import ImednetSDK
-from ..decorators import with_sdk
-from ..utils import STUDY_KEY_ARG, display_list, echo_fetch, parse_filter_args
+from ..utils import register_list_command
 
 app = typer.Typer(name="subjects", help="Manage subjects within a study.")
 
-
-@app.command("list")
-@with_sdk
-def list_subjects(
-    sdk: ImednetSDK,
-    study_key: str = STUDY_KEY_ARG,
-    subject_filter: Optional[List[str]] = typer.Option(
-        None,
-        "--filter",
-        "-f",
-        help=("Filter criteria (e.g., 'subject_status=Screened'). " "Repeat for multiple filters."),
-    ),
-) -> None:
-    """List subjects for a specific study."""
-    parsed_filter = parse_filter_args(subject_filter)
-
-    echo_fetch("subjects", study_key)
-    subjects_list = sdk.subjects.list(study_key, **(parsed_filter or {}))
-    display_list(subjects_list, "subjects", "No subjects found matching the criteria.")
+register_list_command(
+    app,
+    attr="subjects",
+    name="subjects",
+    with_filter=True,
+    filter_help_example="subject_status=Screened",
+    empty_msg="No subjects found matching the criteria.",
+)

--- a/imednet/cli/workflows/__init__.py
+++ b/imednet/cli/workflows/__init__.py
@@ -7,7 +7,7 @@ from rich import print
 
 from ...sdk import ImednetSDK
 from ..decorators import with_sdk
-from ..utils import STUDY_KEY_ARG, parse_filter_args
+from ..utils import STUDY_KEY_ARG, FilterOption, parse_filter_args
 
 app = typer.Typer(name="workflows", help="Execute common data workflows.")
 
@@ -17,26 +17,9 @@ app = typer.Typer(name="workflows", help="Execute common data workflows.")
 def extract_records(
     sdk: ImednetSDK,
     study_key: str = STUDY_KEY_ARG,
-    record_filter: Optional[List[str]] = typer.Option(
-        None,
-        "--record-filter",
-        help=("Record filter criteria (e.g., 'form_key=DEMOG'). " "Repeat for multiple filters."),
-    ),
-    subject_filter: Optional[List[str]] = typer.Option(
-        None,
-        "--subject-filter",
-        help=(
-            "Subject filter criteria (e.g., 'subject_status=Screened'). "
-            "Repeat for multiple filters."
-        ),
-    ),
-    visit_filter: Optional[List[str]] = typer.Option(
-        None,
-        "--visit-filter",
-        help=(
-            "Visit filter criteria (e.g., 'visit_key=SCREENING'). " "Repeat for multiple filters."
-        ),
-    ),
+    record_filter: Optional[List[str]] = FilterOption("record", "form_key=DEMOG"),
+    subject_filter: Optional[List[str]] = FilterOption("subject", "subject_status=Screened"),
+    visit_filter: Optional[List[str]] = FilterOption("visit", "visit_key=SCREENING"),
 ) -> None:
     """Extract records based on criteria spanning subjects, visits, and records."""
     from .. import DataExtractionWorkflow


### PR DESCRIPTION
This pull request refactors how filter options are defined and registered for CLI commands, making the codebase more modular and reducing duplication. The main change is the introduction of a reusable `FilterOption` factory and enhancements to the `register_list_command` utility, allowing for easier and more consistent addition of filterable list commands across the CLI.

**Improvements to filter option handling:**

* Introduced a `FilterOption` factory function in `imednet/cli/utils.py` to standardize and simplify the creation of Typer filter options for CLI commands. This reduces repeated code and ensures consistent help text and option names.
* Updated the `extract_records` command in `imednet/cli/workflows/__init__.py` to use the new `FilterOption` factory for `record_filter`, `subject_filter`, and `visit_filter` arguments, replacing the previous inline `typer.Option` definitions.

**Enhancements to list command registration:**

* Refactored the `register_list_command` function in `imednet/cli/utils.py` to support an optional `with_filter` parameter. When enabled, this automatically adds a filter option to the generated list command, streamlining the process for new CLI modules. [[1]](diffhunk://#diff-8752918efadc56dbb0df2a04ebc6ce3bbad2d9e276c8fb65282fb2045698bf35R112-R136) [[2]](diffhunk://#diff-8752918efadc56dbb0df2a04ebc6ce3bbad2d9e276c8fb65282fb2045698bf35R147-R162)
* Updated the `subjects` CLI module to use the new `register_list_command` with filtering enabled, removing the previous hand-written `list_subjects` command and associated boilerplate.

**General code cleanup:**

* Adjusted imports in affected modules to use the new utilities and removed now-unnecessary code. [[1]](diffhunk://#diff-c51e36326d258bf471c02858d2a6e0a2e484766f9d5b3bded471655f99db898aL10-R10) [[2]](diffhunk://#diff-7db0add6beb1acf1df89595cd43deb2d8ec56313a1b906db56ca36941655662bL3-R16)