### PR TITLE
🏛️ Architect: [MRO Inheritance Refactor]

### DIFF
--- a/src/imednet/core/endpoint/base.py
+++ b/src/imednet/core/endpoint/base.py
@@ -81,9 +81,9 @@ class GenericEndpoint(EndpointABC[T]):
 
 
 class GenericListGetEndpoint(
-    GenericEndpoint[T],
     ListEndpointMixin[T],
     FilterGetEndpointMixin[T],
+    GenericEndpoint[T],
 ):
     """
     Generic base for endpoints that provide list and get-by-filter functionality.

--- a/src/imednet/endpoints/jobs.py
+++ b/src/imednet/endpoints/jobs.py
@@ -12,9 +12,9 @@ from imednet.models.jobs import JobStatus
 
 class JobsEndpoint(
     EdcEndpointMixin,
-    GenericEndpoint[JobStatus],
     ListEndpointMixin[JobStatus],
     PathGetEndpointMixin[JobStatus],
+    GenericEndpoint[JobStatus],
 ):
     """
     API endpoint for retrieving status and details of jobs in an iMedNet study.


### PR DESCRIPTION
🏛️ Design Change:
Moved `GenericEndpoint` and `GenericListGetEndpoint` to the end of the MRO inheritance list for all specific SDK endpoints. Python method resolution uses C3 linearization, which means that base classes meant to be overridden by mixins must come after the mixins in the class inheritance order.

♻️ DRY Gains:
Ensures mixin logic correctly evaluates overriding defaults natively across the codebase.

🛡️ Solidity:
Eliminates implicit bugs where methods might be skipped in overlapping multiple inheritance patterns across `GenericEndpoint`.

⚠️ Breaking Changes:
None. Types and synchronous/asynchronous logic behaviors are un-altered.

---
*PR created automatically by Jules for task [14036600680156918914](https://jules.google.com/task/14036600680156918914) started by @fderuiter*