### PR TITLE
Fix mypy error in cli by passing positional arguments

### DIFF
--- a/imednet/cli/subjects/__init__.py
+++ b/imednet/cli/subjects/__init__.py
@@ -8,8 +8,8 @@ app = typer.Typer(name="subjects", help="Manage subjects within a study.")
 
 register_list_command(
     app,
-    attr="subjects",
-    name="subjects",
+    "subjects",
+    "subjects",
     with_filter=True,
     filter_help_example="subject_status=Screened",
     empty_msg="No subjects found matching the criteria.",


### PR DESCRIPTION
This pull request contains a minor change to the way the `register_list_command` function is called in `imednet/cli/subjects/__init__.py`. The change simplifies the argument passing by removing explicit keyword arguments for `attr` and `name`, replacing them with positional arguments.