### PR TITLE
🖋️ Scribe: README.md Local Environment Instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,7 +171,7 @@ The package installs an `imednet` command with subcommands for studies, sites,
 subjects, records, jobs, queries and more. Use `imednet --help` to explore all
 options.
 
-*(Note: If you are running the project from source or a local clone, prefix commands with `poetry run`, e.g., `poetry run imednet --help`)*
+*(Note: If you are running the project from source or a local clone, make sure to first install dependencies with `poetry install`. Then, prefix commands with `poetry run`, e.g., `poetry run imednet --help`)*
 
 ### Data Export
 


### PR DESCRIPTION
Added the explicit `poetry install` prerequisite instruction in the CLI Usage section of the `README.md` to prevent developers running into a `ModuleNotFoundError` on their first try with the local CLI. Also journaled the finding.

---
*PR created automatically by Jules for task [16846016531359590158](https://jules.google.com/task/16846016531359590158) started by @fderuiter*