### PR TITLE
🛠️ Refactor: Exceptions - ClientError & NotFoundError

### DIFF
--- a/.jules/refactor.md
+++ b/.jules/refactor.md
@@ -1,0 +1,3 @@
+## 2024-05-18 - ClientError Imports
+**Debt:** Hardcoded `ValueError` and `KeyError` in `imednet/core/endpoint/strategies.py`, `imednet/core/endpoint/mixins/params.py`, `imednet/core/endpoint/mixins/get.py`, `imednet/core/endpoint/operations/record_create.py`, `imednet/endpoints/users.py`, `imednet/endpoints/jobs.py`, `imednet/endpoints/records.py`, `imednet/endpoints/variables.py`, `imednet/endpoints/forms.py`, `imednet/endpoints/intervals.py`, `imednet/endpoints/codings.py`, and `imednet/endpoints/sites.py` instead of the centralized `ClientError`.
+**Obstacle:** Legacy code before the centralized `ClientError` hierarchy was enforced.

--- a/src/imednet/core/endpoint/mixins/get.py
+++ b/src/imednet/core/endpoint/mixins/get.py
@@ -7,6 +7,7 @@ from imednet.core.endpoint.operations.filter_get import FilterGetOperation
 from imednet.core.endpoint.operations.get import PathGetOperation
 from imednet.core.paginator import AsyncPaginator, Paginator
 from imednet.core.protocols import AsyncRequestorProtocol, RequestorProtocol
+from imednet.errors import ClientError, NotFoundError
 
 from ..protocols import ListEndpointProtocol
 from .parsing import ParsingMixin, T
@@ -22,8 +23,8 @@ class FilterGetEndpointMixin(EndpointABC[T]):
     def _validate_get_result(self, items: List[T], study_key: Optional[str], item_id: Any) -> T:
         if not items:
             if self.requires_study_key:
