### PR TITLE
🖋️ Scribe: [documentation/README improvement]

### DIFF
--- a/README.md
+++ b/README.md
@@ -277,6 +277,9 @@ Contributions are welcome! See the
 **Missing required environment variable(s)**
 If you see an error like `IMEDNET_API_KEY and IMEDNET_SECURITY_KEY environment variables must be set.` (CLI) or `API key and security key are required` (SDK), or an "Unauthorized" API error, ensure you have set these variables in your shell or in a `.env` file in the directory where you run the script. See [Configuration](#configuration).
 
+**ModuleNotFoundError when running the CLI locally**
+If you are running the `imednet` CLI from source (e.g., `poetry run imednet`) and see a `ModuleNotFoundError` (such as `No module named 'imednet'`), ensure you have installed the project dependencies by running `poetry install` in the project root.
+
 ---
 
 ## License


### PR DESCRIPTION
## 🖋️ Scribe: README CLI Troubleshooting

💡 **What:** I added a new section to the `Troubleshooting` area in the `README.md` to address the `ModuleNotFoundError` when users run the CLI locally using `poetry run imednet`. The section explicitly instructs users to run `poetry install`.

🎯 **Why:** Trying to run `poetry run imednet` out of the box in a cloned repository fails with a `ModuleNotFoundError` because the `imednet` project dependencies and entry point are not installed. Since the error tells the user about a missing module or script but not how to fix it effectively, adding a straightforward step to `README.md` reduces confusion and resolves a broken onboarding path.

🧠 **Cognitive Impact:** Reduces the time to understand local testing errors for new developers. Instead of parsing the error stack or troubleshooting their environment randomly, they are directly pointed towards running the right command (`poetry install`). Fixes a first-run crash scenario when working from source.

📖 **Preview:**
```markdown
**ModuleNotFoundError when running the CLI locally**
If you are running the `imednet` CLI from source (e.g., `poetry run imednet`) and see a `ModuleNotFoundError` (such as `No module named 'imednet'`), ensure you have installed the project dependencies by running `poetry install` in the project root.
```

---
*PR created automatically by Jules for task [9006061569321464365](https://jules.google.com/task/9006061569321464365) started by @fderuiter*