### PR TITLE
Fix(utils): Make sanitize_base_url case-insensitive

### DIFF
--- a/imednet/utils/url.py
+++ b/imednet/utils/url.py
@@ -8,4 +8,4 @@ __all__ = ["sanitize_base_url"]
 def sanitize_base_url(url: str) -> str:
     """Return base URL without trailing slashes or ``/api`` suffix."""
     url = url.rstrip("/")
-    return re.sub(r"/api\Z", "", url)
+    return re.sub(r"/api\Z", "", url, flags=re.IGNORECASE)


### PR DESCRIPTION
The `sanitize_base_url` function was using a case-sensitive regex to remove the `/api` suffix from URLs. This meant that URLs with a capitalized `/API` suffix were not being sanitized correctly.

This commit fixes the issue by adding the `re.IGNORECASE` flag to the `re.sub` call, making the suffix removal case-insensitive.