### PR TITLE
🛡️ Shield: Test Coverage for validate_header_value

### DIFF
--- a/tests/unit/utils/test_security.py
+++ b/tests/unit/utils/test_security.py
@@ -1,6 +1,6 @@
 import pytest
 
-from imednet.utils.security import sanitize_csv_formula
+from imednet.utils.security import sanitize_csv_formula, validate_header_value
 
 
 @pytest.mark.parametrize(
@@ -30,3 +30,35 @@ from imednet.utils.security import sanitize_csv_formula
 )
 def test_sanitize_csv_formula(input_val, expected):
     assert sanitize_csv_formula(input_val) == expected
+
+
+@pytest.mark.parametrize(
+    "input_val",
+    [
+        "application/json",
+        "Bearer my-token-123",
+        "Mozilla/5.0",
+        "en-US,en;q=0.5",
+        "",
+        "custom_header_value",
+    ],
+)
+def test_validate_header_value_valid(input_val):
+    validate_header_value(input_val)
+
+
+@pytest.mark.parametrize(
+    "input_val",
+    [
+        "invalid\nvalue",
+        "invalid\rvalue",
+        "invalid\r\nvalue",
+        "\n",
+        "\r",
+        "Bearer \nmy-token",
+        "Bearer my-token\n",
+    ],
+)
+def test_validate_header_value_invalid(input_val):
+    with pytest.raises(ValueError, match="Header value must not contain newlines"):
+        validate_header_value(input_val)


### PR DESCRIPTION
🛑 **Vulnerability:** The `validate_header_value` security utility in `imednet.utils.security` lacked dedicated unit test coverage, leaving a critical CRLF (Carriage Return/Line Feed) injection defense mechanism vulnerable to regressions without alerting the test suite.

🛡️ **Defense:** Added comprehensive parameterized tests (`test_validate_header_value_valid` and `test_validate_header_value_invalid`) to `tests/unit/utils/test_security.py`. These tests cover the "Sad Path" by verifying that strings containing various newline variations (`\n`, `\r`, `\r\n`) strictly raise a `ValueError` with the expected error message, while valid headers pass without issue.

🔬 **Verification:** Run `poetry run pytest tests/unit/utils/test_security.py` to verify the boundary conditions behave exactly as specified.

📊 **Impact:** Increases test coverage for security utilities and completely eliminates the fragility surrounding manual or silent regressions in HTTP header sanitization logic.

---
*PR created automatically by Jules for task [5977971127131803798](https://jules.google.com/task/5977971127131803798) started by @fderuiter*