### PR TITLE
🛠️ Refactor: Endpoints - Explicit Study Key Strategy

### DIFF
--- a/src/imednet/core/endpoint/mixins/params.py
+++ b/src/imednet/core/endpoint/mixins/params.py
@@ -6,7 +6,6 @@ from imednet.core.endpoint.strategies import (
     DefaultParamProcessor,
     KeepStudyKeyStrategy,
     OptionalStudyKeyStrategy,
-    PopStudyKeyStrategy,
     StudyKeyStrategy,
 )
 from imednet.core.endpoint.structs import ParamState
@@ -20,8 +19,6 @@ class ParamMixin:
     """Mixin for handling endpoint parameters and filters."""
 
     requires_study_key: bool = True
-    _pop_study_filter: bool = False
-    _missing_study_exception: type[Exception] = ValueError
 
     PARAM_PROCESSOR: Optional[ParamProcessor] = None
     PARAM_PROCESSOR_CLS: type[ParamProcessor] = DefaultParamProcessor
@@ -38,11 +35,8 @@ class ParamMixin:
         if self.STUDY_KEY_STRATEGY:
             return self.STUDY_KEY_STRATEGY
 
-        # Backward compatibility logic
         if self.requires_study_key:
-            if self._pop_study_filter:
-                return PopStudyKeyStrategy(exception_cls=self._missing_study_exception)
-            return KeepStudyKeyStrategy(exception_cls=self._missing_study_exception)
+            return KeepStudyKeyStrategy()
         return OptionalStudyKeyStrategy()
 
     @property

--- a/src/imednet/core/endpoint/protocols.py
+++ b/src/imednet/core/endpoint/protocols.py
@@ -17,8 +17,6 @@ class EndpointProtocol(Protocol):
     _enable_cache: bool
     requires_study_key: bool
     PAGE_SIZE: int
-    _pop_study_filter: bool
-    _missing_study_exception: type[Exception]
 
     def _auto_filter(self, filters: Dict[str, Any]) -> Dict[str, Any]:
         """Apply automatic filters (e.g., default study key)."""

--- a/src/imednet/endpoints/codings.py
+++ b/src/imednet/endpoints/codings.py
@@ -3,6 +3,7 @@
 from imednet.core.endpoint.base import GenericEndpoint
 from imednet.core.endpoint.edc_mixin import EdcEndpointMixin
 from imednet.core.endpoint.mixins import FilterGetEndpointMixin, ListEndpointMixin
+from imednet.core.endpoint.strategies import PopStudyKeyStrategy
 from imednet.models.codings import Coding
 
 
