### PR TITLE
🏛️ Architect: Handle missing pandas dependency gracefully

### DIFF
--- a/src/imednet/integrations/export.py
+++ b/src/imednet/integrations/export.py
@@ -4,8 +4,10 @@ from __future__ import annotations
 
 from typing import Any, List, Optional
 
-import pandas as pd
-
+try:
+    import pandas as pd
+except ImportError:
+    pd = None  # type: ignore
 from imednet.constants import MAX_SQLITE_COLUMNS
 from imednet.utils import sanitize_csv_formula
 
@@ -51,6 +53,10 @@ def _records_df(
     form_whitelist: Optional[List[int]] = None,
 ) -> pd.DataFrame:
     """Return a DataFrame of study records with duplicate columns removed."""
+    if pd is None:
+        raise ImportError(
+            "pandas is required for _records_df. Install with 'pip install \"imednet[pandas]\"'."
+        )
     df: pd.DataFrame = RecordMapper(sdk).dataframe(
         study_key,
         use_labels_as_columns=use_labels_as_columns,
@@ -280,6 +286,10 @@ def export_to_long_sql(
     chunk_size: int = 1000,
 ) -> None:
     """Export records to a normalized long-format SQL table."""
+    if pd is None:
+        raise ImportError(
+            "pandas is required for export_to_long_sql. Install with 'pip install \"imednet[pandas]\"'."
+        )
     from sqlalchemy import create_engine
 
     engine = create_engine(conn_str)

--- a/src/imednet/integrations/export.py
+++ b/src/imednet/integrations/export.py
@@ -56,9 +56,9 @@ def _records_df(
     if pd is None:
         raise ImportError(
             (
-            "pandas is required for _records_df. Install with "
-            "'pip install \"imednet[pandas]\"'."
-        )
+                "pandas is required for _records_df. Install with "
+                "'pip install \"imednet[pandas]\"'."
+            )
         )
     df: pd.DataFrame = RecordMapper(sdk).dataframe(
         study_key,
@@ -292,9 +292,9 @@ def export_to_long_sql(
     if pd is None:
         raise ImportError(
             (
-            "pandas is required for export_to_long_sql. Install with "
-            "'pip install \"imednet[pandas]\"'."
-        )
+                "pandas is required for export_to_long_sql. Install with "
+                "'pip install \"imednet[pandas]\"'."
+            )
         )
     from sqlalchemy import create_engine
 

--- a/src/imednet/integrations/export.py
+++ b/src/imednet/integrations/export.py
@@ -55,7 +55,10 @@ def _records_df(
     """Return a DataFrame of study records with duplicate columns removed."""
     if pd is None:
         raise ImportError(
-            "pandas is required for _records_df. Install with 'pip install \"imednet[pandas]\"'."
+            (
+            "pandas is required for _records_df. Install with "
+            "'pip install \"imednet[pandas]\"'."
+        )
         )
     df: pd.DataFrame = RecordMapper(sdk).dataframe(
         study_key,
@@ -288,7 +291,10 @@ def export_to_long_sql(
     """Export records to a normalized long-format SQL table."""
     if pd is None:
         raise ImportError(
-            "pandas is required for export_to_long_sql. Install with 'pip install \"imednet[pandas]\"'."
+            (
+            "pandas is required for export_to_long_sql. Install with "
+            "'pip install \"imednet[pandas]\"'."
+        )
         )
     from sqlalchemy import create_engine
 

--- a/src/imednet/utils/pandas.py
+++ b/src/imednet/utils/pandas.py
@@ -25,7 +25,10 @@ def records_to_dataframe(records: List[Record], *, flatten: bool = False) -> pd.
     """
     if pd is None:
         raise ImportError(
-            "pandas is required for records_to_dataframe. Install with 'pip install \"imednet[pandas]\"'."
+            (
+            "pandas is required for records_to_dataframe. Install "
+            "with 'pip install \"imednet[pandas]\"'."
+        )
         )
 
     rows = [r.model_dump(by_alias=False) for r in records]
@@ -47,7 +50,10 @@ def export_records_csv(
     """
     if pd is None:
         raise ImportError(
-            "pandas is required for export_records_csv. Install with 'pip install \"imednet[pandas]\"'."
+            (
+            "pandas is required for export_records_csv. Install with "
+            "'pip install \"imednet[pandas]\"'."
+        )
         )
 
     records = sdk.records.list(study_key=study_key)

--- a/src/imednet/utils/pandas.py
+++ b/src/imednet/utils/pandas.py
@@ -26,9 +26,9 @@ def records_to_dataframe(records: List[Record], *, flatten: bool = False) -> pd.
     if pd is None:
         raise ImportError(
             (
-            "pandas is required for records_to_dataframe. Install "
-            "with 'pip install \"imednet[pandas]\"'."
-        )
+                "pandas is required for records_to_dataframe. Install "
+                "with 'pip install \"imednet[pandas]\"'."
+            )
         )
 
     rows = [r.model_dump(by_alias=False) for r in records]
@@ -51,9 +51,9 @@ def export_records_csv(
     if pd is None:
         raise ImportError(
             (
-            "pandas is required for export_records_csv. Install with "
-            "'pip install \"imednet[pandas]\"'."
-        )
+                "pandas is required for export_records_csv. Install with "
+                "'pip install \"imednet[pandas]\"'."
+            )
         )
 
     records = sdk.records.list(study_key=study_key)

--- a/src/imednet/utils/pandas.py
+++ b/src/imednet/utils/pandas.py
@@ -4,8 +4,10 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, List
 
-import pandas as pd
-
+try:
+    import pandas as pd
+except ImportError:
+    pd = None  # type: ignore
 from ..models.records import Record
 from .security import sanitize_csv_formula
 
@@ -21,6 +23,10 @@ def records_to_dataframe(records: List[Record], *, flatten: bool = False) -> pd.
     expanded using :func:`pandas.json_normalize` so that each variable becomes a
     column in the resulting DataFrame.
     """
+    if pd is None:
+        raise ImportError(
+            "pandas is required for records_to_dataframe. Install with 'pip install \"imednet[pandas]\"'."
+        )
 
     rows = [r.model_dump(by_alias=False) for r in records]
     df = pd.DataFrame(rows)
@@ -39,6 +45,10 @@ def export_records_csv(
     DataFrame is written with :meth:`pandas.DataFrame.to_csv` using
     ``index=False``.
     """
+    if pd is None:
+        raise ImportError(
+            "pandas is required for export_records_csv. Install with 'pip install \"imednet[pandas]\"'."
+        )
 
     records = sdk.records.list(study_key=study_key)
     df = records_to_dataframe(records, flatten=flatten)

--- a/src/imednet/workflows/record_mapper.py
+++ b/src/imednet/workflows/record_mapper.py
@@ -188,7 +188,10 @@ class RecordMapper:
         """Return a :class:`pandas.DataFrame` of records for a study."""
         if pd is None:
             raise ImportError(
-                "pandas is required for RecordMapper.dataframe. Install with 'pip install \"imednet[pandas]\"'."
+                (
+                "pandas is required for RecordMapper.dataframe. Install "
+                "with 'pip install \"imednet[pandas]\"'."
+            )
             )
         variable_keys, label_map = self._fetch_variable_metadata(
             study_key,

--- a/src/imednet/workflows/record_mapper.py
+++ b/src/imednet/workflows/record_mapper.py
@@ -1,7 +1,12 @@
+from __future__ import annotations
+
 import logging
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, Type, Union
 
-import pandas as pd
+try:
+    import pandas as pd
+except ImportError:
+    pd = None  # type: ignore
 from pydantic import BaseModel, Field, ValidationError, create_model
 
 from imednet.endpoints.records import Record as RecordModel  # type: ignore[attr-defined]
@@ -181,6 +186,10 @@ class RecordMapper:
         form_whitelist: Optional[List[int]] = None,
     ) -> pd.DataFrame:
         """Return a :class:`pandas.DataFrame` of records for a study."""
+        if pd is None:
+            raise ImportError(
+                "pandas is required for RecordMapper.dataframe. Install with 'pip install \"imednet[pandas]\"'."
+            )
         variable_keys, label_map = self._fetch_variable_metadata(
             study_key,
             variable_whitelist=variable_whitelist,

--- a/src/imednet/workflows/record_mapper.py
+++ b/src/imednet/workflows/record_mapper.py
@@ -189,9 +189,9 @@ class RecordMapper:
         if pd is None:
             raise ImportError(
                 (
-                "pandas is required for RecordMapper.dataframe. Install "
-                "with 'pip install \"imednet[pandas]\"'."
-            )
+                    "pandas is required for RecordMapper.dataframe. Install "
+                    "with 'pip install \"imednet[pandas]\"'."
+                )
             )
         variable_keys, label_map = self._fetch_variable_metadata(
             study_key,


### PR DESCRIPTION
## 🏛️ Refactor Candidate: Missing pandas handling in export tools

**The Smell:**
Functions in `src/imednet/utils/pandas.py` and `src/imednet/integrations/export.py` unconditionally import `pandas`, crashing the application with `ModuleNotFoundError` during import if the user doesn't have the optional `[pandas]` extra installed.

**The Fix:**
I have applied a try/except block around the `import pandas as pd` statement, setting `pd = None` if the import fails. Then, explicit runtime checks (`if pd is None: raise ImportError(...)`) were added inside the functions that use `pandas` (`export_records_csv`, `records_to_dataframe`, `_records_df`, `export_to_long_sql`, and `RecordMapper.dataframe()`). This allows the modules to load successfully, and only raises a descriptive `ImportError` telling the user to run `pip install "imednet[pandas]"` when these specific features are actually invoked.

**The Code:**
Changes applied to:
- `src/imednet/utils/pandas.py`
- `src/imednet/integrations/export.py`
- `src/imednet/workflows/record_mapper.py`

**Verification:**
- [x] Strict typing: `mypy` passes (added `from __future__ import annotations` where needed to avoid type hint evaluation errors when `pd=None`).
- [x] Structural integrity changes: Unit tests (`pytest`) pass, proving no regressions.

**Architect's Advice:**
This pattern avoids eager module import crashes for optional dependencies while maintaining type hint compliance by deferring `pandas` validation to the runtime of the functions that require it.

---
*PR created automatically by Jules for task [1293561987945211564](https://jules.google.com/task/1293561987945211564) started by @fderuiter*