### PR TITLE
🏛️ Architect: [Refactor ENDPOINT_REGISTRY]

### DIFF
--- a/src/imednet/endpoints/registry.py
+++ b/src/imednet/endpoints/registry.py
@@ -25,18 +25,20 @@ from imednet.endpoints.users import UsersEndpoint
 from imednet.endpoints.variables import VariablesEndpoint
 from imednet.endpoints.visits import VisitsEndpoint
 
-ENDPOINT_REGISTRY: Mapping[str, Type[GenericEndpoint]] = MappingProxyType({
-    "codings": CodingsEndpoint,
-    "forms": FormsEndpoint,
-    "intervals": IntervalsEndpoint,
-    "jobs": JobsEndpoint,
-    "queries": QueriesEndpoint,
-    "record_revisions": RecordRevisionsEndpoint,
-    "records": RecordsEndpoint,
-    "sites": SitesEndpoint,
-    "studies": StudiesEndpoint,
-    "subjects": SubjectsEndpoint,
-    "users": UsersEndpoint,
-    "variables": VariablesEndpoint,
-    "visits": VisitsEndpoint,
-})
+ENDPOINT_REGISTRY: Mapping[str, Type[GenericEndpoint]] = MappingProxyType(
+    {
+        "codings": CodingsEndpoint,
+        "forms": FormsEndpoint,
+        "intervals": IntervalsEndpoint,
+        "jobs": JobsEndpoint,
+        "queries": QueriesEndpoint,
+        "record_revisions": RecordRevisionsEndpoint,
+        "records": RecordsEndpoint,
+        "sites": SitesEndpoint,
+        "studies": StudiesEndpoint,
+        "subjects": SubjectsEndpoint,
+        "users": UsersEndpoint,
+        "variables": VariablesEndpoint,
+        "visits": VisitsEndpoint,
+    }
+)

--- a/src/imednet/endpoints/registry.py
+++ b/src/imednet/endpoints/registry.py
@@ -7,7 +7,8 @@ allowing for easier extension and maintenance.
 
 from __future__ import annotations
 
-from typing import Dict, Type
+from types import MappingProxyType
+from typing import Mapping, Type
 
 from imednet.core.endpoint.base import GenericEndpoint
 from imednet.endpoints.codings import CodingsEndpoint
@@ -24,7 +25,7 @@ from imednet.endpoints.users import UsersEndpoint
 from imednet.endpoints.variables import VariablesEndpoint
 from imednet.endpoints.visits import VisitsEndpoint
 
-ENDPOINT_REGISTRY: Dict[str, Type[GenericEndpoint]] = {
+ENDPOINT_REGISTRY: Mapping[str, Type[GenericEndpoint]] = MappingProxyType({
     "codings": CodingsEndpoint,
     "forms": FormsEndpoint,
     "intervals": IntervalsEndpoint,
@@ -38,4 +39,4 @@ ENDPOINT_REGISTRY: Dict[str, Type[GenericEndpoint]] = {
     "users": UsersEndpoint,
     "variables": VariablesEndpoint,
     "visits": VisitsEndpoint,
-}
+})


### PR DESCRIPTION
🏛️ Design Change:
Refactored `ENDPOINT_REGISTRY` in `src/imednet/endpoints/registry.py` from a mutable dictionary to an immutable `types.MappingProxyType`.

♻️ DRY Gains:
N/A - focused on structural integrity rather than repetition.

🛡️ Solidity:
Enforces the 'No Global Mutable State' constraint, preventing unpredictable runtime modifications to core SDK components.

⚠️ Breaking Changes:
None. Any code dynamically modifying the registry (which would be an anti-pattern) will now correctly fail, but read access remains unchanged.

---
*PR created automatically by Jules for task [2853099481521703626](https://jules.google.com/task/2853099481521703626) started by @fderuiter*