### PR TITLE
🛠️ Refactor: Endpoints - Extract GenericListGetEndpoint

### DIFF
--- a/src/imednet/core/endpoint/base.py
+++ b/src/imednet/core/endpoint/base.py
@@ -9,6 +9,7 @@ from urllib.parse import quote
 
 from imednet.core.context import Context
 from imednet.core.endpoint.abc import EndpointABC
+from imednet.core.endpoint.mixins import FilterGetEndpointMixin, ListEndpointMixin
 from imednet.core.protocols import AsyncRequestorProtocol, RequestorProtocol
 from imednet.models.json_base import JsonModel
 
@@ -77,3 +78,18 @@ class GenericEndpoint(EndpointABC[T]):
         if self._async_client is None:
             raise RuntimeError("Async client not configured")
         return self._async_client
+
+
+class GenericListGetEndpoint(
+    GenericEndpoint[T],
+    ListEndpointMixin[T],
+    FilterGetEndpointMixin[T],
+):
+    """
+    Generic base for endpoints that provide list and get-by-filter functionality.
+
+    Combines GenericEndpoint with ListEndpointMixin and FilterGetEndpointMixin
+    to provide standard CRUD read operations.
+    """
+
+    pass

--- a/src/imednet/endpoints/codings.py
+++ b/src/imednet/endpoints/codings.py
@@ -1,17 +1,14 @@
 """Endpoint for managing codings (medical coding) in a study."""
 
-from imednet.core.endpoint.base import GenericEndpoint
+from imednet.core.endpoint.base import GenericListGetEndpoint
 from imednet.core.endpoint.edc_mixin import EdcEndpointMixin
-from imednet.core.endpoint.mixins import FilterGetEndpointMixin, ListEndpointMixin
 from imednet.core.endpoint.strategies import PopStudyKeyStrategy
 from imednet.models.codings import Coding
 
 
 class CodingsEndpoint(
     EdcEndpointMixin,
-    GenericEndpoint[Coding],
-    ListEndpointMixin[Coding],
-    FilterGetEndpointMixin[Coding],
+    GenericListGetEndpoint[Coding],
 ):
     """
     API endpoint for interacting with codings (medical coding) in an iMedNet study.

--- a/src/imednet/endpoints/forms.py
+++ b/src/imednet/endpoints/forms.py
@@ -1,17 +1,14 @@
 """Endpoint for managing forms (eCRFs) in a study."""
 
-from imednet.core.endpoint.base import GenericEndpoint
+from imednet.core.endpoint.base import GenericListGetEndpoint
 from imednet.core.endpoint.edc_mixin import EdcEndpointMixin
-from imednet.core.endpoint.mixins import FilterGetEndpointMixin, ListEndpointMixin
 from imednet.core.endpoint.strategies import PopStudyKeyStrategy
 from imednet.models.forms import Form
 
 
 class FormsEndpoint(
     EdcEndpointMixin,
-    GenericEndpoint[Form],
-    ListEndpointMixin[Form],
-    FilterGetEndpointMixin[Form],
+    GenericListGetEndpoint[Form],
 ):
     """
     API endpoint for interacting with forms (eCRFs) in an iMedNet study.

--- a/src/imednet/endpoints/intervals.py
+++ b/src/imednet/endpoints/intervals.py
@@ -1,17 +1,14 @@
 """Endpoint for managing intervals (visit definitions) in a study."""
 
-from imednet.core.endpoint.base import GenericEndpoint
+from imednet.core.endpoint.base import GenericListGetEndpoint
 from imednet.core.endpoint.edc_mixin import EdcEndpointMixin
