### PR TITLE
🛠️ Refactor: Journal - Document MRO Abstraction Obstacle

### DIFF
--- a/.jules/refactor.md
+++ b/.jules/refactor.md
@@ -1,0 +1,3 @@
+## 2025-04-29 - [Refactor] Generic Endpoints Abstraction
+**Debt:** Multiple endpoints duplicate the inheritance of both `GenericListGetEndpoint` and `EdcEndpointMixin`.
+**Obstacle:** We attempted to resolve this by creating `EdcListGetEndpoint` (combining `EdcEndpointMixin` and `GenericListGetEndpoint`). However, due to Python's Method Resolution Order (MRO), combining them breaks endpoints that inject behavior *between* them (like `PopStudyKeyMixin` or `CachedEndpointMixin`). A single combined class prevents injecting mixins that override methods in `GenericListGetEndpoint` but need to run after `EdcEndpointMixin`. We are journaling this to document why this pattern is rejected.


### PR DESCRIPTION
Added `.jules/refactor.md` as requested by the user.

This PR adds the journal entry documenting a rejected abstraction pattern due to Python's MRO constraints, adhering to the Refactor persona's guidelines for tracking structural debt and un-fixable obstacles.

---
*PR created automatically by Jules for task [14492347331657799517](https://jules.google.com/task/14492347331657799517) started by @fderuiter*