### PR TITLE
fix(validators): Handle float strings in parse_bool

### DIFF
--- a/imednet/utils/validators.py
+++ b/imednet/utils/validators.py
@@ -60,6 +60,10 @@ def parse_bool(v: Any) -> bool:
             return True
         if val in ("false", "0", "no", "n", "f"):
             return False
+        try:
+            return bool(float(val))
+        except ValueError:
+            pass  # Fall through to the final error
     if isinstance(v, (int, float)):
         return bool(v)
     if isinstance(v, str):

--- a/tests/unit/utils/test_validators.py
+++ b/tests/unit/utils/test_validators.py
@@ -33,6 +33,8 @@ from imednet.utils.validators import (
         (0, False),
         (1.0, True),
         (0.0, False),
+        ("1.0", True),
+        ("0.0", False),
     ],
 )
 def test_parse_bool(value, expected):


### PR DESCRIPTION
The `parse_bool` function did not correctly parse string representations of floating-point numbers (e.g., "1.0", "0.0"). While it handled floats directly, it would raise a ValueError for their string equivalents.

This commit adds logic to attempt to parse the string as a float if it's not one of the recognized boolean string values. This makes the function more robust and handles a wider range of string inputs consistently with how it handles numeric types.