### PR TITLE
🖋️ Scribe: Update CLI error string in documentation to match exact output

### DIFF
--- a/README.md
+++ b/README.md
@@ -275,7 +275,7 @@ Contributions are welcome! See the
 ## Troubleshooting
 
 **Missing required environment variable(s)**
-If you see an error like `IMEDNET_API_KEY and IMEDNET_SECURITY_KEY environment variables must be set.` (CLI) or `API key and security key are required` (SDK), or an "Unauthorized" API error, ensure you have set these variables in your shell or in a `.env` file in the directory where you run the script. See [Configuration](#configuration).
+If you see an error like `Error: IMEDNET_API_KEY and IMEDNET_SECURITY_KEY environment variables must be set.` (CLI) or `API key and security key are required` (SDK), or an "Unauthorized" API error, ensure you have set these variables in your shell or in a `.env` file in the directory where you run the script. See [Configuration](#configuration).
 
 **ModuleNotFoundError when running the CLI locally**
 If you are running the `imednet` CLI from source (e.g., `poetry run imednet`) and see a `ModuleNotFoundError` (such as `No module named 'imednet'`), ensure you have installed the project dependencies by running `poetry install` in the project root.

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -97,4 +97,4 @@ Troubleshooting
 
 **Missing required environment variable(s)**
 
-If you see an error like ``API key and security key are required`` or an "Unauthorized" API error, ensure you have set these variables in your shell or in a ``.env`` file in the directory where you run the script. See `Using a .env File`_ for details.
+If you see an error like ``Error: IMEDNET_API_KEY and IMEDNET_SECURITY_KEY environment variables must be set.`` (CLI) or ``API key and security key are required`` (SDK), or an "Unauthorized" API error, ensure you have set these variables in your shell or in a ``.env`` file in the directory where you run the script. See `Using a .env File`_ for details.


### PR DESCRIPTION
**Title:** 🖋️ Scribe: [documentation/README improvement]

💡 **What:** 
Updated the CLI error messages in the Troubleshooting sections of both `README.md` and `docs/configuration.rst` to accurately match the actual CLI output string `Error: IMEDNET_API_KEY and IMEDNET_SECURITY_KEY environment variables must be set.`.

🎯 **Why:** 
The documentation drifted from the codebase. The CLI prefixes the missing environment variable message with `Error: `, but the docs missed this prefix. Also, `docs/configuration.rst` completely lacked the CLI-specific error message and only included the generic SDK exception (`API key and security key are required`). This fixes the "zombie docs" by making them perfectly accurate.

🧠 **Cognitive Impact:** 
Eliminates confusion for new developers. When a new user hits an authentication wall, they will be able to search the exact terminal output (`Error: IMEDNET_API_KEY...`) and immediately land on the correct Troubleshooting resolution, significantly lowering the "Time to Understand" the missing `.env` issue.

---
*PR created automatically by Jules for task [922039759933746731](https://jules.google.com/task/922039759933746731) started by @fderuiter*