### PR TITLE
🧪 Add tests for parse_bool with unusual and edge-case inputs

### DIFF
--- a/tests/unit/utils/test_validators.py
+++ b/tests/unit/utils/test_validators.py
@@ -117,3 +117,34 @@ def test_parse_datetime_handles_datetime_objects():
 def test_parse_datetime_handles_string_timestamps():
     dt = datetime(2024, 1, 1, 12, 0, tzinfo=timezone.utc)
     assert parse_datetime("2024-01-01T12:00:00Z") == dt
+
+
+def test_parse_bool_handles_unusual_strings():
+    # Test cases that trigger the float fallback
+    assert parse_bool("inf") is True
+    assert parse_bool("nan") is True
+    assert parse_bool("1.5") is True
+    assert parse_bool("100") is True
+    assert parse_bool("-1") is True
+    # Test edge cases for float fallback that should return False
+    assert parse_bool(".") is False
+    assert parse_bool("+") is False
+    assert parse_bool("-") is False
+    assert parse_bool("n") is False  # 'n' is in _FALSE_LOWER, explicitly False
+    assert parse_bool("i") is False  # 'i' not in TRUE/FALSE sets, but triggers float fallback check
+
+
+def test_parse_bool_handles_non_string_types():
+    # Non-truthy values according to rationale should return False
+    assert parse_bool(None) is False
+    assert parse_bool([]) is False
+    assert parse_bool({}) is False
+    assert parse_bool(object()) is False
+
+
+def test_parse_bool_handles_extra_numeric_values():
+    # Numeric types are truthy if non-zero
+    assert parse_bool(float("inf")) is True
+    assert parse_bool(float("nan")) is True
+    assert parse_bool(100) is True
+    assert parse_bool(-1) is True


### PR DESCRIPTION
# 🧪 Testing Improvement: parse_bool Edge Cases

🎯 **What:**
The `parse_bool` utility had basic tests for common boolean strings but lacked coverage for unusual inputs that trigger its more complex logic paths, such as the float fallback (e.g., "inf", "nan", numeric strings) and non-standard types.

📊 **Coverage:**
- **Unusual Strings:** Added coverage for "inf", "nan", "1.5", "100", "-1" (all truthy via float conversion), and edge cases like ".", "+", "-", "i" (all falsy).
- **Non-String Types:** Verified that `None`, empty lists `[]`, empty dicts `{}`, and generic `object()` instances are handled correctly (defaulting to `False`).
- **Extra Numeric Values:** Verified that actual `float('inf')`, `float('nan')`, and non-zero integers are handled correctly as truthy.

✨ **Result:**
Increased test coverage for `imednet.utils.validators.parse_bool`, ensuring robust behavior when encountering irregular API responses or unexpected data types. Verified parity with the optimized implementation which uses pre-computed sets and float fallback logic.

---
*PR created automatically by Jules for task [17228967635593003885](https://jules.google.com/task/17228967635593003885) started by @fderuiter*