### PR TITLE
Fix(validation): Use float validator for 'number' type

### DIFF
--- a/imednet/validation/cache.py
+++ b/imednet/validation/cache.py
@@ -147,7 +147,7 @@ def _validate_text(value: Any) -> None:
 _TYPE_VALIDATORS: Dict[str, Callable[[Any], None]] = {
     "int": _validate_int,
     "integer": _validate_int,
-    "number": _validate_int,
+    "number": _validate_float,
     "float": _validate_float,
     "decimal": _validate_float,
     "bool": _validate_bool,

--- a/tests/unit/test_utils_schema.py
+++ b/tests/unit/test_utils_schema.py
@@ -89,3 +89,8 @@ def test_schema_validator_batch_calls_validate_record() -> None:
     assert validator.validate_record.call_count == 2
     validator.validate_record.assert_any_call("ST", {"a": 1})
     validator.validate_record.assert_any_call("ST", {"b": 2})
+
+
+def test_check_type_number_allows_float() -> None:
+    var = _make_var("measurement", "number")
+    _check_type(var.variable_type, 1.5)


### PR DESCRIPTION
The schema validator incorrectly used an integer-only validator for the 'number' type, causing floating-point values to be rejected.

This change maps the 'number' type to the float validator, which correctly handles both integers and floats. A new unit test is added to verify that float values are now accepted for variables of this type.