### PR TITLE
🖋️ Scribe: Fix execution commands and bash syntax in examples

### DIFF
--- a/docs/examples/async_quick_start.rst
+++ b/docs/examples/async_quick_start.rst
@@ -14,9 +14,9 @@ Environment variables
 
    export IMEDNET_API_KEY
    export IMEDNET_SECURITY_KEY
-   export IMEDNET_BASE_URL (optional)
-   export IMEDNET_JOB_STUDY_KEY (optional)
-   export IMEDNET_BATCH_ID (optional)
+   # export IMEDNET_BASE_URL
+   # export IMEDNET_JOB_STUDY_KEY
+   # export IMEDNET_BATCH_ID
 
 Description
 -----------

--- a/docs/examples/export_long_sql.rst
+++ b/docs/examples/export_long_sql.rst
@@ -14,7 +14,7 @@ Environment variables
 
    export IMEDNET_API_KEY
    export IMEDNET_SECURITY_KEY
-   export IMEDNET_BASE_URL (optional)
+   # export IMEDNET_BASE_URL
 
 Description
 -----------

--- a/docs/examples/get_codings.rst
+++ b/docs/examples/get_codings.rst
@@ -15,7 +15,7 @@ Environment variables
    export IMEDNET_API_KEY
    export IMEDNET_SECURITY_KEY
    export IMEDNET_STUDY_KEY
-   export IMEDNET_BASE_URL (optional)
+   # export IMEDNET_BASE_URL
 
 Description
 -----------

--- a/docs/examples/get_record_revisions.rst
+++ b/docs/examples/get_record_revisions.rst
@@ -15,7 +15,7 @@ Environment variables
    export IMEDNET_API_KEY
    export IMEDNET_SECURITY_KEY
    export IMEDNET_STUDY_KEY
-   export IMEDNET_BASE_URL (optional)
+   # export IMEDNET_BASE_URL
 
 Description
 -----------

--- a/docs/examples/get_records.rst
+++ b/docs/examples/get_records.rst
@@ -15,7 +15,7 @@ Environment variables
    export IMEDNET_API_KEY
    export IMEDNET_SECURITY_KEY
    export IMEDNET_STUDY_KEY
-   export IMEDNET_BASE_URL (optional)
+   # export IMEDNET_BASE_URL
 
 Description
 -----------

--- a/docs/examples/get_records_async.rst
+++ b/docs/examples/get_records_async.rst
@@ -14,7 +14,7 @@ Environment variables
 
    export IMEDNET_API_KEY
    export IMEDNET_SECURITY_KEY
-   export IMEDNET_BASE_URL (optional)
+   # export IMEDNET_BASE_URL
 
 Description
 -----------

--- a/docs/examples/get_sites.rst
+++ b/docs/examples/get_sites.rst
@@ -15,7 +15,7 @@ Environment variables
    export IMEDNET_API_KEY
    export IMEDNET_SECURITY_KEY
    export IMEDNET_STUDY_KEY
-   export IMEDNET_BASE_URL (optional)
+   # export IMEDNET_BASE_URL
 
 Description
 -----------

--- a/docs/examples/get_studies.rst
+++ b/docs/examples/get_studies.rst
@@ -14,7 +14,7 @@ Environment variables
 
    export IMEDNET_API_KEY
    export IMEDNET_SECURITY_KEY
-   export IMEDNET_BASE_URL (optional)
+   # export IMEDNET_BASE_URL
 
 Description
 -----------

--- a/docs/examples/get_study_structure.rst
+++ b/docs/examples/get_study_structure.rst
@@ -15,7 +15,7 @@ Environment variables
    export IMEDNET_API_KEY
    export IMEDNET_SECURITY_KEY
    export IMEDNET_STUDY_KEY
-   export IMEDNET_BASE_URL (optional)
+   # export IMEDNET_BASE_URL
 
 Description
 -----------

--- a/docs/examples/get_subjects.rst
+++ b/docs/examples/get_subjects.rst
@@ -15,7 +15,7 @@ Environment variables
    export IMEDNET_API_KEY
    export IMEDNET_SECURITY_KEY
    export IMEDNET_STUDY_KEY
