### PR TITLE
🖋️ Scribe: Fixed outdated config validation error messages in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -275,7 +275,7 @@ Contributions are welcome! See the
 ## Troubleshooting
 
 **Missing required environment variable(s)**
-If you see an error like `IMEDNET_API_KEY and IMEDNET_SECURITY_KEY environment variables must be set.` or an "Unauthorized" API error, ensure you have set these variables in your shell or in a `.env` file in the directory where you run the script. See [Configuration](#configuration).
+If you see an error like `API key and security key are required` or an "Unauthorized" API error, ensure you have set these variables in your shell or in a `.env` file in the directory where you run the script. See [Configuration](#configuration).
 
 ---
 

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -97,4 +97,4 @@ Troubleshooting
 
 **Missing required environment variable(s)**
 
-If you see an error like ``IMEDNET_API_KEY and IMEDNET_SECURITY_KEY environment variables must be set.`` or an "Unauthorized" API error, ensure you have set these variables in your shell or in a ``.env`` file in the directory where you run the script. See `Using a .env File`_ for details.
+If you see an error like ``API key and security key are required`` or an "Unauthorized" API error, ensure you have set these variables in your shell or in a ``.env`` file in the directory where you run the script. See `Using a .env File`_ for details.


### PR DESCRIPTION
**PR Title:** 🖋️ Scribe: Fixed outdated config validation error messages in documentation

💡 **What:** Updated the Troubleshooting sections in `README.md` and `docs/configuration.rst` to replace the outdated error string (`IMEDNET_API_KEY and IMEDNET_SECURITY_KEY environment variables must be set.`) with the correct, granular strings currently thrown by `load_config` (e.g., `API key and security key are required`). 

🎯 **Why:** The configuration loading logic was updated previously to provide more granular, specific error messages when auth keys are missing. However, the documentation still referred to an older, hardcoded error message. This constituted "zombie documentation" which could confuse new developers, making them search their console output for a string that the app no longer actually produces.

🧠 **Cognitive Impact:** Fixes broken onboarding path. Developers troubleshooting missing environment variables will now be able to easily match the explicit CLI/SDK error messages ("API key is required") directly to the documentation's Troubleshooting guide, saving time and reducing friction during initial setup.

📖 **Preview:**
```markdown
**Missing required environment variable(s)**
If you see an error like `API key and security key are required` or an "Unauthorized" API error, ensure you have set these variables in your shell or in a `.env` file in the directory where you run the script. See [Configuration](#configuration).
```

---
*PR created automatically by Jules for task [1278134431895468774](https://jules.google.com/task/1278134431895468774) started by @fderuiter*