### PR TITLE
🏛️ Architect: Endpoints - Fix property overriding

### DIFF
--- a/src/imednet/core/endpoint/abc.py
+++ b/src/imednet/core/endpoint/abc.py
@@ -31,13 +31,11 @@ class EndpointABC(ABC, ClientProvider, Generic[T]):
         """The model class associated with this endpoint."""
         pass
 
-    @property
-    def requires_study_key(self) -> bool:
-        """
-        Whether this endpoint requires a study key.
-        Defaults to True. Override in subclasses if needed.
-        """
-        return True
+    requires_study_key: bool = True
+    """
+    Whether this endpoint requires a study key.
+    Defaults to True. Override in subclasses if needed.
+    """
 
     @property
     def _id_param(self) -> str:

--- a/src/imednet/endpoints/studies.py
+++ b/src/imednet/endpoints/studies.py
@@ -19,4 +19,4 @@ class StudiesEndpoint(
     MODEL = Study
     _id_param = "studyKey"
     _enable_cache = True
-    requires_study_key = False
+    requires_study_key: bool = False

--- a/tests/unit/endpoints/test_list_get.py
+++ b/tests/unit/endpoints/test_list_get.py
@@ -46,18 +46,18 @@ def test_list_and_get(dummy_client, context, paginator_factory, cls, module, mod
     ep = cls(dummy_client, context)
     capture = paginator_factory(module, [{cls._id_param: item_id}])
 
-    list_kwargs = {"study_key": "S1"} if getattr(cls, "requires_study_key", True) else {}
+    list_kwargs = {"study_key": "S1"} if getattr(ep, "requires_study_key", True) else {}
     result = ep.list(**list_kwargs)
 
     expected_path = "/api/v1/edc/studies"
-    if getattr(cls, "requires_study_key", True):
+    if getattr(ep, "requires_study_key", True):
         expected_path += f"/S1/{cls.PATH}"
     elif cls.PATH:
         expected_path += f"/{cls.PATH}"
     assert capture["path"] == expected_path
     assert isinstance(result[0], model)
 
-    get_args = ("S1", item_id) if getattr(cls, "requires_study_key", True) else (None, item_id)
+    get_args = ("S1", item_id) if getattr(ep, "requires_study_key", True) else (None, item_id)
     got = ep.get(*get_args)
     assert isinstance(got, model)
 
@@ -76,17 +76,17 @@ async def test_async_list_and_get(
     ep = cls(dummy_client, context, async_client=dummy_client)
     capture = async_paginator_factory(module, [{cls._id_param: item_id}])
 
-    list_kwargs = {"study_key": "S1"} if getattr(cls, "requires_study_key", True) else {}
+    list_kwargs = {"study_key": "S1"} if getattr(ep, "requires_study_key", True) else {}
     result = await ep.async_list(**list_kwargs)
 
     expected_path = "/api/v1/edc/studies"
-    if getattr(cls, "requires_study_key", True):
+    if getattr(ep, "requires_study_key", True):
         expected_path += f"/S1/{cls.PATH}"
     elif cls.PATH:
         expected_path += f"/{cls.PATH}"
     assert capture["path"] == expected_path
     assert isinstance(result[0], model)
 
-    get_args = ("S1", item_id) if getattr(cls, "requires_study_key", True) else (None, item_id)
+    get_args = ("S1", item_id) if getattr(ep, "requires_study_key", True) else (None, item_id)
     got = await ep.async_get(*get_args)
     assert isinstance(got, model)


### PR DESCRIPTION
🏛️ Design Change:
Converted `requires_study_key` from a `@property` in `EndpointABC` to a properly type-hinted class attribute. This fixes MRO shadowing issues where overriding the property with a class attribute in subclasses or mixins would cause issues.

♻️ DRY Gains:
Simplified configuration across endpoints, avoiding verbose `@property` overrides for a simple boolean flag.

🛡️ Solidity:
Improved type safety and predictability. Fixed tests in `test_list_get.py` to evaluate the attribute on the instance (`ep`) rather than the class (`cls`), ensuring proper resolution of overridden values (previously it inadvertently worked by returning truthy property objects).

⚠️ Breaking Changes:
None. The public interface and behavior remain exactly the same.

---
*PR created automatically by Jules for task [6777910474801290279](https://jules.google.com/task/6777910474801290279) started by @fderuiter*