-   export IMEDNET_BASE_URL (optional)
+   # export IMEDNET_BASE_URL
 
 Description
 -----------

--- a/docs/examples/get_users.rst
+++ b/docs/examples/get_users.rst
@@ -15,7 +15,7 @@ Environment variables
    export IMEDNET_API_KEY
    export IMEDNET_SECURITY_KEY
    export IMEDNET_STUDY_KEY
-   export IMEDNET_BASE_URL (optional)
+   # export IMEDNET_BASE_URL
 
 Description
 -----------

--- a/docs/examples/get_variables.rst
+++ b/docs/examples/get_variables.rst
@@ -15,7 +15,7 @@ Environment variables
    export IMEDNET_API_KEY
    export IMEDNET_SECURITY_KEY
    export IMEDNET_STUDY_KEY
-   export IMEDNET_BASE_URL (optional)
+   # export IMEDNET_BASE_URL
 
 Description
 -----------

--- a/docs/examples/get_visits.rst
+++ b/docs/examples/get_visits.rst
@@ -15,7 +15,7 @@ Environment variables
    export IMEDNET_API_KEY
    export IMEDNET_SECURITY_KEY
    export IMEDNET_STUDY_KEY
-   export IMEDNET_BASE_URL (optional)
+   # export IMEDNET_BASE_URL
 
 Description
 -----------

--- a/docs/examples/post_register_subjects.rst
+++ b/docs/examples/post_register_subjects.rst
@@ -15,7 +15,7 @@ Environment variables
    export IMEDNET_API_KEY
    export IMEDNET_SECURITY_KEY
    export IMEDNET_STUDY_KEY
-   export IMEDNET_BASE_URL (optional)
+   # export IMEDNET_BASE_URL
 
 Description
 -----------

--- a/docs/examples/quick_start.rst
+++ b/docs/examples/quick_start.rst
@@ -14,7 +14,7 @@ Environment variables
 
    export IMEDNET_API_KEY
    export IMEDNET_SECURITY_KEY
-   export IMEDNET_BASE_URL (optional)
+   # export IMEDNET_BASE_URL
 
 Description
 -----------

--- a/docs/form_builder.rst
+++ b/docs/form_builder.rst
@@ -45,7 +45,7 @@ For CI/CD or automated workflows, use the example script:
 
 .. code-block:: console
 
-    python examples/build_form_payload.py --preset "Demo Form" \
+    poetry run python examples/build_form_payload.py --preset "Demo Form" \
         --base-url "https://your.imednet.com" \
         --phpsessid "YOUR_SESSION_ID" \
         --csrf "YOUR_CSRF_KEY" \

--- a/docs/imednet.cli.intervals.rst
+++ b/docs/imednet.cli.intervals.rst
@@ -1,0 +1,10 @@
+imednet.cli.intervals package
+=============================
+
+Module contents
+---------------
+
+.. automodule:: imednet.cli.intervals
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/retry_policy.rst
+++ b/docs/retry_policy.rst
@@ -67,4 +67,4 @@ transport:
 
    export IMEDNET_API_KEY=dummy
    export IMEDNET_SECURITY_KEY=dummy
-   python examples/custom_retry.py
+   poetry run python examples/custom_retry.py

--- a/examples/async_quick_start.py
+++ b/examples/async_quick_start.py
@@ -17,7 +17,7 @@ Example::
 
     export IMEDNET_API_KEY="your_api_key"
     export IMEDNET_SECURITY_KEY="your_security_key"
-    python examples/async_quick_start.py
+    poetry run python examples/async_quick_start.py
 """
 
 

--- a/examples/basic/get_studies.py
+++ b/examples/basic/get_studies.py
@@ -17,7 +17,7 @@ Prerequisites:
 
 Usage:
 1. Ensure your environment variables are set correctly (e.g. `export IMEDNET_API_KEY="..."`).
-2. Run the script: `python examples/basic/get_studies.py`
+2. Run the script: `poetry run python examples/basic/get_studies.py`
 """
 
 