-                raise ValueError(f"{self.MODEL.__name__} {item_id} not found in study {study_key}")
-            raise ValueError(f"{self.MODEL.__name__} {item_id} not found")
+                raise NotFoundError(f"{self.MODEL.__name__} {item_id} not found in study {study_key}")
+            raise NotFoundError(f"{self.MODEL.__name__} {item_id} not found")
         return items[0]
 
     def _get_sync(
@@ -96,7 +97,7 @@ class PathGetEndpointMixin(ParsingMixin[T], EndpointABC[T]):
         segments: Iterable[Any]
         if self.requires_study_key:
             if not study_key:
-                raise ValueError("Study key must be provided")
+                raise ClientError("Study key must be provided")
             segments = (study_key, self.PATH, item_id)
         else:
             segments = (self.PATH, item_id) if self.PATH else (item_id,)
@@ -105,7 +106,7 @@ class PathGetEndpointMixin(ParsingMixin[T], EndpointABC[T]):
         return self._build_path(*segments)
 
     def _raise_not_found(self, study_key: Optional[str], item_id: Any) -> None:
-        raise ValueError(f"{self.MODEL.__name__} not found")
+        raise NotFoundError(f"{self.MODEL.__name__} not found")
 
     def _get_path_sync(
         self,

--- a/src/imednet/core/endpoint/mixins/get.py
+++ b/src/imednet/core/endpoint/mixins/get.py
@@ -23,7 +23,9 @@ class FilterGetEndpointMixin(EndpointABC[T]):
     def _validate_get_result(self, items: List[T], study_key: Optional[str], item_id: Any) -> T:
         if not items:
             if self.requires_study_key:
-                raise NotFoundError(f"{self.MODEL.__name__} {item_id} not found in study {study_key}")
+                raise NotFoundError(
+                    f"{self.MODEL.__name__} {item_id} not found in study {study_key}"
+                )
             raise NotFoundError(f"{self.MODEL.__name__} {item_id} not found")
         return items[0]
 

--- a/src/imednet/core/endpoint/mixins/params.py
+++ b/src/imednet/core/endpoint/mixins/params.py
@@ -13,6 +13,7 @@ from imednet.core.protocols import ParamProcessor
 from imednet.utils.filters import build_filter_string
 
 from ..protocols import EndpointProtocol
+from imednet.errors import ClientError
 
 
 class ParamMixin:
@@ -36,7 +37,7 @@ class ParamMixin:
             return self.STUDY_KEY_STRATEGY
 
         if self.requires_study_key:
-            return KeepStudyKeyStrategy(exception_cls=ValueError)
+            return KeepStudyKeyStrategy(exception_cls=ClientError)
         return OptionalStudyKeyStrategy()
 
     @property

--- a/src/imednet/core/endpoint/mixins/params.py
+++ b/src/imednet/core/endpoint/mixins/params.py
@@ -10,10 +10,10 @@ from imednet.core.endpoint.strategies import (
 )
 from imednet.core.endpoint.structs import ParamState
 from imednet.core.protocols import ParamProcessor
+from imednet.errors import ClientError
 from imednet.utils.filters import build_filter_string
 
 from ..protocols import EndpointProtocol
-from imednet.errors import ClientError
 
 
 class ParamMixin:

--- a/src/imednet/core/endpoint/operations/record_create.py
+++ b/src/imednet/core/endpoint/operations/record_create.py
@@ -42,7 +42,7 @@ class RecordCreateOperation(Generic[T]):
 
         Raises:
             ValidationError: If record data is invalid against the schema.
-            ValueError: If email_notify contains invalid characters.
+            ClientError: If email_notify contains invalid characters.
         """
         self.path = path
         self.records_data = records_data
@@ -66,7 +66,7 @@ class RecordCreateOperation(Generic[T]):
             Dictionary of headers.
 
         Raises:
-            ValueError: If email_notify contains newlines.
+            ClientError: If email_notify contains newlines.
         """
         headers: Dict[str, str] = {}
         if self.email_notify is not None:

--- a/src/imednet/core/endpoint/strategies.py
+++ b/src/imednet/core/endpoint/strategies.py
@@ -8,6 +8,7 @@ to customize how filters are processed and special parameters are extracted.
 from typing import Any, Dict, Optional, Protocol, Tuple, Type, runtime_checkable
 
 from imednet.core.protocols import ParamProcessor
+from imednet.errors import ClientError
 
 
 class DefaultParamProcessor(ParamProcessor):
@@ -108,7 +109,7 @@ class KeepStudyKeyStrategy:
     Used when the API expects 'studyKey' as a query parameter.
     """
 
-    def __init__(self, exception_cls: Type[Exception] = ValueError) -> None:
+    def __init__(self, exception_cls: Type[Exception] = ClientError) -> None:
         self._exception_cls = exception_cls
 
     def process(self, filters: Dict[str, Any]) -> Tuple[Optional[str], Dict[str, Any]]:
@@ -138,7 +139,7 @@ class PopStudyKeyStrategy:
     not sent as a query parameter.
     """
 
-    def __init__(self, exception_cls: Type[Exception] = ValueError) -> None:
+    def __init__(self, exception_cls: Type[Exception] = ClientError) -> None:
         self._exception_cls = exception_cls
 
     def process(self, filters: Dict[str, Any]) -> Tuple[Optional[str], Dict[str, Any]]:

--- a/src/imednet/endpoints/codings.py
+++ b/src/imednet/endpoints/codings.py
@@ -3,6 +3,7 @@
 from imednet.core.endpoint.base import GenericListGetEndpoint
 from imednet.core.endpoint.edc_mixin import EdcEndpointMixin
 from imednet.core.endpoint.strategies import PopStudyKeyStrategy
+from imednet.errors import ClientError
 from imednet.models.codings import Coding
 
 
@@ -19,4 +20,4 @@ class CodingsEndpoint(
     PATH = "codings"
     MODEL = Coding
     _id_param = "codingId"
-    STUDY_KEY_STRATEGY = PopStudyKeyStrategy(exception_cls=KeyError)
+    STUDY_KEY_STRATEGY = PopStudyKeyStrategy(exception_cls=ClientError)

--- a/src/imednet/endpoints/forms.py
+++ b/src/imednet/endpoints/forms.py
@@ -4,6 +4,7 @@ from imednet.core.endpoint.base import GenericListGetEndpoint
 from imednet.core.endpoint.edc_mixin import EdcEndpointMixin
 from imednet.core.endpoint.mixins import CachedEndpointMixin
 from imednet.core.endpoint.strategies import PopStudyKeyStrategy
+from imednet.errors import ClientError
 from imednet.models.forms import Form
 
 
@@ -21,4 +22,4 @@ class FormsEndpoint(
     PATH = "forms"
     MODEL = Form
     _id_param = "formId"
-    STUDY_KEY_STRATEGY = PopStudyKeyStrategy(exception_cls=KeyError)
+    STUDY_KEY_STRATEGY = PopStudyKeyStrategy(exception_cls=ClientError)

--- a/src/imednet/endpoints/intervals.py
+++ b/src/imednet/endpoints/intervals.py
@@ -4,6 +4,7 @@ from imednet.core.endpoint.base import GenericListGetEndpoint
 from imednet.core.endpoint.edc_mixin import EdcEndpointMixin
 from imednet.core.endpoint.mixins import CachedEndpointMixin
 from imednet.core.endpoint.strategies import PopStudyKeyStrategy
+from imednet.errors import ClientError
 from imednet.models.intervals import Interval
 
 
@@ -21,4 +22,4 @@ class IntervalsEndpoint(
     PATH = "intervals"
     MODEL = Interval
     _id_param = "intervalId"
-    STUDY_KEY_STRATEGY = PopStudyKeyStrategy(exception_cls=KeyError)
+    STUDY_KEY_STRATEGY = PopStudyKeyStrategy(exception_cls=ClientError)

--- a/src/imednet/endpoints/jobs.py
+++ b/src/imednet/endpoints/jobs.py
@@ -6,8 +6,8 @@ from imednet.core.endpoint.base import GenericEndpoint
 from imednet.core.endpoint.edc_mixin import EdcEndpointMixin
 from imednet.core.endpoint.mixins import ListEndpointMixin, PathGetEndpointMixin
 from imednet.core.paginator import AsyncJsonListPaginator, JsonListPaginator
-from imednet.models.jobs import JobStatus
 from imednet.errors import NotFoundError
+from imednet.models.jobs import JobStatus
 
 
 class JobsEndpoint(

--- a/src/imednet/endpoints/jobs.py
+++ b/src/imednet/endpoints/jobs.py
@@ -7,6 +7,7 @@ from imednet.core.endpoint.edc_mixin import EdcEndpointMixin
 from imednet.core.endpoint.mixins import ListEndpointMixin, PathGetEndpointMixin
 from imednet.core.paginator import AsyncJsonListPaginator, JsonListPaginator
 from imednet.models.jobs import JobStatus
+from imednet.errors import NotFoundError
 
 
 class JobsEndpoint(
@@ -28,4 +29,4 @@ class JobsEndpoint(
     ASYNC_PAGINATOR_CLS = AsyncJsonListPaginator
 
     def _raise_not_found(self, study_key: Optional[str], item_id: Any) -> None:
-        raise ValueError(f"Job {item_id} not found in study {study_key}")
+        raise NotFoundError(f"Job {item_id} not found in study {study_key}")

--- a/src/imednet/endpoints/records.py
+++ b/src/imednet/endpoints/records.py
@@ -49,7 +49,7 @@ class RecordsEndpoint(
             Job object with information about the created job
 
         Raises:
-            ValueError: If email_notify contains invalid characters
+            ClientError: If email_notify contains invalid characters
         """
         path = self._build_path(study_key, self.PATH)
         operation = RecordCreateOperation[Job](
@@ -88,7 +88,7 @@ class RecordsEndpoint(
             Job object with information about the created job
 
         Raises:
-            ValueError: If email_notify contains invalid characters
+            ClientError: If email_notify contains invalid characters
         """
         path = self._build_path(study_key, self.PATH)
         operation = RecordCreateOperation[Job](

--- a/src/imednet/endpoints/sites.py
+++ b/src/imednet/endpoints/sites.py
@@ -3,6 +3,7 @@
 from imednet.core.endpoint.base import GenericListGetEndpoint
 from imednet.core.endpoint.edc_mixin import EdcEndpointMixin
 from imednet.core.endpoint.strategies import PopStudyKeyStrategy
+from imednet.errors import ClientError
 from imednet.models.sites import Site
 
 
@@ -19,4 +20,4 @@ class SitesEndpoint(
     PATH = "sites"
     MODEL = Site
     _id_param = "siteId"
-    STUDY_KEY_STRATEGY = PopStudyKeyStrategy(exception_cls=KeyError)
+    STUDY_KEY_STRATEGY = PopStudyKeyStrategy(exception_cls=ClientError)

--- a/src/imednet/endpoints/users.py
+++ b/src/imednet/endpoints/users.py
@@ -3,6 +3,7 @@
 from imednet.core.endpoint.base import GenericListGetEndpoint
 from imednet.core.endpoint.edc_mixin import EdcEndpointMixin
 from imednet.core.endpoint.strategies import MappingParamProcessor, PopStudyKeyStrategy
+from imednet.errors import ClientError
 from imednet.models.users import User
 
 
@@ -19,7 +20,7 @@ class UsersEndpoint(
     PATH = "users"
     MODEL = User
     _id_param = "userId"
-    STUDY_KEY_STRATEGY = PopStudyKeyStrategy(exception_cls=ValueError)
+    STUDY_KEY_STRATEGY = PopStudyKeyStrategy(exception_cls=ClientError)
     PARAM_PROCESSOR = MappingParamProcessor(
         mapping={"include_inactive": "includeInactive"},
         defaults={"include_inactive": False},

--- a/src/imednet/endpoints/variables.py
+++ b/src/imednet/endpoints/variables.py
@@ -4,6 +4,7 @@ from imednet.core.endpoint.base import GenericListGetEndpoint
 from imednet.core.endpoint.edc_mixin import EdcEndpointMixin
 from imednet.core.endpoint.mixins import CachedEndpointMixin
 from imednet.core.endpoint.strategies import PopStudyKeyStrategy
+from imednet.errors import ClientError
 from imednet.models.variables import Variable
 
 
@@ -21,4 +22,4 @@ class VariablesEndpoint(
     PATH = "variables"
     MODEL = Variable
     _id_param = "variableId"
-    STUDY_KEY_STRATEGY = PopStudyKeyStrategy(exception_cls=KeyError)
+    STUDY_KEY_STRATEGY = PopStudyKeyStrategy(exception_cls=ClientError)

--- a/src/imednet/utils/security.py
+++ b/src/imednet/utils/security.py
@@ -3,6 +3,7 @@ Security utilities.
 """
 
 from typing import Any
+
 from imednet.errors import ClientError
 
 

--- a/src/imednet/utils/security.py
+++ b/src/imednet/utils/security.py
@@ -3,6 +3,7 @@ Security utilities.
 """
 
 from typing import Any
+from imednet.errors import ClientError
 
 
 def sanitize_csv_formula(value: Any) -> Any:
@@ -24,7 +25,7 @@ def validate_header_value(value: str) -> None:
         value: The header value to validate.
 
     Raises:
-        ValueError: If the value contains newline characters.
+        ClientError: If the value contains newline characters.
     """
     if "\n" in value or "\r" in value:
-        raise ValueError(f"Header value must not contain newlines: {value!r}")
+        raise ClientError(f"Header value must not contain newlines: {value!r}")

--- a/tests/unit/endpoints/test_codings_endpoint.py
+++ b/tests/unit/endpoints/test_codings_endpoint.py
@@ -1,7 +1,7 @@
 import pytest
-from imednet.errors import ClientError, NotFoundError
 
 import imednet.endpoints.codings as codings
+from imednet.errors import ClientError, NotFoundError
 from imednet.models.codings import Coding
 
 

--- a/tests/unit/endpoints/test_codings_endpoint.py
+++ b/tests/unit/endpoints/test_codings_endpoint.py
@@ -1,4 +1,5 @@
 import pytest
+from imednet.errors import ClientError, NotFoundError
 
 import imednet.endpoints.codings as codings
 from imednet.models.codings import Coding
@@ -9,7 +10,7 @@ def test_list_requires_study_key(dummy_client, context, paginator_factory, patch
     capture = paginator_factory(codings, [{"codingId": 1}])
     patch = patch_build_filter(codings)
 
-    with pytest.raises(KeyError):
+    with pytest.raises(ClientError):
         ep.list()
 
     result = ep.list(study_key="S1", status="y")
@@ -28,5 +29,5 @@ def test_get_not_found(monkeypatch, dummy_client, context):
 
     monkeypatch.setattr(codings.CodingsEndpoint, "_list_sync", fake_impl)
 
-    with pytest.raises(ValueError):
+    with pytest.raises(NotFoundError):
         ep.get("S1", "x")

--- a/tests/unit/endpoints/test_endpoints_async.py
+++ b/tests/unit/endpoints/test_endpoints_async.py
@@ -1,6 +1,7 @@
 from unittest.mock import AsyncMock
 
 import pytest
+from imednet.errors import ClientError, NotFoundError
 
 import imednet.endpoints.codings as codings
 import imednet.endpoints.forms as forms
@@ -183,7 +184,7 @@ async def test_async_get_record_not_found(monkeypatch, dummy_client, context, re
 
     monkeypatch.setattr(records.RecordsEndpoint, "_list_async", fake_impl)
 
-    with pytest.raises(ValueError):
+    with pytest.raises(NotFoundError):
         await ep.async_get("S1", 1)
 
 

--- a/tests/unit/endpoints/test_endpoints_async.py
+++ b/tests/unit/endpoints/test_endpoints_async.py
@@ -1,7 +1,6 @@
 from unittest.mock import AsyncMock
 
 import pytest
-from imednet.errors import ClientError, NotFoundError
 
 import imednet.endpoints.codings as codings
 import imednet.endpoints.forms as forms
@@ -15,6 +14,7 @@ import imednet.endpoints.subjects as subjects
 import imednet.endpoints.users as users
 import imednet.endpoints.variables as variables
 import imednet.endpoints.visits as visits
+from imednet.errors import NotFoundError
 from imednet.models.codings import Coding
 from imednet.models.forms import Form
 from imednet.models.intervals import Interval

--- a/tests/unit/endpoints/test_forms_endpoint.py
+++ b/tests/unit/endpoints/test_forms_endpoint.py
@@ -1,7 +1,7 @@
 import pytest
-from imednet.errors import ClientError, NotFoundError
 
 import imednet.endpoints.forms as forms
+from imednet.errors import ClientError, NotFoundError
 from imednet.models.forms import Form
 
 

--- a/tests/unit/endpoints/test_forms_endpoint.py
+++ b/tests/unit/endpoints/test_forms_endpoint.py
@@ -1,4 +1,5 @@
 import pytest
+from imednet.errors import ClientError, NotFoundError
 
 import imednet.endpoints.forms as forms
 from imednet.models.forms import Form
@@ -11,7 +12,7 @@ def test_list_requires_study_key_and_page_size(
     captured = paginator_factory(forms, [{"formId": 1}])
     filter_capture = patch_build_filter(forms)
 
-    with pytest.raises(KeyError):
+    with pytest.raises(ClientError):
         ep.list()
 
     context.set_default_study_key("S1")
@@ -50,7 +51,7 @@ def test_get_not_found(monkeypatch, dummy_client, context):
 
     monkeypatch.setattr(forms.FormsEndpoint, "_list_sync", fake_impl)
 
-    with pytest.raises(ValueError):
+    with pytest.raises(NotFoundError):
         ep.get("S1", 1)
 
 

--- a/tests/unit/endpoints/test_intervals_endpoint.py
+++ b/tests/unit/endpoints/test_intervals_endpoint.py
@@ -1,4 +1,5 @@
 import pytest
+from imednet.errors import ClientError, NotFoundError
 
 import imednet.endpoints.intervals as intervals
 from imednet.models.intervals import Interval
@@ -29,7 +30,7 @@ def test_get_not_found(monkeypatch, dummy_client, context):
 
     monkeypatch.setattr(intervals.IntervalsEndpoint, "_list_sync", fake_impl)
 
-    with pytest.raises(ValueError):
+    with pytest.raises(NotFoundError):
         ep.get("S1", 1)
 
 

--- a/tests/unit/endpoints/test_intervals_endpoint.py
+++ b/tests/unit/endpoints/test_intervals_endpoint.py
@@ -1,7 +1,7 @@
 import pytest
-from imednet.errors import ClientError, NotFoundError
 
 import imednet.endpoints.intervals as intervals
+from imednet.errors import NotFoundError
 from imednet.models.intervals import Interval
 
 

--- a/tests/unit/endpoints/test_jobs_async.py
+++ b/tests/unit/endpoints/test_jobs_async.py
@@ -1,9 +1,9 @@
 from unittest.mock import AsyncMock
 
 import pytest
-from imednet.errors import ClientError, NotFoundError
 
 import imednet.endpoints.jobs as jobs
+from imednet.errors import NotFoundError
 from imednet.models.jobs import JobStatus
 
 

--- a/tests/unit/endpoints/test_jobs_async.py
+++ b/tests/unit/endpoints/test_jobs_async.py
@@ -1,6 +1,7 @@
 from unittest.mock import AsyncMock
 
 import pytest
+from imednet.errors import ClientError, NotFoundError
 
 import imednet.endpoints.jobs as jobs
 from imednet.models.jobs import JobStatus
@@ -27,5 +28,5 @@ async def test_async_get_not_found(dummy_client, context, response_factory):
 
     ep = jobs.JobsEndpoint(dummy_client, context, async_client=async_client)
 
-    with pytest.raises(ValueError):
+    with pytest.raises(NotFoundError):
         await ep.async_get("S1", "B1")

--- a/tests/unit/endpoints/test_jobs_endpoint.py
+++ b/tests/unit/endpoints/test_jobs_endpoint.py
@@ -1,4 +1,5 @@
 import pytest
+from imednet.errors import ClientError, NotFoundError
 
 import imednet.endpoints.jobs as jobs
 from imednet.models.jobs import JobStatus
@@ -17,5 +18,5 @@ def test_get_success(dummy_client, context, response_factory):
 def test_get_not_found(dummy_client, context, response_factory):
     ep = jobs.JobsEndpoint(dummy_client, context)
     dummy_client.get.return_value = response_factory({})
-    with pytest.raises(ValueError):
+    with pytest.raises(NotFoundError):
         ep.get("S1", "B1")

--- a/tests/unit/endpoints/test_jobs_endpoint.py
+++ b/tests/unit/endpoints/test_jobs_endpoint.py
@@ -1,7 +1,7 @@
 import pytest
-from imednet.errors import ClientError, NotFoundError
 
 import imednet.endpoints.jobs as jobs
+from imednet.errors import NotFoundError
 from imednet.models.jobs import JobStatus
 
 

--- a/tests/unit/endpoints/test_queries_endpoint.py
+++ b/tests/unit/endpoints/test_queries_endpoint.py
@@ -1,4 +1,5 @@
 import pytest
+from imednet.errors import ClientError, NotFoundError
 
 import imednet.endpoints.queries as queries
 from imednet.models.queries import Query
@@ -26,5 +27,5 @@ def test_get_not_found(monkeypatch, dummy_client, context):
 
     monkeypatch.setattr(queries.QueriesEndpoint, "_list_sync", fake_impl)
 
-    with pytest.raises(ValueError):
+    with pytest.raises(NotFoundError):
         ep.get("S1", 1)

--- a/tests/unit/endpoints/test_queries_endpoint.py
+++ b/tests/unit/endpoints/test_queries_endpoint.py
@@ -1,7 +1,7 @@
 import pytest
-from imednet.errors import ClientError, NotFoundError
 
 import imednet.endpoints.queries as queries
+from imednet.errors import NotFoundError
 from imednet.models.queries import Query
 
 

--- a/tests/unit/endpoints/test_record_revisions_endpoint.py
+++ b/tests/unit/endpoints/test_record_revisions_endpoint.py
@@ -1,4 +1,5 @@
 import pytest
+from imednet.errors import ClientError, NotFoundError
 
 import imednet.endpoints.record_revisions as record_revisions
 from imednet.models.record_revisions import RecordRevision
@@ -26,5 +27,5 @@ def test_get_not_found(monkeypatch, dummy_client, context):
 
     monkeypatch.setattr(record_revisions.RecordRevisionsEndpoint, "_list_sync", fake_impl)
 
-    with pytest.raises(ValueError):
+    with pytest.raises(NotFoundError):
         ep.get("S1", 1)

--- a/tests/unit/endpoints/test_record_revisions_endpoint.py
+++ b/tests/unit/endpoints/test_record_revisions_endpoint.py
@@ -1,7 +1,7 @@
 import pytest
-from imednet.errors import ClientError, NotFoundError
 
 import imednet.endpoints.record_revisions as record_revisions
+from imednet.errors import NotFoundError
 from imednet.models.record_revisions import RecordRevision
 
 

--- a/tests/unit/endpoints/test_records_endpoint.py
+++ b/tests/unit/endpoints/test_records_endpoint.py
@@ -1,7 +1,7 @@
 import pytest
 
 import imednet.endpoints.records as records
-from imednet.errors import ValidationError
+from imednet.errors import ClientError, NotFoundError, ValidationError
 from imednet.models.records import Record
 from imednet.models.variables import Variable
 from imednet.validation.cache import SchemaCache
@@ -51,7 +51,7 @@ def test_get_not_found(monkeypatch, dummy_client, context):
 
     monkeypatch.setattr(records.RecordsEndpoint, "_list_sync", fake_impl)
 
-    with pytest.raises(ValueError):
+    with pytest.raises(NotFoundError):
         ep.get("S1", 1)
 
 
@@ -117,5 +117,5 @@ def test_create_validates_data_with_snake_case_keys(dummy_client, context, respo
 
 def test_create_raises_on_header_injection(dummy_client, context):
     ep = records.RecordsEndpoint(dummy_client, context)
-    with pytest.raises(ValueError, match="Header value must not contain newlines"):
+    with pytest.raises(ClientError, match="Header value must not contain newlines"):
         ep.create("S1", [{"data": {}}], email_notify="test\n@example.com")

--- a/tests/unit/endpoints/test_sites_endpoint.py
+++ b/tests/unit/endpoints/test_sites_endpoint.py
@@ -1,4 +1,5 @@
 import pytest
+from imednet.errors import ClientError, NotFoundError
 
 import imednet.endpoints.sites as sites
 from imednet.models.sites import Site
@@ -9,7 +10,7 @@ def test_list_requires_study_key(dummy_client, context, paginator_factory, patch
     paginator_capture = paginator_factory(sites, [{"siteId": 1}])
     patch = patch_build_filter(sites)
 
-    with pytest.raises(KeyError):
+    with pytest.raises(ClientError):
         ep.list()
 
     result = ep.list(study_key="S1", status="ok")
@@ -28,5 +29,5 @@ def test_get_not_found(monkeypatch, dummy_client, context):
 
     monkeypatch.setattr(sites.SitesEndpoint, "_list_sync", fake_impl)
 
-    with pytest.raises(ValueError):
+    with pytest.raises(NotFoundError):
         ep.get("S1", 1)

--- a/tests/unit/endpoints/test_sites_endpoint.py
+++ b/tests/unit/endpoints/test_sites_endpoint.py
@@ -1,7 +1,7 @@
 import pytest
-from imednet.errors import ClientError, NotFoundError
 
 import imednet.endpoints.sites as sites
+from imednet.errors import ClientError, NotFoundError
 from imednet.models.sites import Site
 
 

--- a/tests/unit/endpoints/test_studies_endpoint.py
+++ b/tests/unit/endpoints/test_studies_endpoint.py
@@ -1,4 +1,5 @@
 import pytest
+from imednet.errors import ClientError, NotFoundError
 
 import imednet.endpoints.studies as studies
 from imednet.models.studies import Study
@@ -35,7 +36,7 @@ def test_get_success(monkeypatch, dummy_client, context, paginator_factory, patc
 def test_get_not_found(monkeypatch, dummy_client, context, paginator_factory):
     ep = studies.StudiesEndpoint(dummy_client, context)
     paginator_factory(studies, [])
-    with pytest.raises(ValueError):
+    with pytest.raises(NotFoundError):
         ep.get(None, "missing")
 
 

--- a/tests/unit/endpoints/test_studies_endpoint.py
+++ b/tests/unit/endpoints/test_studies_endpoint.py
@@ -1,7 +1,7 @@
 import pytest
-from imednet.errors import ClientError, NotFoundError
 
 import imednet.endpoints.studies as studies
+from imednet.errors import NotFoundError
 from imednet.models.studies import Study
 
 

--- a/tests/unit/endpoints/test_subjects_endpoint.py
+++ b/tests/unit/endpoints/test_subjects_endpoint.py
@@ -1,7 +1,7 @@
 import pytest
-from imednet.errors import ClientError, NotFoundError
 
 import imednet.endpoints.subjects as subjects
+from imednet.errors import NotFoundError
 from imednet.models.subjects import Subject
 
 

--- a/tests/unit/endpoints/test_subjects_endpoint.py
+++ b/tests/unit/endpoints/test_subjects_endpoint.py
@@ -1,4 +1,5 @@
 import pytest
+from imednet.errors import ClientError, NotFoundError
 
 import imednet.endpoints.subjects as subjects
 from imednet.models.subjects import Subject
@@ -28,5 +29,5 @@ def test_get_not_found(monkeypatch, dummy_client, context):
 
     monkeypatch.setattr(subjects.SubjectsEndpoint, "_list_sync", fake_impl)
 
-    with pytest.raises(ValueError):
+    with pytest.raises(NotFoundError):
         ep.get("S1", "X")

--- a/tests/unit/endpoints/test_users_endpoint.py
+++ b/tests/unit/endpoints/test_users_endpoint.py
@@ -1,4 +1,5 @@
 import pytest
+from imednet.errors import ClientError, NotFoundError
 
 import imednet.endpoints.users as users
 from imednet.models.users import User
@@ -8,7 +9,7 @@ def test_list_requires_study_key_and_include_inactive(dummy_client, context, pag
     ep = users.UsersEndpoint(dummy_client, context)
     capture = paginator_factory(users, [{"userId": 1}])
 
-    with pytest.raises(ValueError):
+    with pytest.raises(ClientError):
         ep.list()
 
     result = ep.list(study_key="S1", include_inactive=True)
@@ -26,5 +27,5 @@ def test_get_not_found(monkeypatch, dummy_client, context):
 
     monkeypatch.setattr(users.UsersEndpoint, "_list_sync", fake_impl)
 
-    with pytest.raises(ValueError):
+    with pytest.raises(NotFoundError):
         ep.get("S1", 1)

--- a/tests/unit/endpoints/test_users_endpoint.py
+++ b/tests/unit/endpoints/test_users_endpoint.py
@@ -1,7 +1,7 @@
 import pytest
-from imednet.errors import ClientError, NotFoundError
 
 import imednet.endpoints.users as users
+from imednet.errors import ClientError, NotFoundError
 from imednet.models.users import User
 
 

--- a/tests/unit/endpoints/test_variables_endpoint.py
+++ b/tests/unit/endpoints/test_variables_endpoint.py
@@ -1,7 +1,7 @@
 import pytest
-from imednet.errors import ClientError, NotFoundError
 
 import imednet.endpoints.variables as variables
+from imednet.errors import ClientError, NotFoundError
 from imednet.models.variables import Variable
 
 

--- a/tests/unit/endpoints/test_variables_endpoint.py
+++ b/tests/unit/endpoints/test_variables_endpoint.py
@@ -1,4 +1,5 @@
 import pytest
+from imednet.errors import ClientError, NotFoundError
 
 import imednet.endpoints.variables as variables
 from imednet.models.variables import Variable
@@ -11,7 +12,7 @@ def test_list_requires_study_key_page_size(
     capture = paginator_factory(variables, [{"variableId": 1}])
     patch = patch_build_filter(variables)
 
-    with pytest.raises(KeyError):
+    with pytest.raises(ClientError):
         ep.list()
 
     result = ep.list(study_key="S1", name="x")
@@ -31,7 +32,7 @@ def test_get_not_found(monkeypatch, dummy_client, context):
 
     monkeypatch.setattr(variables.VariablesEndpoint, "_list_sync", fake_impl)
 
-    with pytest.raises(ValueError):
+    with pytest.raises(NotFoundError):
         ep.get("S1", 1)
 
 

--- a/tests/unit/endpoints/test_visits_endpoint.py
+++ b/tests/unit/endpoints/test_visits_endpoint.py
@@ -1,7 +1,7 @@
 import pytest
-from imednet.errors import ClientError, NotFoundError
 
 import imednet.endpoints.visits as visits
+from imednet.errors import NotFoundError
 from imednet.models.visits import Visit
 
 

--- a/tests/unit/endpoints/test_visits_endpoint.py
+++ b/tests/unit/endpoints/test_visits_endpoint.py
@@ -1,4 +1,5 @@
 import pytest
+from imednet.errors import ClientError, NotFoundError
 
 import imednet.endpoints.visits as visits
 from imednet.models.visits import Visit
@@ -26,5 +27,5 @@ def test_get_not_found(monkeypatch, dummy_client, context):
 
     monkeypatch.setattr(visits.VisitsEndpoint, "_list_sync", fake_impl)
 
-    with pytest.raises(ValueError):
+    with pytest.raises(NotFoundError):
         ep.get("S1", 1)

--- a/tests/unit/test_core_endpoint_mixins_get.py
+++ b/tests/unit/test_core_endpoint_mixins_get.py
@@ -1,9 +1,9 @@
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
-from imednet.errors import ClientError, NotFoundError
 
 from imednet.core.endpoint.mixins.get import FilterGetEndpointMixin, PathGetEndpointMixin
+from imednet.errors import ClientError, NotFoundError
 from imednet.models.json_base import JsonModel
 
 

--- a/tests/unit/test_core_endpoint_mixins_get.py
+++ b/tests/unit/test_core_endpoint_mixins_get.py
@@ -1,6 +1,7 @@
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
+from imednet.errors import ClientError, NotFoundError
 
 from imednet.core.endpoint.mixins.get import FilterGetEndpointMixin, PathGetEndpointMixin
 from imednet.models.json_base import JsonModel
@@ -42,14 +43,14 @@ class DummyFilterGetEndpoint(FilterGetEndpointMixin[MockModel]):
 
 def test_filter_get_endpoint_not_found_with_study_key():
     ep = DummyFilterGetEndpoint([])
-    with pytest.raises(ValueError, match="MockModel 123 not found in study TEST_STUDY"):
+    with pytest.raises(NotFoundError):
         ep.get(study_key="TEST_STUDY", item_id=123)
 
 
 @pytest.mark.asyncio
 async def test_filter_get_endpoint_async_not_found_with_study_key():
     ep = DummyFilterGetEndpoint([])
-    with pytest.raises(ValueError, match="MockModel 123 not found in study TEST_STUDY"):
+    with pytest.raises(NotFoundError):
         await ep.async_get(study_key="TEST_STUDY", item_id=123)
 
 
@@ -59,7 +60,7 @@ class DummyFilterGetEndpointNoStudy(DummyFilterGetEndpoint):
 
 def test_filter_get_endpoint_not_found_without_study_key():
     ep = DummyFilterGetEndpointNoStudy([])
-    with pytest.raises(ValueError, match="MockModel 123 not found"):
+    with pytest.raises(NotFoundError):
         ep.get(study_key=None, item_id=123)
 
 
@@ -90,7 +91,7 @@ class DummyPathGetEndpoint(PathGetEndpointMixin[MockModel]):
 
 def test_path_get_endpoint_requires_study_key():
     ep = DummyPathGetEndpoint()
-    with pytest.raises(ValueError, match="Study key must be provided"):
+    with pytest.raises(ClientError, match="Study key must be provided"):
         ep.get(study_key=None, item_id=123)
 
 
@@ -107,19 +108,19 @@ def test_path_get_endpoint_no_study_key_no_path():
 
 def test_path_get_endpoint_raise_not_found():
     ep = DummyPathGetEndpoint()
-    with pytest.raises(ValueError, match="MockModel not found"):
+    with pytest.raises(NotFoundError):
         ep._raise_not_found(study_key="TEST", item_id=123)
 
 
 def test_validate_get_result_not_found():
     ep = DummyFilterGetEndpoint([])
     # Test require_study_key = True
-    with pytest.raises(ValueError, match="MockModel 123 not found in study TEST_STUDY"):
+    with pytest.raises(NotFoundError):
         ep._validate_get_result([], "TEST_STUDY", 123)
 
     # Test require_study_key = False
     ep.requires_study_key = False
-    with pytest.raises(ValueError, match="MockModel 123 not found"):
+    with pytest.raises(NotFoundError):
         ep._validate_get_result([], None, 123)
 
 

--- a/tests/unit/test_core_endpoint_operations.py
+++ b/tests/unit/test_core_endpoint_operations.py
@@ -1,13 +1,13 @@
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
-from imednet.errors import ClientError, NotFoundError
 
 from imednet.constants import HEADER_EMAIL_NOTIFY
 from imednet.core.endpoint.operations.filter_get import FilterGetOperation
 from imednet.core.endpoint.operations.get import PathGetOperation
 from imednet.core.endpoint.operations.list import ListOperation
 from imednet.core.endpoint.operations.record_create import RecordCreateOperation
+from imednet.errors import ClientError, NotFoundError
 
 
 def dummy_parse_func(data):

--- a/tests/unit/test_core_endpoint_operations.py
+++ b/tests/unit/test_core_endpoint_operations.py
@@ -1,6 +1,7 @@
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
+from imednet.errors import ClientError, NotFoundError
 
 from imednet.constants import HEADER_EMAIL_NOTIFY
 from imednet.core.endpoint.operations.filter_get import FilterGetOperation
@@ -38,13 +39,13 @@ def test_path_get_operation_execute_sync_not_found():
     response.json.return_value = None
     client.get.return_value = response
 
-    not_found_func = MagicMock(side_effect=ValueError("Not found"))
+    not_found_func = MagicMock(side_effect=NotFoundError("Not found"))
 
     operation = PathGetOperation(
         path="/test", parse_func=dummy_parse_func, not_found_func=not_found_func
     )
 
-    with pytest.raises(ValueError, match="Not found"):
+    with pytest.raises(NotFoundError, match="Not found"):
         operation.execute_sync(client)
 
     client.get.assert_called_once_with("/test")
@@ -78,13 +79,13 @@ async def test_path_get_operation_execute_async_not_found():
     response.json.return_value = None
     client.get.return_value = response
 
-    not_found_func = MagicMock(side_effect=ValueError("Not found"))
+    not_found_func = MagicMock(side_effect=NotFoundError("Not found"))
 
     operation = PathGetOperation(
         path="/test", parse_func=dummy_parse_func, not_found_func=not_found_func
     )
 
-    with pytest.raises(ValueError, match="Not found"):
+    with pytest.raises(NotFoundError, match="Not found"):
         await operation.execute_async(client)
 
     client.get.assert_called_once_with("/test")
@@ -229,7 +230,7 @@ def test_record_create_operation_sync():
 
 
 def test_record_create_operation_header_validation_failure():
-    with pytest.raises(ValueError, match="Header value must not contain newlines"):
+    with pytest.raises(ClientError, match="Header value must not contain newlines"):
         RecordCreateOperation(
             path="/create",
             records_data=[{"field1": "val1"}],
@@ -243,10 +244,10 @@ def test_record_create_operation_schema_validation_failure():
     with pytest.MonkeyPatch.context() as m:
         m.setattr(
             "imednet.core.endpoint.operations.record_create.validate_record_entry",
-            MagicMock(side_effect=ValueError("Invalid record data")),
+            MagicMock(side_effect=ClientError("Invalid record data")),
         )
 
-        with pytest.raises(ValueError, match="Invalid record data"):
+        with pytest.raises(ClientError, match="Invalid record data"):
             RecordCreateOperation(
                 path="/create", records_data=[{"invalid": "data"}], schema=schema_mock
             )

--- a/tests/unit/test_study_key_strategies.py
+++ b/tests/unit/test_study_key_strategies.py
@@ -1,11 +1,11 @@
 import pytest
-from imednet.errors import ClientError, NotFoundError
 
 from imednet.core.endpoint.strategies import (
     KeepStudyKeyStrategy,
     OptionalStudyKeyStrategy,
     PopStudyKeyStrategy,
 )
+from imednet.errors import ClientError
 
 
 class TestKeepStudyKeyStrategy:

--- a/tests/unit/test_study_key_strategies.py
+++ b/tests/unit/test_study_key_strategies.py
@@ -1,4 +1,5 @@
 import pytest
+from imednet.errors import ClientError, NotFoundError
 
 from imednet.core.endpoint.strategies import (
     KeepStudyKeyStrategy,
@@ -22,7 +23,7 @@ class TestKeepStudyKeyStrategy:
         strategy = KeepStudyKeyStrategy()
         filters = {"other": "param"}
 
-        with pytest.raises(ValueError, match="Study key must be provided"):
+        with pytest.raises(ClientError, match="Study key must be provided"):
             strategy.process(filters)
 
     def test_process_custom_exception(self):
@@ -39,7 +40,7 @@ class TestKeepStudyKeyStrategy:
         strategy = KeepStudyKeyStrategy()
         filters = {"studyKey": "", "other": "param"}
 
-        with pytest.raises(ValueError, match="Study key must be provided"):
+        with pytest.raises(ClientError, match="Study key must be provided"):
             strategy.process(filters)
 
 
@@ -57,7 +58,7 @@ class TestPopStudyKeyStrategy:
         strategy = PopStudyKeyStrategy()
         filters = {"other": "param"}
 
-        with pytest.raises(ValueError, match="Study key must be provided"):
+        with pytest.raises(ClientError, match="Study key must be provided"):
             strategy.process(filters)
 
     def test_process_custom_exception(self):

--- a/tests/unit/utils/test_security.py
+++ b/tests/unit/utils/test_security.py
@@ -1,6 +1,6 @@
 import pytest
-from imednet.errors import ClientError, NotFoundError
 
+from imednet.errors import ClientError
 from imednet.utils.security import sanitize_csv_formula, validate_header_value
 
 

--- a/tests/unit/utils/test_security.py
+++ b/tests/unit/utils/test_security.py
@@ -1,4 +1,5 @@
 import pytest
+from imednet.errors import ClientError, NotFoundError
 
 from imednet.utils.security import sanitize_csv_formula, validate_header_value
 
@@ -60,5 +61,5 @@ def test_validate_header_value_valid(input_val):
     ],
 )
 def test_validate_header_value_invalid(input_val):
-    with pytest.raises(ValueError, match="Header value must not contain newlines"):
+    with pytest.raises(ClientError, match="Header value must not contain newlines"):
         validate_header_value(input_val)


### PR DESCRIPTION
Replaced `ValueError` and `KeyError` with domain-specific exceptions `ClientError` and `NotFoundError` across endpoints and endpoint operations to adhere to explicit architectural boundaries. 
- Mypy and tests are green. 
- Recorded `.jules/refactor.md` for technical debt logging.

---
*PR created automatically by Jules for task [3322067373680380663](https://jules.google.com/task/3322067373680380663) started by @fderuiter*