### PR TITLE
🏛️ Architect: Centralized immutable Error Registry

### DIFF
--- a/src/imednet/core/http/handlers.py
+++ b/src/imednet/core/http/handlers.py
@@ -8,25 +8,7 @@ import json
 
 import httpx
 
-from imednet.errors import (
-    ApiError,
-    BadRequestError,
-    ConflictError,
-    ForbiddenError,
-    NotFoundError,
-    RateLimitError,
-    ServerError,
-    UnauthorizedError,
-)
-
-STATUS_TO_ERROR: dict[int, type[ApiError]] = {
-    400: BadRequestError,
-    401: UnauthorizedError,
-    403: ForbiddenError,
-    404: NotFoundError,
-    409: ConflictError,
-    429: RateLimitError,
-}
+from imednet.errors import get_error_class
 
 
 def handle_response(response: httpx.Response) -> httpx.Response:
@@ -37,10 +19,7 @@ def handle_response(response: httpx.Response) -> httpx.Response:
             body = response.json()
         except json.JSONDecodeError:
             body = response.text
-        exc_cls = STATUS_TO_ERROR.get(status)
-        if exc_cls:
-            raise exc_cls(body, status_code=status)
-        if 500 <= status < 600:
-            raise ServerError(body, status_code=status)
-        raise ApiError(body, status_code=status)
+
+        exc_cls = get_error_class(status)
+        raise exc_cls(body, status_code=status)
     return response

--- a/src/imednet/errors/__init__.py
+++ b/src/imednet/errors/__init__.py
@@ -14,9 +14,11 @@ from .api import (
 from .base import ImednetError
 from .client import ClientError
 from .network import RequestError
+from .registry import get_error_class
 from .validation import BadRequestError, UnknownVariableTypeError, ValidationError
 
 __all__ = [
+    "get_error_class",
     "ImednetError",
     "RequestError",
     "ClientError",

--- a/src/imednet/errors/registry.py
+++ b/src/imednet/errors/registry.py
@@ -1,0 +1,43 @@
+"""Registry for HTTP status code to error class mappings."""
+
+from __future__ import annotations
+
+import types
+from typing import Mapping, Type
+
+from .api import (
+    ApiError,
+    ConflictError,
+    ForbiddenError,
+    NotFoundError,
+    RateLimitError,
+    ServerError,
+    UnauthorizedError,
+)
+from .validation import BadRequestError
+
+# Use MappingProxyType to ensure immutability, avoiding global mutable state
+STATUS_TO_ERROR: Mapping[int, Type[ApiError]] = types.MappingProxyType(
+    {
+        400: BadRequestError,
+        401: UnauthorizedError,
+        403: ForbiddenError,
+        404: NotFoundError,
+        409: ConflictError,
+        429: RateLimitError,
+    }
+)
+
+
+def get_error_class(status_code: int) -> Type[ApiError]:
+    """
+    Get error class for status code.
+
+    Defaults to generic ApiError for unmapped client/server errors.
+    """
+    error_cls = STATUS_TO_ERROR.get(status_code)
+    if error_cls:
+        return error_cls
+    if 500 <= status_code < 600:
+        return ServerError
+    return ApiError


### PR DESCRIPTION
🏛️ Architect: Centralized immutable Error Registry

🏗️ Design Change:
Extracted hardcoded `STATUS_TO_ERROR` logic from `src/imednet/core/http/handlers.py` into a dedicated immutable registry in `src/imednet/errors/registry.py`.

♻️ DRY Gains:
Coupling removed from the core HTTP handler, centralizing HTTP status-code to exception resolution.

🛡️ Solidity:
Used `types.MappingProxyType` to explicitly enforce immutability, preventing mutable global state while satisfying Open/Closed Principle.

⚠️ Breaking Changes:
None. Public-facing API mapping behavior remains perfectly identical.

---
*PR created automatically by Jules for task [1681995226279086694](https://jules.google.com/task/1681995226279086694) started by @fderuiter*