--- a/examples/build_form_payload.py
+++ b/examples/build_form_payload.py
@@ -4,7 +4,8 @@ Hybrid Entry Point for iMedNet Form Builder.
 
 Usage:
   # Headless Mode (CLI)
-  poetry run python examples/build_form_payload.py --preset "Demo Form" --form-id 123 --revision 5 ...
+  poetry run python examples/build_form_payload.py \
+      --preset "Demo Form" --form-id 123 --revision 5
 """
 
 import argparse

--- a/examples/build_form_payload.py
+++ b/examples/build_form_payload.py
@@ -4,7 +4,7 @@ Hybrid Entry Point for iMedNet Form Builder.
 
 Usage:
   # Headless Mode (CLI)
-  python examples/build_form_payload.py --preset "Demo Form" --form-id 123 --revision 5 ...
+  poetry run python examples/build_form_payload.py --preset "Demo Form" --form-id 123 --revision 5 ...
 """
 
 import argparse

--- a/examples/custom_retry.py
+++ b/examples/custom_retry.py
@@ -21,7 +21,7 @@ Example:
 
     export IMEDNET_API_KEY="dummy"
     export IMEDNET_SECURITY_KEY="dummy"
-    python examples/custom_retry.py
+    poetry run python examples/custom_retry.py
 """
 
 

--- a/examples/export_long_sql.py
+++ b/examples/export_long_sql.py
@@ -12,7 +12,7 @@ Set ``IMEDNET_API_KEY`` and ``IMEDNET_SECURITY_KEY`` before running this script.
 Optionally set ``IMEDNET_BASE_URL`` for non-default instances.
 
 Usage:
-    python examples/export_long_sql.py STUDY_KEY TABLE_NAME OUTPUT_DB
+    poetry run python examples/export_long_sql.py STUDY_KEY TABLE_NAME OUTPUT_DB
 
 The ``OUTPUT_DB`` path is used to build the SQLite connection string.
 """
@@ -23,7 +23,7 @@ def main() -> None:
 
     if len(sys.argv) != 4:
         print(
-            "Usage: python examples/export_long_sql.py STUDY_KEY TABLE_NAME OUTPUT_DB",
+            "Usage: poetry run python examples/export_long_sql.py STUDY_KEY TABLE_NAME OUTPUT_DB",
             file=sys.stderr,
         )
         sys.exit(1)

--- a/examples/quick_start.py
+++ b/examples/quick_start.py
@@ -14,7 +14,7 @@ Example:
 
     export IMEDNET_API_KEY="your_api_key"
     export IMEDNET_SECURITY_KEY="your_security_key"
-    python examples/quick_start.py
+    poetry run python examples/quick_start.py
 """
 
 


### PR DESCRIPTION
💡 **What:** 
- Updated bash commands in docstrings (e.g., `examples/quick_start.py`) and `.rst` files to use `poetry run python examples/...` instead of `python examples/...`.
- Changed `export IMEDNET_BASE_URL (optional)` to `# export IMEDNET_BASE_URL` in RST examples.

🎯 **Why:** 
- `ModuleNotFoundError`: If developers run `python examples/quick_start.py` from source before fully installing the package globally, it errors out because `src/` isn't in `sys.path`. Using `poetry run python` guarantees it runs inside the project's virtual environment.
- Bash syntax error: Users who copy-paste `export VAR_NAME (optional)` into a terminal receive a syntax error `bash: syntax error near unexpected token '('`.

🧠 **Cognitive Impact:** 
- Fixes first-run crash for developers cloning the project.
- Prevents copy-paste errors, creating a smoother onboarding path.

📖 **Preview:**
```bash
   export IMEDNET_API_KEY
   export IMEDNET_SECURITY_KEY
   export IMEDNET_STUDY_KEY
   # export IMEDNET_BASE_URL
```
```python
    # Usage:
    poetry run python examples/quick_start.py
```

---
*PR created automatically by Jules for task [6940982492059089691](https://jules.google.com/task/6940982492059089691) started by @fderuiter*