### PR TITLE
🖋️ Scribe: Fix CLI troubleshooting documentation mismatch in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -275,7 +275,7 @@ Contributions are welcome! See the
 ## Troubleshooting
 
 **Missing required environment variable(s)**
-If you see an error like `API key and security key are required` or an "Unauthorized" API error, ensure you have set these variables in your shell or in a `.env` file in the directory where you run the script. See [Configuration](#configuration).
+If you see an error like `IMEDNET_API_KEY and IMEDNET_SECURITY_KEY environment variables must be set.` (CLI) or `API key and security key are required` (SDK), or an "Unauthorized" API error, ensure you have set these variables in your shell or in a `.env` file in the directory where you run the script. See [Configuration](#configuration).
 
 ---
 


### PR DESCRIPTION
💡 **What:** 
Updated the "Troubleshooting" section in `README.md` to reflect the actual error message generated by the CLI when environment variables are missing.

🎯 **Why:**
The previous documentation only showed the error message emitted by the Python SDK (`API key and security key are required`). However, if a new user attempted to run the CLI directly (e.g. `imednet studies list`) without setting up their `.env` file or exporting the keys, they would receive a different message: `IMEDNET_API_KEY and IMEDNET_SECURITY_KEY environment variables must be set.`. 
This discrepancy created a "zombie doc" where the Troubleshooting section was incomplete and confusing for CLI-first users. 

🧠 **Cognitive Impact:** 
Fixes a confusing onboarding path for new users attempting to use the CLI. They will now be able to successfully Ctrl+F / search the `README.md` for the exact error string their terminal outputs, guiding them instantly to the configuration step.

📖 **Preview:**
```markdown
## Troubleshooting

**Missing required environment variable(s)**
If you see an error like `IMEDNET_API_KEY and IMEDNET_SECURITY_KEY environment variables must be set.` (CLI) or `API key and security key are required` (SDK), or an "Unauthorized" API error, ensure you have set these variables in your shell or in a `.env` file in the directory where you run the script. See [Configuration](#configuration).
```

---
*PR created automatically by Jules for task [11349311560731522667](https://jules.google.com/task/11349311560731522667) started by @fderuiter*