### PR TITLE
Fix F821: Undefined name 'importlib' in test_airflow_operators.py

### DIFF
--- a/tests/unit/test_airflow_operators.py
+++ b/tests/unit/test_airflow_operators.py
@@ -1,3 +1,4 @@
+import importlib
 import sys
 from types import ModuleType, SimpleNamespace
 from unittest.mock import MagicMock


### PR DESCRIPTION
This pull request makes a minor update to the `tests/unit/test_airflow_operators.py` file by adding an import for the `importlib` module. This change likely prepares the test suite for dynamic module loading or reloading in future tests.