### PR TITLE
🛡️ Shield: Add async coverage to RecordUpdateWorkflow

### DIFF
--- a/tests/unit/test_workflows_record_update.py
+++ b/tests/unit/test_workflows_record_update.py
@@ -280,3 +280,102 @@ def test_create_or_update_records_form_key_not_found() -> None:
             "STUDY",
             [{"formKey": "UNKNOWN_FORM", "data": {"a": 1}}],
         )
+
+
+from unittest.mock import AsyncMock
+
+
+@pytest.mark.asyncio
+async def test_async_create_or_update_records_no_wait() -> None:
+    sdk = MagicMock()
+    sdk._async_client = True
+    job = Job(batch_id="1", state="PROCESSING")
+    sdk.records.async_create = AsyncMock(return_value=job)
+
+    wf = RecordUpdateWorkflow(sdk)
+    result = await wf.async_create_or_update_records("STUDY", [{"a": 1}])
+
+    sdk.records.async_create.assert_called_once_with("STUDY", [{"a": 1}], schema=wf._schema)
+    assert result == job
+
+
+@pytest.mark.asyncio
+async def test_async_create_or_update_records_wait_for_completion(monkeypatch) -> None:
+    sdk = MagicMock()
+    sdk._async_client = True
+    initial_job = Job(batch_id="1", state="PROCESSING")
+    completed_job = Job(batch_id="1", state="COMPLETED")
+    sdk.records.async_create = AsyncMock(return_value=initial_job)
+    sdk.jobs.async_get = AsyncMock(side_effect=[initial_job, completed_job])
+
+    wf = RecordUpdateWorkflow(sdk)
+    import anyio
+
+    monkeypatch.setattr(anyio, "sleep", AsyncMock())
+    result = await wf.async_create_or_update_records(
+        "STUDY",
+        [{"a": 1}],
+        wait_for_completion=True,
+        poll_interval=0,
+        timeout=5,
+    )
+
+    sdk.records.async_create.assert_called_once_with("STUDY", [{"a": 1}], schema=wf._schema)
+    sdk.jobs.async_get.assert_called_with("STUDY", "1")
+    assert result.state == "COMPLETED"
+
+
+@pytest.mark.asyncio
+async def test_async_create_or_update_records_validation() -> None:
+    sdk = MagicMock()
+    sdk._async_client = True
+    var = Variable(variable_name="age", variable_type="integer", form_id=1, form_key="F1")
+    sdk.variables.async_list = AsyncMock(return_value=[var])
+    sdk.records.async_create = AsyncMock()
+
+    wf = RecordUpdateWorkflow(sdk)
+
+    with pytest.raises(ValidationError):
+        await wf.async_create_or_update_records("STUDY", [{"formKey": "F1", "data": {"bad": 1}}])
+    sdk.records.async_create.assert_not_called()
+
+    sdk.records.async_create.return_value = Job(batch_id="1", state="PROCESSING")
+    await wf.async_create_or_update_records("STUDY", [{"formKey": "F1", "data": {"age": 5}}])
+    sdk.variables.async_list.assert_called_once_with(study_key="STUDY", refresh=True)
+    sdk.records.async_create.assert_called_once_with(
+        "STUDY", [{"formKey": "F1", "data": {"age": 5}}], schema=wf._schema
+    )
+
+
+@pytest.mark.asyncio
+async def test_async_create_or_update_records_wait_for_completion_no_batch_id() -> None:
+    sdk = MagicMock()
+    sdk._async_client = True
+    job = Job(batch_id="", state="PROCESSING")
+    sdk.records.async_create = AsyncMock(return_value=job)
+    var = Variable(variable_name="a", variable_type="integer", form_id=1, form_key="F1")
+    sdk.variables.async_list = AsyncMock(return_value=[var])
+
+    wf = RecordUpdateWorkflow(sdk)
+
+    with pytest.raises(ValueError, match="Submission successful but no batch_id received."):
+        await wf.async_create_or_update_records(
+            "STUDY",
+            [{"formKey": "F1", "data": {"a": 1}}],
+            wait_for_completion=True,
+        )
+
+
+@pytest.mark.asyncio
+async def test_async_create_or_update_records_form_key_not_found() -> None:
+    sdk = MagicMock()
+    sdk._async_client = True
+    sdk.variables.async_list = AsyncMock(return_value=[])
+
+    wf = RecordUpdateWorkflow(sdk)
+
+    with pytest.raises(ValueError, match="Form key 'UNKNOWN_FORM' not found"):
+        await wf.async_create_or_update_records(
+            "STUDY",
+            [{"formKey": "UNKNOWN_FORM", "data": {"a": 1}}],
+        )

--- a/tests/unit/test_workflows_record_update.py
+++ b/tests/unit/test_workflows_record_update.py
@@ -1,4 +1,4 @@
-from unittest.mock import MagicMock
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
@@ -11,7 +11,7 @@ from imednet.workflows.record_update import RecordUpdateWorkflow
 def test_create_or_update_records_no_wait() -> None:
     sdk = MagicMock()
     sdk._async_client = None
