### PR TITLE
🖋️ Scribe: Fix broken mypy command path in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,7 +215,7 @@ the specified table name. See ``docs/cli.rst`` for full examples.
 poetry run ruff check --fix .
 poetry run black --check .
 poetry run isort --check --profile black .
-poetry run mypy imednet
+poetry run mypy src/imednet
 poetry run pytest -q
 ```
 


### PR DESCRIPTION
💡 **What:** Updated the `mypy` command in the `README.md` from `poetry run mypy imednet` to `poetry run mypy src/imednet`.
🎯 **Why:** The previous command failed with `mypy: can't read file 'imednet': No such file or directory` because the codebase is structured with a `src/` layout.
🧠 **Cognitive Impact:** Fixes a broken installation/setup path, preventing immediate errors for new developers trying to run static analysis checks.
📖 **Preview:** 
```markdown
poetry run isort --check --profile black .
poetry run mypy src/imednet
poetry run pytest -q
```

---
*PR created automatically by Jules for task [16969738905993981243](https://jules.google.com/task/16969738905993981243) started by @fderuiter*