### PR TITLE
🏛️ Architect: Refactor KeyErrorPopStudyKeyMixin

### DIFF
--- a/src/imednet/core/endpoint/mixins/__init__.py
+++ b/src/imednet/core/endpoint/mixins/__init__.py
@@ -4,7 +4,7 @@ from imednet.utils.filters import build_filter_string
 from .caching import CachedEndpointMixin, CacheMixin
 from .get import FilterGetEndpointMixin, PathGetEndpointMixin
 from .list import ListEndpointMixin
-from .params import KeyErrorPopStudyKeyMixin, ParamMixin
+from .params import ParamMixin
 from .parsing import ParsingMixin
 
 __all__ = [
@@ -12,7 +12,6 @@ __all__ = [
     "CachedEndpointMixin",
     "CacheMixin",
     "FilterGetEndpointMixin",
-    "KeyErrorPopStudyKeyMixin",
     "ListEndpointMixin",
     "Paginator",
     "ParamMixin",

--- a/src/imednet/core/endpoint/mixins/params.py
+++ b/src/imednet/core/endpoint/mixins/params.py
@@ -93,7 +93,3 @@ class ParamMixin:
         return ParamState(study=study, params=params, other_filters=other_filters)
 
 
-class KeyErrorPopStudyKeyMixin:
-    """Mixin that configures the endpoint to pop the study key and raise KeyError if missing."""
-
-    STUDY_KEY_STRATEGY: Optional[StudyKeyStrategy] = PopStudyKeyStrategy(exception_cls=KeyError)

--- a/src/imednet/core/endpoint/mixins/params.py
+++ b/src/imednet/core/endpoint/mixins/params.py
@@ -6,7 +6,6 @@ from imednet.core.endpoint.strategies import (
     DefaultParamProcessor,
     KeepStudyKeyStrategy,
     OptionalStudyKeyStrategy,
-    PopStudyKeyStrategy,
     StudyKeyStrategy,
 )
 from imednet.core.endpoint.structs import ParamState

--- a/src/imednet/core/endpoint/mixins/params.py
+++ b/src/imednet/core/endpoint/mixins/params.py
@@ -91,5 +91,3 @@ class ParamMixin:
             params.update(extra_params)
 
         return ParamState(study=study, params=params, other_filters=other_filters)
-
-

--- a/src/imednet/endpoints/codings.py
+++ b/src/imednet/endpoints/codings.py
@@ -2,13 +2,12 @@
 
 from imednet.core.endpoint.base import GenericListGetEndpoint
 from imednet.core.endpoint.edc_mixin import EdcEndpointMixin
-from imednet.core.endpoint.mixins import KeyErrorPopStudyKeyMixin
+from imednet.core.endpoint.strategies import PopStudyKeyStrategy
 from imednet.models.codings import Coding
 
 
 class CodingsEndpoint(
     EdcEndpointMixin,
-    KeyErrorPopStudyKeyMixin,
     GenericListGetEndpoint[Coding],
 ):
     """
@@ -20,3 +19,4 @@ class CodingsEndpoint(
     PATH = "codings"
     MODEL = Coding
     _id_param = "codingId"
+    STUDY_KEY_STRATEGY = PopStudyKeyStrategy(exception_cls=KeyError)

--- a/src/imednet/endpoints/forms.py
+++ b/src/imednet/endpoints/forms.py
@@ -2,13 +2,13 @@
 
 from imednet.core.endpoint.base import GenericListGetEndpoint
 from imednet.core.endpoint.edc_mixin import EdcEndpointMixin
-from imednet.core.endpoint.mixins import CachedEndpointMixin, KeyErrorPopStudyKeyMixin
+from imednet.core.endpoint.mixins import CachedEndpointMixin
+from imednet.core.endpoint.strategies import PopStudyKeyStrategy
 from imednet.models.forms import Form
 
 
 class FormsEndpoint(
     EdcEndpointMixin,
-    KeyErrorPopStudyKeyMixin,
     CachedEndpointMixin,
     GenericListGetEndpoint[Form],
 ):
@@ -21,3 +21,4 @@ class FormsEndpoint(
     PATH = "forms"
     MODEL = Form
     _id_param = "formId"
+    STUDY_KEY_STRATEGY = PopStudyKeyStrategy(exception_cls=KeyError)

--- a/src/imednet/endpoints/intervals.py
+++ b/src/imednet/endpoints/intervals.py
@@ -2,13 +2,13 @@
 
 from imednet.core.endpoint.base import GenericListGetEndpoint
 from imednet.core.endpoint.edc_mixin import EdcEndpointMixin
-from imednet.core.endpoint.mixins import CachedEndpointMixin, KeyErrorPopStudyKeyMixin
+from imednet.core.endpoint.mixins import CachedEndpointMixin
+from imednet.core.endpoint.strategies import PopStudyKeyStrategy
 from imednet.models.intervals import Interval
 
 
 class IntervalsEndpoint(
     EdcEndpointMixin,
-    KeyErrorPopStudyKeyMixin,
     CachedEndpointMixin,
     GenericListGetEndpoint[Interval],
 ):
@@ -21,3 +21,4 @@ class IntervalsEndpoint(
     PATH = "intervals"
     MODEL = Interval
     _id_param = "intervalId"
+    STUDY_KEY_STRATEGY = PopStudyKeyStrategy(exception_cls=KeyError)

--- a/src/imednet/endpoints/sites.py
+++ b/src/imednet/endpoints/sites.py
@@ -2,13 +2,12 @@
 
 from imednet.core.endpoint.base import GenericListGetEndpoint
 from imednet.core.endpoint.edc_mixin import EdcEndpointMixin
-from imednet.core.endpoint.mixins import KeyErrorPopStudyKeyMixin
+from imednet.core.endpoint.strategies import PopStudyKeyStrategy
 from imednet.models.sites import Site
 
 
 class SitesEndpoint(
     EdcEndpointMixin,
-    KeyErrorPopStudyKeyMixin,
     GenericListGetEndpoint[Site],
 ):
     """
@@ -20,3 +19,4 @@ class SitesEndpoint(
     PATH = "sites"
     MODEL = Site
     _id_param = "siteId"
+    STUDY_KEY_STRATEGY = PopStudyKeyStrategy(exception_cls=KeyError)

--- a/src/imednet/endpoints/variables.py
+++ b/src/imednet/endpoints/variables.py
@@ -2,13 +2,13 @@
 
 from imednet.core.endpoint.base import GenericListGetEndpoint
 from imednet.core.endpoint.edc_mixin import EdcEndpointMixin
-from imednet.core.endpoint.mixins import CachedEndpointMixin, KeyErrorPopStudyKeyMixin
+from imednet.core.endpoint.mixins import CachedEndpointMixin
+from imednet.core.endpoint.strategies import PopStudyKeyStrategy
 from imednet.models.variables import Variable
 
 
 class VariablesEndpoint(
     EdcEndpointMixin,
-    KeyErrorPopStudyKeyMixin,
     CachedEndpointMixin,
     GenericListGetEndpoint[Variable],
 ):
@@ -21,3 +21,4 @@ class VariablesEndpoint(
     PATH = "variables"
     MODEL = Variable
     _id_param = "variableId"
+    STUDY_KEY_STRATEGY = PopStudyKeyStrategy(exception_cls=KeyError)


### PR DESCRIPTION
### 🏛️ Architect: Refactor KeyErrorPopStudyKeyMixin

**The Smell:** 
The `KeyErrorPopStudyKeyMixin` in `src/imednet/core/endpoint/mixins/params.py` was acting merely as a container to implicitly set the `STUDY_KEY_STRATEGY` to `PopStudyKeyStrategy(exception_cls=KeyError)`. This inflated the inheritance tree of multiple endpoints unnecessarily and obscured the endpoint configurations.

**The Fix:** 
Removed `KeyErrorPopStudyKeyMixin` entirely. Migrated its explicit logic to all dependent endpoint classes (`CodingsEndpoint`, `FormsEndpoint`, `IntervalsEndpoint`, `SitesEndpoint`, `VariablesEndpoint`) by assigning `STUDY_KEY_STRATEGY = PopStudyKeyStrategy(exception_cls=KeyError)` directly. This enhances code locality, reduces cognitive load, and aligns with the "Explicit > Implicit" rule.

**Verification:**
- [x] Strict typing passes (`mypy`)
- [x] Test suite is green (`pytest`), confirming no behavioral changes
- [x] Sync/Async parity maintained (structural refactor)

---
*PR created automatically by Jules for task [16890505940147578802](https://jules.google.com/task/16890505940147578802) started by @fderuiter*