### PR TITLE
docs: Fix gaps in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,8 +103,7 @@ The official iMednet API documentation is at <https://portal.prod.imednetapi.com
 
 ## Postman Collection
 
-The repository includes a ready-to-import Postman collection generated from
-[`openapi.yaml`](openapi.yaml). Download
+The repository includes a ready-to-import Postman collection. Download
 [`imednet.postman_collection.json`](imednet.postman_collection.json) and import it
 into Postman to explore and test the API endpoints. The collection uses the
 `{{baseUrl}}` variable for the API host; set this alongside your `x-api-key` and

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -107,7 +107,13 @@ autosummary_generate = True
 # Mock heavy optional dependencies so autodoc does not import them
 autodoc_mock_imports = ["pandas", "numpy", "matplotlib", "pydantic", "airflow"]
 
-suppress_warnings = ["ref.ref", "toc.excluded", "autodoc.import", "autodoc", "sphinx_autodoc_typehints"]
+suppress_warnings = [
+    "ref.ref",
+    "toc.excluded",
+    "autodoc.import",
+    "autodoc",
+    "sphinx_autodoc_typehints",
+]
 
 # Ignore noisy pydantic schema generation warnings.
 warnings.filterwarnings("ignore", message="Failed guarded type import", category=UserWarning)

--- a/docs/imednet.rst
+++ b/docs/imednet.rst
@@ -34,3 +34,18 @@ imednet.sdk module
    :undoc-members:
    :show-inheritance:
 
+imednet.async_sdk module
+------------------------
+
+.. automodule:: imednet.async_sdk
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+imednet.discovery module
+------------------------
+
+.. automodule:: imednet.discovery
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/tests/unit/test_airflow_operators.py
+++ b/tests/unit/test_airflow_operators.py
@@ -1,4 +1,3 @@
-import importlib
 import sys
 from types import ModuleType, SimpleNamespace
 from unittest.mock import MagicMock
@@ -144,6 +143,7 @@ def test_job_sensor(monkeypatch):
     _setup_airflow(monkeypatch)
     import imednet.integrations.airflow.operators as ops
     import imednet.integrations.airflow.sensors as sensors
+
     _patch_basehook(monkeypatch)
     sdk = MagicMock()
     job = MagicMock(state="COMPLETED")


### PR DESCRIPTION
This pull request introduces documentation improvements and minor code cleanups. The main focus is on expanding the Sphinx documentation to include new modules, clarifying the README, and making small formatting and import adjustments.

**Documentation enhancements:**

* Added documentation sections for the `imednet.async_sdk` and `imednet.discovery` modules in `docs/imednet.rst`, making their APIs visible in the generated docs.
* Improved the formatting of the `suppress_warnings` list in `docs/conf.py` for readability.

**General documentation clarity:**

* Updated the `README.md` to remove the outdated reference to `openapi.yaml` in the Postman collection instructions, making the setup steps clearer.

**Code cleanup:**

* Removed an unused `importlib` import from `tests/unit/test_airflow_operators.py`.
* Minor whitespace adjustment in the `test_job_sensor` function in `tests/unit/test_airflow_operators.py`.