### PR TITLE
🏗️ Architect: Fix Hidden Dictionary Mutation in Parameter Resolution

### DIFF
--- a/src/imednet/core/endpoint/mixins/params.py
+++ b/src/imednet/core/endpoint/mixins/params.py
@@ -63,6 +63,9 @@ class ParamMixin:
         extra_params: Optional[Dict[str, Any]],
         filters: Dict[str, Any],
     ) -> ParamState:
+        # Prevent hidden mutable state by safely copying the dictionary
+        filters = filters.copy()
+
         # This method handles filter normalization and cache retrieval preparation
         # Assuming _auto_filter is available via self (EndpointProtocol)
         filters = cast(EndpointProtocol, self)._auto_filter(filters)


### PR DESCRIPTION
Fixes a hidden mutability bug where the `imednet-python-sdk` incorrectly modified user-provided parameter dictionaries directly in-place. This patch ensures pure functions and avoids potentially frustrating debugging sessions when reusing query dictionaries across multiple requests.

Architectural details have been recorded in `.jules/architect.md`.

---
*PR created automatically by Jules for task [6390265235132214929](https://jules.google.com/task/6390265235132214929) started by @fderuiter*