### PR TITLE
🏛️ Architect: Simplify JobPoller loop structures

### DIFF
--- a/src/imednet/workflows/job_poller.py
+++ b/src/imednet/workflows/job_poller.py
@@ -45,17 +45,15 @@ class JobPoller:
     ) -> JobStatus:
         start = time.monotonic()
 
-        result = self._get_job(study_key, batch_id)
-        status = self._check_complete(cast(JobStatus, result), batch_id)
-
-        while status.state.upper() not in TERMINAL_JOB_STATES:
-            self._check_timeout(start, timeout, batch_id)
-            time.sleep(interval)
-
+        while True:
             result = self._get_job(study_key, batch_id)
             status = self._check_complete(cast(JobStatus, result), batch_id)
 
-        return status
+            if status.state.upper() in TERMINAL_JOB_STATES:
+                return status
+
+            self._check_timeout(start, timeout, batch_id)
+            time.sleep(interval)
 
     async def _poll_async(
         self,
@@ -66,17 +64,15 @@ class JobPoller:
     ) -> JobStatus:
         start = time.monotonic()
 
-        result = await self._get_job(study_key, batch_id)
-        status = self._check_complete(cast(JobStatus, result), batch_id)
-
-        while status.state.upper() not in TERMINAL_JOB_STATES:
-            self._check_timeout(start, timeout, batch_id)
-            await asyncio.sleep(interval)
-
+        while True:
             result = await self._get_job(study_key, batch_id)
             status = self._check_complete(cast(JobStatus, result), batch_id)
 
-        return status
+            if status.state.upper() in TERMINAL_JOB_STATES:
+                return status
+
+            self._check_timeout(start, timeout, batch_id)
+            await asyncio.sleep(interval)
 
     def run(
         self, study_key: str, batch_id: str, interval: int = 5, timeout: int = 300


### PR DESCRIPTION
## 🏛️ Architect: Refactor JobPoller loops

**Design Change:**
Converted the "loop-and-a-half" polling structures in `JobPoller._poll_sync` and `JobPoller._poll_async` into a unified `while True:` structure.

**DRY Gains:**
Eliminated the duplicated `_get_job` and `_check_complete` method calls.

**Solidity:**
Maintains strict explicit > implicit guidelines and does not change any runtime behavior. Both Sync and Async implementations were updated identically to preserve Sync/Async parity. 

**Breaking Changes:**
None. Public API and test behavior are identical.

---
*PR created automatically by Jules for task [3376989155786798074](https://jules.google.com/task/3376989155786798074) started by @fderuiter*