### PR TITLE
🖋️ Scribe: regex breakdown comment

### DIFF
--- a/src/imednet/utils/dates.py
+++ b/src/imednet/utils/dates.py
@@ -12,6 +12,14 @@ from datetime import datetime, timezone
 _IS_PY311_OR_GREATER = sys.version_info >= (3, 11)
 
 # Pre-compile regex for older python versions
+# Breakdown of _ISO8601_FRAC_REGEX:
+# \.               - Matches the literal dot preceding fractional seconds
+# (\d+)            - Captures one or more digits (the fractional seconds)
+# (?=              - Positive lookahead to ensure the fraction is followed by:
+#   [+-]\d{2}:\d{2} - A timezone offset (e.g., +00:00, -05:00)
+#   |               - OR
+#   $               - The end of the string (e.g., implicitly UTC if 'Z' was stripped)
+# )
 _ISO8601_FRAC_REGEX = re.compile(r"\.(\d+)(?=[+-]\d{2}:\d{2}|$)")
 
 


### PR DESCRIPTION
### 🖋️ Scribe: [regex breakdown comment]

💡 **What:** 
Added a detailed line-by-line breakdown comment above the `_ISO8601_FRAC_REGEX` regular expression in `src/imednet/utils/dates.py`.

🎯 **Why:** 
The regex used to parse ISO-8601 strings and fractional seconds for backwards compatibility was complex and lacked documentation. This required developers to mentally deconstruct the expression (lookaheads, optional boundaries) to understand its behavior and limits. 

🧠 **Cognitive Impact:** 
Reduces the "Time to Understand" by instantly clarifying the syntax and intent of the regular expression, eliminating ambiguity around how fractional seconds and time zone offsets are matched.

📖 **Preview:** 
```python
# Breakdown of _ISO8601_FRAC_REGEX:
# \.               - Matches the literal dot preceding fractional seconds
# (\d+)            - Captures one or more digits (the fractional seconds)
# (?=              - Positive lookahead to ensure the fraction is followed by:
#   [+-]\d{2}:\d{2} - A timezone offset (e.g., +00:00, -05:00)
#   |               - OR
#   $               - The end of the string (e.g., implicitly UTC if 'Z' was stripped)
# )
_ISO8601_FRAC_REGEX = re.compile(r"\.(\d+)(?=[+-]\d{2}:\d{2}|$)")
```

---
*PR created automatically by Jules for task [5330415148176077774](https://jules.google.com/task/5330415148176077774) started by @fderuiter*