### PR TITLE
🖋️ Scribe: fix broken mypy command in contributing docs

### DIFF
--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -20,7 +20,7 @@ Run these commands and ensure **≥90%** test coverage before opening a pull req
    poetry run ruff check --fix .
    poetry run black --check .
    poetry run isort --check --profile black .
-   poetry run mypy imednet
+   poetry run mypy src/imednet
    poetry run pytest -q
 
 Conventions


### PR DESCRIPTION
💡 **What:** Updated the `mypy` command in the `docs/contributing.rst` file to correctly point to `src/imednet`. Also added an entry to Scribe's journal about documenting CLI commands correctly using the `src/` layout.

🎯 **Why:** The codebase uses a `src/` layout, but the contributing guide instructed users to run `poetry run mypy imednet`, which throws a `No such file or directory` error for new contributors following the validation steps.

🧠 **Cognitive Impact:** Fixes a broken onboarding path. Contributors can now copy-paste the validation commands and successfully run static analysis without encountering immediate pathing errors.

📖 **Preview:**
```rst
   poetry run ruff check --fix .
   poetry run black --check .
   poetry run isort --check --profile black .
   poetry run mypy src/imednet
   poetry run pytest -q
```

---
*PR created automatically by Jules for task [1182728389692049655](https://jules.google.com/task/1182728389692049655) started by @fderuiter*