### PR TITLE
Fix: Raise TypeError in parse_bool for unhandled types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- `imednet.utils.validators.parse_bool` now raises a `TypeError` for unhandled
+  input types instead of silently returning `False`.
+
 - Renamed `load_config` to `load_config_from_env` for clarity.
 - Refactored `ImednetSDK` to use a `ClientFactory` for client creation.
 - Moved `Workflows` class to `imednet/workflows/__init__.py`.

--- a/imednet/api/endpoints/_mixins.py
+++ b/imednet/api/endpoints/_mixins.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import inspect
-import sys
 from typing import TYPE_CHECKING, Any, Dict, Iterable, Optional, Protocol, Type
 
 from pydantic import BaseModel

--- a/imednet/api/endpoints/codings.py
+++ b/imednet/api/endpoints/codings.py
@@ -1,6 +1,5 @@
 """Endpoint for managing codings (medical coding) in a study."""
 
-from ..core.paginator import AsyncPaginator, Paginator
 from ..models.codings import Coding
 from ._mixins import ListGetEndpoint
 from .registry import register_endpoint

--- a/imednet/api/endpoints/users.py
+++ b/imednet/api/endpoints/users.py
@@ -5,7 +5,6 @@ from typing import Any, Optional
 from ..core.paginator import AsyncPaginator, Paginator  # noqa: F401
 from ..models.users import User
 from ._mixins import ListGetEndpoint
-
 from .registry import register_endpoint
 
 

--- a/imednet/testing/fake_data.py
+++ b/imednet/testing/fake_data.py
@@ -6,9 +6,10 @@ from typing import Any, Dict, List, Optional
 
 from faker import Faker
 
+from imednet.validation.cache import SchemaCache
+
 from ..api.models.forms import Form
 from ..api.models.variables import Variable
-from imednet.validation.cache import SchemaCache
 
 faker = Faker()
 

--- a/imednet/utils/validators.py
+++ b/imednet/utils/validators.py
@@ -64,7 +64,7 @@ def parse_bool(v: Any) -> bool:
         return bool(v)
     if isinstance(v, str):
         raise ValueError(f"Could not parse boolean from string: {v}")
-    return False
+    raise TypeError(f"Could not parse boolean from type: {type(v).__name__}")
 
 
 def parse_int_or_default(v: Any, default: int = 0, strict: bool = False) -> int:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,4 @@
-from unittest.mock import MagicMock
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 import pytest_asyncio
@@ -28,14 +28,10 @@ def dummy_client(response_factory):
     return client
 
 
-from unittest.mock import AsyncMock
-
 @pytest.fixture
 def async_dummy_client(response_factory):
     client = AsyncMock(spec=AsyncClient)
-    client.get.return_value = response_factory(
-        {"data": [], "pagination": {"totalPages": 1}}
-    )
+    client.get.return_value = response_factory({"data": [], "pagination": {"totalPages": 1}})
     return client
 
 

--- a/tests/unit/cli/test_cli.py
+++ b/tests/unit/cli/test_cli.py
@@ -9,8 +9,8 @@ from typer.testing import CliRunner
 
 import imednet.cli as cli
 from imednet.api.core.exceptions import ApiError
-from imednet.integrations import export as export_mod
 from imednet.api.models.error import ApiErrorDetail
+from imednet.integrations import export as export_mod
 
 
 @pytest.fixture(autouse=True)

--- a/tests/unit/endpoints/test_endpoints_async.py
+++ b/tests/unit/endpoints/test_endpoints_async.py
@@ -175,7 +175,9 @@ async def test_async_get_record(monkeypatch, async_dummy_client, context, respon
 
 
 @pytest.mark.asyncio
-async def test_async_get_record_not_found(monkeypatch, async_dummy_client, context, response_factory):
+async def test_async_get_record_not_found(
+    monkeypatch, async_dummy_client, context, response_factory
+):
     ep = records.RecordsEndpoint(async_dummy_client, context, async_client=async_dummy_client)
 
     async def fake_impl(self, client, paginator, *, study_key=None, refresh=False, **filters):

--- a/tests/unit/test_typed_values.py
+++ b/tests/unit/test_typed_values.py
@@ -1,3 +1,5 @@
+import pytest
+
 from imednet.testing import typed_values
 
 
@@ -9,9 +11,6 @@ def test_value_for_each_type() -> None:
     assert typed_values.value_for("dropdown") == "1"
     assert typed_values.value_for("memo") == "example memo"
     assert typed_values.value_for("checkbox") is True
-
-
-import pytest
 
 
 def test_canonical_type_synonyms() -> None:

--- a/tests/unit/utils/test_validators.py
+++ b/tests/unit/utils/test_validators.py
@@ -1,4 +1,5 @@
 import datetime
+
 import pytest
 
 from imednet.utils.validators import (
@@ -32,9 +33,6 @@ from imednet.utils.validators import (
         (0, False),
         (1.0, True),
         (0.0, False),
-        ([], False),
-        ({}, False),
-        (None, False),
     ],
 )
 def test_parse_bool(value, expected):
@@ -48,6 +46,16 @@ def test_parse_bool_invalid_string_raises_error():
         parse_bool("not-a-boolean")
     with pytest.raises(ValueError):
         parse_bool("maybe")
+
+
+def test_parse_bool_invalid_type_raises_error():
+    """Test that parse_bool raises a TypeError for invalid types."""
+    with pytest.raises(TypeError):
+        parse_bool([])
+    with pytest.raises(TypeError):
+        parse_bool({})
+    with pytest.raises(TypeError):
+        parse_bool(None)
 
 
 def test_parse_int_or_default():


### PR DESCRIPTION
The `parse_bool` function in `imednet/utils/validators.py` would previously return `False` for any unhandled input types (e.g., `None`, lists, or dicts). This could mask potential data issues by silently coercing invalid input to a boolean.

This commit changes the behavior to raise a `TypeError` when an unhandled type is passed to `parse_bool`. This makes the function's behavior more explicit and consistent with its handling of unparseable strings, where it raises a `ValueError`.

A new test case has been added to verify that a `TypeError` is raised for unhandled types, and the existing tests have been updated to reflect this new behavior.