### PR TITLE
🏗️ Architect: Fix `async_get_studies` method signature

### DIFF
--- a/src/imednet/sdk_convenience.py
+++ b/src/imednet/sdk_convenience.py
@@ -175,10 +175,10 @@ class SDKConvenienceMixin:
         return await self.sites.async_list(study_key, **filters)
 
     async def async_get_studies(
-        self: SDKProtocol, study_key: str | None = None, **filters: Any
+        self: SDKProtocol, **filters: Any
     ) -> List[Study]:
         """Asynchronously list studies."""
-        return await self.studies.async_list(study_key, **filters)
+        return await self.studies.async_list(**filters)
 
     async def async_get_subjects(
         self: SDKProtocol, study_key: str | None = None, **filters: Any

--- a/src/imednet/sdk_convenience.py
+++ b/src/imednet/sdk_convenience.py
@@ -174,9 +174,7 @@ class SDKConvenienceMixin:
         """Asynchronously list sites."""
         return await self.sites.async_list(study_key, **filters)
 
-    async def async_get_studies(
-        self: SDKProtocol, **filters: Any
-    ) -> List[Study]:
+    async def async_get_studies(self: SDKProtocol, **filters: Any) -> List[Study]:
         """Asynchronously list studies."""
         return await self.studies.async_list(**filters)
 

--- a/tests/unit/test_sdk_async.py
+++ b/tests/unit/test_sdk_async.py
@@ -31,3 +31,18 @@ async def test_async_context_management(monkeypatch) -> None:
         assert isinstance(sdk, sdk_mod.ImednetSDK)
 
     assert called["close"]
+
+
+@pytest.mark.asyncio
+async def test_convenience_methods_delegate_to_endpoints_async(monkeypatch) -> None:
+    sdk = _create_async_sdk()
+    calls = {}
+
+    async def fake_async_studies_list(**kw):
+        calls["studies"] = kw
+        return ["STUDY"]
+
+    monkeypatch.setattr(sdk.studies, "async_list", fake_async_studies_list)
+
+    assert await sdk.async_get_studies(status="active") == ["STUDY"]
+    assert calls["studies"] == {"status": "active"}


### PR DESCRIPTION
The `StudiesEndpoint` does not require a `study_key` parameter because it fetches root-level resources (studies themselves). The synchronous convenience wrapper `get_studies` was already correctly implemented, but the `async_get_studies` wrapper was incorrectly left with a `study_key` parameter in its signature, which was then forwarded to the `StudiesEndpoint`'s async list method.

This commit removes the unnecessary `study_key` from `async_get_studies` and adds a dedicated asynchronous test in `test_sdk_async.py` to lock down this expected behavior.

---
*PR created automatically by Jules for task [7116101258176688760](https://jules.google.com/task/7116101258176688760) started by @fderuiter*