-    job = Job(batch_id="1", state="PROCESSING")
+    job = Job(jobId="1", batchId="1", state="PROCESSING")
     sdk.records.create.return_value = job
 
     wf = RecordUpdateWorkflow(sdk)
@@ -24,8 +24,8 @@ def test_create_or_update_records_no_wait() -> None:
 def test_create_or_update_records_wait_for_completion(monkeypatch) -> None:
     sdk = MagicMock()
     sdk._async_client = None
-    initial_job = Job(batch_id="1", state="PROCESSING")
-    completed_job = Job(batch_id="1", state="COMPLETED")
+    initial_job = Job(jobId="1", batchId="1", state="PROCESSING")
+    completed_job = Job(jobId="1", batchId="1", state="COMPLETED")
     sdk.records.create.return_value = initial_job
     sdk.jobs.get.side_effect = [initial_job, completed_job]
 
@@ -49,7 +49,7 @@ def test_update_scheduled_record_builds_payload() -> None:
     sdk = MagicMock()
     sdk._async_client = None
     wf = RecordUpdateWorkflow(sdk)
-    wf.create_or_update_records = MagicMock(return_value="job")  # type: ignore[method-assign]
+    wf.create_or_update_records = MagicMock(return_value="job")  # type: ignore[method-assign]  # type: ignore[method-assign]
 
     result = wf.update_scheduled_record(
         "STUDY",
@@ -76,7 +76,22 @@ def test_update_scheduled_record_builds_payload() -> None:
 def test_create_or_update_records_validation() -> None:
     sdk = MagicMock()
     sdk._async_client = None
-    var = Variable(variable_name="age", variable_type="integer", form_id=1, form_key="F1")
+    var = Variable(
+        studyKey="STUDY",
+        variableId=1,
+        sequence=1,
+        revision=1,
+        disabled=False,
+        variableOid="OID1",
+        deleted=False,
+        formName="F1",
+        label="Label",
+        blinded=False,
+        variableName="age",
+        variableType="integer",
+        formId=1,
+        formKey="F1",
+    )
     sdk.variables.list.return_value = [var]
     wf = RecordUpdateWorkflow(sdk)
 
@@ -84,7 +99,7 @@ def test_create_or_update_records_validation() -> None:
         wf.create_or_update_records("STUDY", [{"formKey": "F1", "data": {"bad": 1}}])
     sdk.records.create.assert_not_called()
 
-    sdk.records.create.return_value = Job(batch_id="1", state="PROCESSING")
+    sdk.records.create.return_value = Job(jobId="1", batchId="1", state="PROCESSING")
     wf.create_or_update_records("STUDY", [{"formKey": "F1", "data": {"age": 5}}])
     sdk.variables.list.assert_called_once_with(study_key="STUDY", refresh=True)
     sdk.records.create.assert_called_once_with(
@@ -98,7 +113,7 @@ def test_register_subject_builds_payload() -> None:
     sdk._async_client = None
 
     wf = RecordUpdateWorkflow(sdk)
-    wf.create_or_update_records = MagicMock(return_value="job")
+    wf.create_or_update_records = MagicMock(return_value="job")  # type: ignore[method-assign]
 
     result = wf.register_subject(
         "STUDY",
@@ -124,7 +139,7 @@ def test_register_subject_with_site_id() -> None:
     sdk = MagicMock()
     sdk._async_client = None
     wf = RecordUpdateWorkflow(sdk)
-    wf.create_or_update_records = MagicMock(return_value="job")
+    wf.create_or_update_records = MagicMock(return_value="job")  # type: ignore[method-assign]
 
     result = wf.register_subject(
         "STUDY",
@@ -150,7 +165,7 @@ def test_create_new_record_builds_payload() -> None:
     sdk = MagicMock()
     sdk._async_client = None
     wf = RecordUpdateWorkflow(sdk)
-    wf.create_or_update_records = MagicMock(return_value="job")
+    wf.create_or_update_records = MagicMock(return_value="job")  # type: ignore[method-assign]
 
     result = wf.create_new_record(
         "STUDY",
@@ -176,7 +191,7 @@ def test_create_new_record_with_subject_oid() -> None:
     sdk = MagicMock()
     sdk._async_client = None
     wf = RecordUpdateWorkflow(sdk)
-    wf.create_or_update_records = MagicMock(return_value="job")
+    wf.create_or_update_records = MagicMock(return_value="job")  # type: ignore[method-assign]
 
     result = wf.create_new_record(
         "STUDY",
@@ -249,11 +264,26 @@ def test_create_or_update_records_wait_for_completion_no_batch_id() -> None:
     sdk._async_client = None
 
     # Return a job with no batch_id
-    job = Job(batch_id="", state="PROCESSING")
+    job = Job(jobId="1", batchId="", state="PROCESSING")
     sdk.records.create.return_value = job
 
     # Provide variable so form validation passes
-    var = Variable(variable_name="a", variable_type="integer", form_id=1, form_key="F1")
+    var = Variable(
+        studyKey="STUDY",
+        variableId=1,
+        sequence=1,
+        revision=1,
+        disabled=False,
+        variableOid="OID1",
+        deleted=False,
+        formName="F1",
+        label="Label",
+        blinded=False,
+        variableName="a",
+        variableType="integer",
+        formId=1,
+        formKey="F1",
+    )
     sdk.variables.list.return_value = [var]
 
     wf = RecordUpdateWorkflow(sdk)
@@ -282,14 +312,11 @@ def test_create_or_update_records_form_key_not_found() -> None:
         )
 
 
-from unittest.mock import AsyncMock
-
-
 @pytest.mark.asyncio
 async def test_async_create_or_update_records_no_wait() -> None:
     sdk = MagicMock()
     sdk._async_client = True
-    job = Job(batch_id="1", state="PROCESSING")
+    job = Job(jobId="1", batchId="1", state="PROCESSING")
     sdk.records.async_create = AsyncMock(return_value=job)
 
     wf = RecordUpdateWorkflow(sdk)
@@ -303,8 +330,8 @@ async def test_async_create_or_update_records_no_wait() -> None:
 async def test_async_create_or_update_records_wait_for_completion(monkeypatch) -> None:
     sdk = MagicMock()
     sdk._async_client = True
-    initial_job = Job(batch_id="1", state="PROCESSING")
-    completed_job = Job(batch_id="1", state="COMPLETED")
+    initial_job = Job(jobId="1", batchId="1", state="PROCESSING")
+    completed_job = Job(jobId="1", batchId="1", state="COMPLETED")
     sdk.records.async_create = AsyncMock(return_value=initial_job)
     sdk.jobs.async_get = AsyncMock(side_effect=[initial_job, completed_job])
 
@@ -329,7 +356,22 @@ async def test_async_create_or_update_records_wait_for_completion(monkeypatch) -
 async def test_async_create_or_update_records_validation() -> None:
     sdk = MagicMock()
     sdk._async_client = True
-    var = Variable(variable_name="age", variable_type="integer", form_id=1, form_key="F1")
+    var = Variable(
+        studyKey="STUDY",
+        variableId=1,
+        sequence=1,
+        revision=1,
+        disabled=False,
+        variableOid="OID1",
+        deleted=False,
+        formName="F1",
+        label="Label",
+        blinded=False,
+        variableName="age",
+        variableType="integer",
+        formId=1,
+        formKey="F1",
+    )
     sdk.variables.async_list = AsyncMock(return_value=[var])
     sdk.records.async_create = AsyncMock()
 
@@ -339,7 +381,7 @@ async def test_async_create_or_update_records_validation() -> None:
         await wf.async_create_or_update_records("STUDY", [{"formKey": "F1", "data": {"bad": 1}}])
     sdk.records.async_create.assert_not_called()
 
-    sdk.records.async_create.return_value = Job(batch_id="1", state="PROCESSING")
+    sdk.records.async_create.return_value = Job(jobId="1", batchId="1", state="PROCESSING")
     await wf.async_create_or_update_records("STUDY", [{"formKey": "F1", "data": {"age": 5}}])
     sdk.variables.async_list.assert_called_once_with(study_key="STUDY", refresh=True)
     sdk.records.async_create.assert_called_once_with(
@@ -351,9 +393,24 @@ async def test_async_create_or_update_records_validation() -> None:
 async def test_async_create_or_update_records_wait_for_completion_no_batch_id() -> None:
     sdk = MagicMock()
     sdk._async_client = True
-    job = Job(batch_id="", state="PROCESSING")
+    job = Job(jobId="1", batchId="", state="PROCESSING")
     sdk.records.async_create = AsyncMock(return_value=job)
-    var = Variable(variable_name="a", variable_type="integer", form_id=1, form_key="F1")
+    var = Variable(
+        studyKey="STUDY",
+        variableId=1,
+        sequence=1,
+        revision=1,
+        disabled=False,
+        variableOid="OID1",
+        deleted=False,
+        formName="F1",
+        label="Label",
+        blinded=False,
+        variableName="a",
+        variableType="integer",
+        formId=1,
+        formKey="F1",
+    )
     sdk.variables.async_list = AsyncMock(return_value=[var])
 
     wf = RecordUpdateWorkflow(sdk)


### PR DESCRIPTION
🛑 **Vulnerability:** The async path in `RecordUpdateWorkflow` (`async_create_or_update_records` and `_async_validate_form_key`) lacked testing, leaving the asynchronous behavior and error paths vulnerable to regressions.
🛡️ **Defense:** Explicitly test `async_create_or_update_records` (for both "no wait" and "wait for completion" branches) and `_async_validate_form_key` ensuring `async` interactions and errors match the sync implementations.
🔬 **Verification:** Run `poetry run pytest tests/unit/test_workflows_record_update.py --cov=src/imednet/workflows/record_update.py` to ensure 100% coverage.
📊 **Impact:** Covers missing async branches and improves confidence against asynchronous test regressions.

---
*PR created automatically by Jules for task [6328061099407273234](https://jules.google.com/task/6328061099407273234) started by @fderuiter*