### PR TITLE
fix(export): Use form-specific variables in `export_to_sql_by_form`

### DIFF
--- a/imednet/integrations/export.py
+++ b/imednet/integrations/export.py
@@ -272,7 +272,7 @@ def export_to_sql_by_form(
             study_key,
             extra_filters={
                 "formId": form.form_id,
-                **({"variableNames": variable_whitelist} if variable_whitelist else {}),
+                **({"variableNames": variable_keys} if variable_whitelist else {}),
             },
         )
         rows, _ = mapper._parse_records(records, record_model)

--- a/tests/unit/test_utils_dates_and_filters.py
+++ b/tests/unit/test_utils_dates_and_filters.py
@@ -40,6 +40,11 @@ def test_parse_iso_datetime_invalid() -> None:
         parse_iso_datetime("not-a-date")
 
 
+def test_parse_iso_datetime_nanos() -> None:
+    dt = parse_iso_datetime("2024-01-01T12:30:00.1234567Z")
+    assert dt.microsecond == 123456
+
+
 def test_parse_iso_datetime_none() -> None:
     with pytest.raises(AttributeError):
         parse_iso_datetime(None)  # type: ignore[arg-type]


### PR DESCRIPTION
The `export_to_sql_by_form` function was using the global `variable_whitelist` when fetching records for each form. This was incorrect as it should only filter for variables that are part of the current form being processed.

This change corrects the logic to use the form-specific `variable_keys` list, which is already computed within the function, for the `variableNames` filter in the API call. This ensures that the record fetching is more efficient and correct.

---
name: Pull Request
about: Describe the changes you are making
title: 'feat: '
labels: ''
assignees: ''
---

**Description**
A clear and concise description of the change.

**Related Issue**
Closes # (issue number)

**Type of Change**

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update

**How Has This Been Tested?**
Describe the tests that you ran to verify your changes. If tests were skipped,
note the reason (see `docs/test_skip_conditions.md`).

**Checklist:**

- [ ] I ran `poetry run ruff check --fix .` and `poetry run black --check .`
- [ ] I ran `poetry run mypy imednet`
- [ ] I ran `poetry run pytest -q --cov=imednet --cov-report=xml` and all tests pass
- [ ] My commits follow [Conventional Commits](https://www.conventionalcommits.org/)
- [ ] New modules align with the architecture in `docs/architecture.rst`
- [ ] My code follows the style guidelines (PEP 8, `black`, `ruff`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added or updated documentation as needed
- [ ] Skipped tests match the cases documented in `docs/test_skip_conditions.md`