-from imednet.core.endpoint.mixins import FilterGetEndpointMixin, ListEndpointMixin
 from imednet.core.endpoint.strategies import PopStudyKeyStrategy
 from imednet.models.intervals import Interval
 
 
 class IntervalsEndpoint(
     EdcEndpointMixin,
-    GenericEndpoint[Interval],
-    ListEndpointMixin[Interval],
-    FilterGetEndpointMixin[Interval],
+    GenericListGetEndpoint[Interval],
 ):
     """
     API endpoint for interacting with intervals (visit definitions) in an iMedNet study.

--- a/src/imednet/endpoints/queries.py
+++ b/src/imednet/endpoints/queries.py
@@ -1,16 +1,13 @@
 """Endpoint for managing queries (dialogue/questions) in a study."""
 
-from imednet.core.endpoint.base import GenericEndpoint
+from imednet.core.endpoint.base import GenericListGetEndpoint
 from imednet.core.endpoint.edc_mixin import EdcEndpointMixin
-from imednet.core.endpoint.mixins import FilterGetEndpointMixin, ListEndpointMixin
 from imednet.models.queries import Query
 
 
 class QueriesEndpoint(
     EdcEndpointMixin,
-    GenericEndpoint[Query],
-    ListEndpointMixin[Query],
-    FilterGetEndpointMixin[Query],
+    GenericListGetEndpoint[Query],
 ):
     """
     API endpoint for interacting with queries (dialogue/questions) in an iMedNet study.

--- a/src/imednet/endpoints/record_revisions.py
+++ b/src/imednet/endpoints/record_revisions.py
@@ -1,16 +1,13 @@
 """Endpoint for retrieving record revision history in a study."""
 
-from imednet.core.endpoint.base import GenericEndpoint
+from imednet.core.endpoint.base import GenericListGetEndpoint
 from imednet.core.endpoint.edc_mixin import EdcEndpointMixin
-from imednet.core.endpoint.mixins import FilterGetEndpointMixin, ListEndpointMixin
 from imednet.models.record_revisions import RecordRevision
 
 
 class RecordRevisionsEndpoint(
     EdcEndpointMixin,
-    GenericEndpoint[RecordRevision],
-    ListEndpointMixin[RecordRevision],
-    FilterGetEndpointMixin[RecordRevision],
+    GenericListGetEndpoint[RecordRevision],
 ):
     """
     API endpoint for accessing record revision history in an iMedNet study.

--- a/src/imednet/endpoints/records.py
+++ b/src/imednet/endpoints/records.py
@@ -2,9 +2,8 @@
 
 from typing import Any, Dict, List, Optional, Union
 
-from imednet.core.endpoint.base import GenericEndpoint
+from imednet.core.endpoint.base import GenericListGetEndpoint
 from imednet.core.endpoint.edc_mixin import EdcEndpointMixin
-from imednet.core.endpoint.mixins import FilterGetEndpointMixin, ListEndpointMixin
 from imednet.core.endpoint.operations import RecordCreateOperation
 from imednet.core.endpoint.strategies import MappingParamProcessor
 from imednet.models.jobs import Job
@@ -14,9 +13,7 @@ from imednet.validation.cache import SchemaCache
 
 class RecordsEndpoint(
     EdcEndpointMixin,
-    GenericEndpoint[Record],
-    ListEndpointMixin[Record],
-    FilterGetEndpointMixin[Record],
+    GenericListGetEndpoint[Record],
 ):
     """
     API endpoint for interacting with records (eCRF instances) in an iMedNet study.

--- a/src/imednet/endpoints/sites.py
+++ b/src/imednet/endpoints/sites.py
@@ -1,17 +1,14 @@
 """Endpoint for managing sites (study locations) in a study."""
 
-from imednet.core.endpoint.base import GenericEndpoint
+from imednet.core.endpoint.base import GenericListGetEndpoint
 from imednet.core.endpoint.edc_mixin import EdcEndpointMixin
-from imednet.core.endpoint.mixins import FilterGetEndpointMixin, ListEndpointMixin
 from imednet.core.endpoint.strategies import PopStudyKeyStrategy
 from imednet.models.sites import Site
 
 
 class SitesEndpoint(
     EdcEndpointMixin,
-    GenericEndpoint[Site],
-    ListEndpointMixin[Site],
-    FilterGetEndpointMixin[Site],
+    GenericListGetEndpoint[Site],
 ):
     """
     API endpoint for interacting with sites (study locations) in an iMedNet study.

--- a/src/imednet/endpoints/studies.py
+++ b/src/imednet/endpoints/studies.py
@@ -1,16 +1,13 @@
 """Endpoint for managing studies in the iMedNet system."""
 
-from imednet.core.endpoint.base import GenericEndpoint
+from imednet.core.endpoint.base import GenericListGetEndpoint
 from imednet.core.endpoint.edc_mixin import EdcEndpointMixin
-from imednet.core.endpoint.mixins import FilterGetEndpointMixin, ListEndpointMixin
 from imednet.models.studies import Study
 
 
 class StudiesEndpoint(
     EdcEndpointMixin,
-    GenericEndpoint[Study],
-    ListEndpointMixin[Study],
-    FilterGetEndpointMixin[Study],
+    GenericListGetEndpoint[Study],
 ):
     """
     API endpoint for interacting with studies in the iMedNet system.

