### PR TITLE
Fix linting and type checking errors

### DIFF
--- a/imednet/testing/data_dictionary.py
+++ b/imednet/testing/data_dictionary.py
@@ -23,6 +23,10 @@ def _load_dd_from_options(
     if zip_file:
         return DataDictionaryLoader.from_zip(zip_file)
     if all([business_logic_file, choices_file, forms_file, questions_file]):
+        assert business_logic_file is not None
+        assert choices_file is not None
+        assert forms_file is not None
+        assert questions_file is not None
         return DataDictionaryLoader.from_files(
             business_logic=business_logic_file,
             choices=choices_file,

--- a/imednet/testing/record_generator.py
+++ b/imednet/testing/record_generator.py
@@ -33,9 +33,7 @@ class RecordGenerator:
         self.sdk = sdk
         self.data_dictionary = data_dictionary
         self.faker = Faker()
-        self.forms: Dict[str, dict] = {
-            form["Form Key"]: form for form in data_dictionary.forms
-        }
+        self.forms: Dict[str, dict] = {form["Form Key"]: form for form in data_dictionary.forms}
         self.questions: Dict[str, List[Dict[str, str]]] = {}
         for question in data_dictionary.questions:
             self.questions.setdefault(question["Form"], []).append(question)

--- a/imednet/workflows/clinical_guidance.py
+++ b/imednet/workflows/clinical_guidance.py
@@ -30,7 +30,9 @@ class ClinicalGuidanceWorkflow:
             A dictionary where keys are role names and values are their descriptions.
         """
         return {
-            "Principal Investigator/Investigator": "Data entry and approval from the study site’s side",
+            "Principal Investigator/Investigator": (
+                "Data entry and approval from the study site’s side"
+            ),
             "Data Coordinator/Site Coordinator": "Data entry from the study site’s side",
             "Monitor/CRA": "Data clarification and verification",
             "Project Manager": "Data overview and formation of requests on supplies of IP",
@@ -53,13 +55,34 @@ class ClinicalGuidanceWorkflow:
             A list of strings, each describing a requirement.
         """
         return [
-            "The PI is responsible for providing adequate training and supervision to all delegates.",
-            "Delegation of study-related tasks must be appropriate to the individual's education, training, and experience.",
-            "A list of appropriately qualified persons with delegated trial-related duties must be maintained.",
-            "Tasks of a clinical or medical nature must be delegated to staff with appropriate education, experience, and licensing.",
-            "The Delegation of Authority log should be completed at study initiation and kept up-to-date.",
-            "Corrections to the delegation of authority record must follow 'good clinical practice' procedures.",
-            "The delegation of authority record may be maintained electronically in a 21 CFR Part 11 compliant system.",
+            (
+                "The PI is responsible for providing adequate training and supervision to "
+                "all delegates."
+            ),
+            (
+                "Delegation of study-related tasks must be appropriate to the "
+                "individual's education, training, and experience."
+            ),
+            (
+                "A list of appropriately qualified persons with delegated trial-related duties "
+                "must be maintained."
+            ),
+            (
+                "Tasks of a clinical or medical nature must be delegated to staff with "
+                "appropriate education, experience, and licensing."
+            ),
+            (
+                "The Delegation of Authority log should be completed at study initiation and "
+                "kept up-to-date."
+            ),
+            (
+                "Corrections to the delegation of authority record must follow "
+                "'good clinical practice' procedures."
+            ),
+            (
+                "The delegation of authority record may be maintained electronically in a "
+                "21 CFR Part 11 compliant system."
+            ),
         ]
 
     @staticmethod
@@ -76,7 +99,10 @@ class ClinicalGuidanceWorkflow:
             "Identification and specification of authorized source data originators.",
             "Creation of data element identifiers to facilitate examination of the audit trail.",
             "Define methods for capturing source data into the eCRF (manual or electronic).",
-            "Clarify clinical investigator responsibilities for reviewing and retaining electronic data.",
+            (
+                "Clarify clinical investigator responsibilities for reviewing and retaining "
+                "electronic data."
+            ),
             "Ensure proper use and description of computerized systems in clinical investigations.",
         ]
 

--- a/tests/unit/test_clinical_guidance.py
+++ b/tests/unit/test_clinical_guidance.py
@@ -1,7 +1,7 @@
 import unittest
 from unittest.mock import MagicMock
 
-from imednet.models.users import User, Role
+from imednet.models.users import Role, User
 from imednet.workflows.clinical_guidance import ClinicalGuidanceWorkflow
 
 

--- a/tests/unit/testing/test_record_generator.py
+++ b/tests/unit/testing/test_record_generator.py
@@ -3,10 +3,10 @@ from __future__ import annotations
 from unittest.mock import MagicMock, patch
 
 import pytest
-from tests.unit.test_data_dictionary import FIXTURES
 
 from imednet.testing.record_generator import RecordGenerator
 from imednet.validation import DataDictionary, DataDictionaryLoader
+from tests.unit.test_data_dictionary import FIXTURES
 
 
 @pytest.fixture


### PR DESCRIPTION
Ran the full linting and static analysis suite and fixed the issues reported by `ruff` and `mypy`.

- Fixed several "line too long" errors in `imednet/workflows/clinical_guidance.py`.
- Added asserts to `imednet/testing/data_dictionary.py` to fix `mypy` errors.
- Ran `black` and `isort` to fix formatting and import order.

---
name: Pull Request
about: Describe the changes you are making
title: 'feat: '
labels: ''
assignees: ''
---

**Description**
A clear and concise description of the change.

**Related Issue**
Closes # (issue number)

**Type of Change**

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update

**How Has This Been Tested?**
Describe the tests that you ran to verify your changes. If tests were skipped,
note the reason (see `docs/test_skip_conditions.md`).

**Checklist:**

- [ ] I ran `poetry run ruff check --fix .` and `poetry run black --check .`
- [ ] I ran `poetry run mypy imednet`
- [ ] I ran `poetry run pytest -q --cov=imednet --cov-report=xml` and all tests pass
- [ ] My commits follow [Conventional Commits](https://www.conventionalcommits.org/)
- [ ] New modules align with the architecture in `docs/architecture.rst`
- [ ] My code follows the style guidelines (PEP 8, `black`, `ruff`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added or updated documentation as needed
- [ ] Skipped tests match the cases documented in `docs/test_skip_conditions.md`
