### PR TITLE
🖋️ Scribe: Hide deprecated TUI command from CLI help menu

### DIFF
--- a/src/imednet/cli/__init__.py
+++ b/src/imednet/cli/__init__.py
@@ -58,7 +58,7 @@ app.add_typer(workflows_app)
 app.command("subject-data")(subject_data)
 
 
-@app.command()
+@app.command(hidden=True)
 def tui(ctx: typer.Context) -> None:
     """Launch the interactive terminal user interface (Dashboard)."""
     typer.echo("TUI mode has been removed. Please use the CLI commands.")


### PR DESCRIPTION
💡 **What:** Added `hidden=True` to the `@app.command()` decorator for the deprecated `tui` command in `src/imednet/cli/__init__.py`.

🎯 **Why:** The `tui` command has been removed and only outputs a "removed" message when run. It still appears in the `imednet --help` menu, which clutters the UI and confuses users into thinking it is a valid, functional command.

🧠 **Cognitive Impact:** Reduces cognitive load for new and existing users by simplifying the CLI help menu and hiding a broken path/deprecated feature.

📖 **Preview:**
```python
@app.command(hidden=True)
def tui(ctx: typer.Context) -> None:
    """Launch the interactive terminal user interface (Dashboard)."""
    typer.echo("TUI mode has been removed. Please use the CLI commands.")
    raise typer.Exit(code=1)
```

---
*PR created automatically by Jules for task [12481154699184379799](https://jules.google.com/task/12481154699184379799) started by @fderuiter*