### PR TITLE
🖋️ Scribe: Clarify README Troubleshooting for Invalid API Keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -274,8 +274,8 @@ Contributions are welcome! See the
 
 ## Troubleshooting
 
-**Missing required environment variable(s)**
-If you see an error like `Error: IMEDNET_API_KEY and IMEDNET_SECURITY_KEY environment variables must be set.` (CLI) or `API key and security key are required` (SDK), or an "Unauthorized" API error, ensure you have set these variables in your shell or in a `.env` file in the directory where you run the script. See [Configuration](#configuration).
+**Missing or invalid required environment variable(s)**
+If you see an error like `Error: IMEDNET_API_KEY and IMEDNET_SECURITY_KEY environment variables must be set.` (CLI) or `API key and security key are required` (SDK), or an "Unauthorized" or "Forbidden" (403) API error, ensure you have set valid keys in your shell or in a `.env` file in the directory where you run the script (avoid using "dummy" keys). See [Configuration](#configuration).
 
 **ModuleNotFoundError when running the CLI locally**
 If you are running the `imednet` CLI from source (e.g., `poetry run imednet`) and see a `ModuleNotFoundError` (such as `No module named 'imednet'`), ensure you have installed the project dependencies by running `poetry install` in the project root.


### PR DESCRIPTION
💡 **What:** Added an explicit mention of "Forbidden (403)" errors and invalid keys (like "dummy" keys) to the Troubleshooting section in `README.md`.
🎯 **Why:** Users trying to run scripts with invalid or placeholder API keys (e.g. `dummy`) would encounter a `403 Forbidden` error without a clear indication that it was tied to the `IMEDNET_API_KEY` setup. The previous text only covered "Missing" keys.
🧠 **Cognitive Impact:** Reduces confusion during first-time setup or local script execution. When developers see a `403 Forbidden` error, the README now directly maps the problem to invalid environment variables, preventing unnecessary debugging.
📖 **Preview:** 
**Missing or invalid required environment variable(s)**
If you see an error like `Error: IMEDNET_API_KEY and IMEDNET_SECURITY_KEY environment variables must be set.` (CLI) or `API key and security key are required` (SDK), or an "Unauthorized" or "Forbidden" (403) API error, ensure you have set valid keys in your shell or in a `.env` file in the directory where you run the script (avoid using "dummy" keys). See [Configuration](#configuration).

---
*PR created automatically by Jules for task [920526000998607086](https://jules.google.com/task/920526000998607086) started by @fderuiter*