### PR TITLE
🛡️ Shield: Add sad path unit tests for RecordUpdateWorkflow

### DIFF
--- a/tests/unit/test_workflows_record_update.py
+++ b/tests/unit/test_workflows_record_update.py
@@ -242,3 +242,41 @@ def test_update_scheduled_record_invalid_interval_identifier_type() -> None:
             data={"x": 1},
             interval_identifier_type="invalid_type",  # type: ignore
         )
+
+
+def test_create_or_update_records_wait_for_completion_no_batch_id() -> None:
+    sdk = MagicMock()
+    sdk._async_client = None
+
+    # Return a job with no batch_id
+    job = Job(batch_id="", state="PROCESSING")
+    sdk.records.create.return_value = job
+
+    # Provide variable so form validation passes
+    var = Variable(variable_name="a", variable_type="integer", form_id=1, form_key="F1")
+    sdk.variables.list.return_value = [var]
+
+    wf = RecordUpdateWorkflow(sdk)
+
+    with pytest.raises(ValueError, match="Submission successful but no batch_id received."):
+        wf.create_or_update_records(
+            "STUDY",
+            [{"formKey": "F1", "data": {"a": 1}}],
+            wait_for_completion=True,
+        )
+
+
+def test_create_or_update_records_form_key_not_found() -> None:
+    sdk = MagicMock()
+    sdk._async_client = None
+
+    # Return empty list for variables so the form key is not found even after refresh
+    sdk.variables.list.return_value = []
+
+    wf = RecordUpdateWorkflow(sdk)
+
+    with pytest.raises(ValueError, match="Form key 'UNKNOWN_FORM' not found"):
+        wf.create_or_update_records(
+            "STUDY",
+            [{"formKey": "UNKNOWN_FORM", "data": {"a": 1}}],
+        )


### PR DESCRIPTION
🛑 **Vulnerability:** The "Happy Path" was completely covered for the `RecordUpdateWorkflow.create_or_update_records` method, but error conditions (`ValueError`) involving missing `batch_id` attributes and unknown form keys being submitted to the validator lacked test coverage. This creates a risk of silent failures or poorly-handled state when the API or schema behaves unexpectedly.

🛡️ **Defense:** Added specific "Sad Path" unit tests (`test_create_or_update_records_wait_for_completion_no_batch_id` and `test_create_or_update_records_form_key_not_found`) to ensure that `ValueError` exceptions are properly raised with the expected error messages.

🔬 **Verification:** Run `poetry run pytest --cov=src/imednet/workflows/record_update tests/unit/test_workflows_record_update.py` to observe that these cases succeed reliably and without side effects.

📊 **Impact:** Increases file coverage for `src/imednet/workflows/record_update.py` and provides confidence that API submission boundaries behave safely. Journaled this learning in `.jules/shield.md`.

---
*PR created automatically by Jules for task [15146866063461825007](https://jules.google.com/task/15146866063461825007) started by @fderuiter*