### PR TITLE
⚡ Performance Optimization: Resolve N+1 Query in export_to_sql_by_form

### DIFF
--- a/src/imednet/integrations/export.py
+++ b/src/imednet/integrations/export.py
@@ -232,10 +232,20 @@ def export_to_sql_by_form(
     mapper = RecordMapper(sdk)
     engine = create_engine(conn_str)
     forms = sdk.forms.list(study_key=study_key)
+
+    # Fetch all variables for the study once to avoid N+1 queries
+    all_variables = sdk.variables.list(
+        study_key=study_key,
+        **({"formIds": form_whitelist} if form_whitelist else {}),
+    )
+    variables_by_form: dict[int, list[Any]] = {}
+    for v in all_variables:
+        variables_by_form.setdefault(v.form_id, []).append(v)
+
     for form in forms:
         if form_whitelist is not None and form.form_id not in form_whitelist:
             continue
-        variables = sdk.variables.list(study_key=study_key, formId=form.form_id)
+        variables = variables_by_form.get(form.form_id, [])
         variable_keys = [
             v.variable_name
             for v in variables

--- a/tests/unit/test_integrations_export.py
+++ b/tests/unit/test_integrations_export.py
@@ -191,9 +191,9 @@ def test_export_to_sql_by_form(monkeypatch):
     form1 = MagicMock(form_id=1, form_key="F1")
     form2 = MagicMock(form_id=2, form_key="F2")
     sdk.forms.list.return_value = [form1, form2]
-    sdk.variables.list.side_effect = [
-        [MagicMock(variable_name="A", label="A")],
-        [MagicMock(variable_name="B", label="B")],
+    sdk.variables.list.return_value = [
+        MagicMock(variable_name="A", label="A", form_id=1),
+        MagicMock(variable_name="B", label="B", form_id=2),
     ]
 
     mapper_inst = MagicMock()
@@ -216,7 +216,7 @@ def test_export_to_sql_by_form(monkeypatch):
     export_mod.export_to_sql_by_form(sdk, "STUDY", "sqlite://")
 
     mapper_cls.assert_called_once_with(sdk)
-    assert sdk.variables.list.call_count == 2
+    assert sdk.variables.list.call_count == 1
     df1.to_sql.assert_called_once_with("F1", engine, if_exists="replace", index=False)
     df2.to_sql.assert_called_once_with("F2", engine, if_exists="replace", index=False)
 


### PR DESCRIPTION
💡 **What:**
Optimized the `export_to_sql_by_form` function in `src/imednet/integrations/export.py` to eliminate an N+1 query pattern. Instead of making a remote API call for each form to fetch its variables, the function now fetches all variables for the study in a single bulk request and groups them by `form_id` locally using a dictionary.

🎯 **Why:**
Previously, the loop executed `sdk.variables.list(..., formId=form.form_id)` for every form in the `forms` list. For studies with many forms, this resulted in significant I/O overhead and slow export performance. Bulk-fetching variables reduces the number of API calls from N+1 to 1 (plus the initial forms list call).

📊 **Measured Improvement:**
- **Baseline:** 5 API calls to `sdk.variables.list` for 5 forms.
- **Optimized:** 1 API call to `sdk.variables.list` for any number of forms.
- **Change:** Significant reduction in network latency and API overhead, especially for large studies.

Verified with a reproduction script that confirmed the call count reduction and ensured functionality remains intact. Static analysis with `mypy` passed successfully.

---
*PR created automatically by Jules for task [4238338433989229310](https://jules.google.com/task/4238338433989229310) started by @fderuiter*