@@ -21,5 +22,4 @@ class CodingsEndpoint(
     PATH = "codings"
     MODEL = Coding
     _id_param = "codingId"
-    _pop_study_filter = True
-    _missing_study_exception = KeyError
+    STUDY_KEY_STRATEGY = PopStudyKeyStrategy(exception_cls=KeyError)

--- a/src/imednet/endpoints/forms.py
+++ b/src/imednet/endpoints/forms.py
@@ -3,6 +3,7 @@
 from imednet.core.endpoint.base import GenericEndpoint
 from imednet.core.endpoint.edc_mixin import EdcEndpointMixin
 from imednet.core.endpoint.mixins import FilterGetEndpointMixin, ListEndpointMixin
+from imednet.core.endpoint.strategies import PopStudyKeyStrategy
 from imednet.models.forms import Form
 
 
@@ -22,6 +23,5 @@ class FormsEndpoint(
     MODEL = Form
     _id_param = "formId"
     _enable_cache = True
-    _pop_study_filter = True
-    _missing_study_exception = KeyError
+    STUDY_KEY_STRATEGY = PopStudyKeyStrategy(exception_cls=KeyError)
     PAGE_SIZE = 500

--- a/src/imednet/endpoints/intervals.py
+++ b/src/imednet/endpoints/intervals.py
@@ -3,6 +3,7 @@
 from imednet.core.endpoint.base import GenericEndpoint
 from imednet.core.endpoint.edc_mixin import EdcEndpointMixin
 from imednet.core.endpoint.mixins import FilterGetEndpointMixin, ListEndpointMixin
+from imednet.core.endpoint.strategies import PopStudyKeyStrategy
 from imednet.models.intervals import Interval
 
 
@@ -22,6 +23,5 @@ class IntervalsEndpoint(
     MODEL = Interval
     _id_param = "intervalId"
     _enable_cache = True
-    _pop_study_filter = True
-    _missing_study_exception = KeyError
+    STUDY_KEY_STRATEGY = PopStudyKeyStrategy(exception_cls=KeyError)
     PAGE_SIZE = 500

--- a/src/imednet/endpoints/records.py
+++ b/src/imednet/endpoints/records.py
@@ -27,7 +27,6 @@ class RecordsEndpoint(
     PATH = "records"
     MODEL = Record
     _id_param = "recordId"
-    _pop_study_filter = False
     PARAM_PROCESSOR = MappingParamProcessor({"record_data_filter": "recordDataFilter"})
 
     def create(

--- a/src/imednet/endpoints/sites.py
+++ b/src/imednet/endpoints/sites.py
@@ -3,6 +3,7 @@
 from imednet.core.endpoint.base import GenericEndpoint
 from imednet.core.endpoint.edc_mixin import EdcEndpointMixin
 from imednet.core.endpoint.mixins import FilterGetEndpointMixin, ListEndpointMixin
+from imednet.core.endpoint.strategies import PopStudyKeyStrategy
 from imednet.models.sites import Site
 
 
@@ -21,5 +22,4 @@ class SitesEndpoint(
     PATH = "sites"
     MODEL = Site
     _id_param = "siteId"
-    _pop_study_filter = True
-    _missing_study_exception = KeyError
+    STUDY_KEY_STRATEGY = PopStudyKeyStrategy(exception_cls=KeyError)

--- a/src/imednet/endpoints/users.py
+++ b/src/imednet/endpoints/users.py
@@ -3,7 +3,7 @@
 from imednet.core.endpoint.base import GenericEndpoint
 from imednet.core.endpoint.edc_mixin import EdcEndpointMixin
 from imednet.core.endpoint.mixins import FilterGetEndpointMixin, ListEndpointMixin
-from imednet.core.endpoint.strategies import MappingParamProcessor
+from imednet.core.endpoint.strategies import MappingParamProcessor, PopStudyKeyStrategy
 from imednet.models.users import User
 
 
@@ -22,7 +22,7 @@ class UsersEndpoint(
     PATH = "users"
     MODEL = User
     _id_param = "userId"
-    _pop_study_filter = True
+    STUDY_KEY_STRATEGY = PopStudyKeyStrategy()
     PARAM_PROCESSOR = MappingParamProcessor(
         mapping={"include_inactive": "includeInactive"},
         defaults={"include_inactive": False},

--- a/src/imednet/endpoints/variables.py
+++ b/src/imednet/endpoints/variables.py
@@ -3,6 +3,7 @@
 from imednet.core.endpoint.base import GenericEndpoint
 from imednet.core.endpoint.edc_mixin import EdcEndpointMixin
 from imednet.core.endpoint.mixins import FilterGetEndpointMixin, ListEndpointMixin
+from imednet.core.endpoint.strategies import PopStudyKeyStrategy
 from imednet.models.variables import Variable
 
 
@@ -22,6 +23,5 @@ class VariablesEndpoint(
     MODEL = Variable
     _id_param = "variableId"
     _enable_cache = True
-    _pop_study_filter = True
-    _missing_study_exception = KeyError
+    STUDY_KEY_STRATEGY = PopStudyKeyStrategy(exception_cls=KeyError)
     PAGE_SIZE = 500


### PR DESCRIPTION
This PR refactors how `studyKey` handling strategies are defined and resolved for SDK endpoints.

**Problem:** Endpoints were relying on implicit class-level flags (`_pop_study_filter: bool` and `_missing_study_exception: type[Exception]`) which `ParamMixin` used dynamically to instantiate a `StudyKeyStrategy` via backward compatibility logic. This violated the "Explicit > Implicit" rule and obscured the Strategy pattern.

**Solution:**
1.  Removed `_pop_study_filter` and `_missing_study_exception` from `EndpointProtocol` and `ParamMixin`.
2.  Updated `ParamMixin.study_key_strategy` to resolve `self.STUDY_KEY_STRATEGY` directly, defaulting to `KeepStudyKeyStrategy` or `OptionalStudyKeyStrategy` based solely on `requires_study_key`.
3.  Updated all relevant endpoints (`Codings`, `Forms`, `Intervals`, `Records`, `Sites`, `Users`, `Variables`) to explicitly instantiate and assign the correct `PopStudyKeyStrategy` to their `STUDY_KEY_STRATEGY` attribute.

**Verification:**
*   Tests pass: `poetry run pytest`
*   Type checks pass: `poetry run mypy src/imednet`
*   Formatting checks pass: `poetry run black .` and `poetry run ruff check --fix .`

---
*PR created automatically by Jules for task [10957207828714997985](https://jules.google.com/task/10957207828714997985) started by @fderuiter*