--- a/src/imednet/endpoints/subjects.py
+++ b/src/imednet/endpoints/subjects.py
@@ -2,17 +2,14 @@
 
 from typing import List
 
-from imednet.core.endpoint.base import GenericEndpoint
+from imednet.core.endpoint.base import GenericListGetEndpoint
 from imednet.core.endpoint.edc_mixin import EdcEndpointMixin
-from imednet.core.endpoint.mixins import FilterGetEndpointMixin, ListEndpointMixin
 from imednet.models.subjects import Subject
 
 
 class SubjectsEndpoint(
     EdcEndpointMixin,
-    GenericEndpoint[Subject],
-    ListEndpointMixin[Subject],
-    FilterGetEndpointMixin[Subject],
+    GenericListGetEndpoint[Subject],
 ):
     """
     API endpoint for interacting with subjects in an iMedNet study.

--- a/src/imednet/endpoints/users.py
+++ b/src/imednet/endpoints/users.py
@@ -1,17 +1,14 @@
 """Endpoint for managing users in a study."""
 
-from imednet.core.endpoint.base import GenericEndpoint
+from imednet.core.endpoint.base import GenericListGetEndpoint
 from imednet.core.endpoint.edc_mixin import EdcEndpointMixin
-from imednet.core.endpoint.mixins import FilterGetEndpointMixin, ListEndpointMixin
 from imednet.core.endpoint.strategies import MappingParamProcessor, PopStudyKeyStrategy
 from imednet.models.users import User
 
 
 class UsersEndpoint(
     EdcEndpointMixin,
-    GenericEndpoint[User],
-    ListEndpointMixin[User],
-    FilterGetEndpointMixin[User],
+    GenericListGetEndpoint[User],
 ):
     """
     API endpoint for interacting with users in an iMedNet study.

--- a/src/imednet/endpoints/variables.py
+++ b/src/imednet/endpoints/variables.py
@@ -1,17 +1,14 @@
 """Endpoint for managing variables (data points on eCRFs) in a study."""
 
-from imednet.core.endpoint.base import GenericEndpoint
+from imednet.core.endpoint.base import GenericListGetEndpoint
 from imednet.core.endpoint.edc_mixin import EdcEndpointMixin
-from imednet.core.endpoint.mixins import FilterGetEndpointMixin, ListEndpointMixin
 from imednet.core.endpoint.strategies import PopStudyKeyStrategy
 from imednet.models.variables import Variable
 
 
 class VariablesEndpoint(
     EdcEndpointMixin,
-    GenericEndpoint[Variable],
-    ListEndpointMixin[Variable],
-    FilterGetEndpointMixin[Variable],
+    GenericListGetEndpoint[Variable],
 ):
     """
     API endpoint for interacting with variables (data points on eCRFs) in an iMedNet study.

--- a/src/imednet/endpoints/visits.py
+++ b/src/imednet/endpoints/visits.py
@@ -1,16 +1,13 @@
 """Endpoint for managing visits (interval instances) in a study."""
 
-from imednet.core.endpoint.base import GenericEndpoint
+from imednet.core.endpoint.base import GenericListGetEndpoint
 from imednet.core.endpoint.edc_mixin import EdcEndpointMixin
-from imednet.core.endpoint.mixins import FilterGetEndpointMixin, ListEndpointMixin
 from imednet.models.visits import Visit
 
 
 class VisitsEndpoint(
     EdcEndpointMixin,
-    GenericEndpoint[Visit],
-    ListEndpointMixin[Visit],
-    FilterGetEndpointMixin[Visit],
+    GenericListGetEndpoint[Visit],
 ):
     """
     API endpoint for interacting with visits (interval instances) in an iMedNet study.


### PR DESCRIPTION
Extract generic endpoint pattern into `GenericListGetEndpoint` to DRY up the SDK.

---
*PR created automatically by Jules for task [6377961244100539693](https://jules.google.com/task/6377961244100539693) started by @fderuiter*