### PR TITLE
🏛️ Architect: Strict Typing in CacheMixin

### DIFF
--- a/src/imednet/core/endpoint/mixins/caching.py
+++ b/src/imednet/core/endpoint/mixins/caching.py
@@ -1,31 +1,51 @@
 from __future__ import annotations
 
-from typing import Any, Dict, Optional
+from typing import Any, Dict, Generic, List, Optional, TypeVar, Union
+
+from imednet.models.json_base import JsonModel
+
+T = TypeVar("T", bound=JsonModel)
 
 
-class CacheMixin:
+class CacheMixin(Generic[T]):
     """Mixin for handling endpoint caching."""
 
     requires_study_key: bool
     _enable_cache: bool = False  # Default, overridden by EndpointABC/subclasses
-    _cache: Any = None  # Default, overridden by GenericEndpoint
+    _cache: Optional[Union[List[T], Dict[str, List[T]]]] = None
+    # Default, overridden by GenericEndpoint
 
-    def _get_local_cache(self) -> Any:
+    def _get_local_cache(self) -> Optional[Union[List[T], Dict[str, List[T]]]]:
+        """
+        Retrieve the local cache if caching is enabled.
+
+        Returns:
+            The cached data, which can be a list of items or a dictionary mapping
+            study keys to lists of items. Returns None if caching is disabled.
+        """
         if self._enable_cache:
             return self._cache
         return None
 
     def _update_local_cache(
         self,
-        result: Any,
+        result: List[T],
         study: str | None,
         has_filters: bool,
     ) -> None:
+        """
+        Update the local cache with newly fetched results.
+
+        Args:
+            result: The newly fetched list of items to cache.
+            study: The study key associated with the result, if applicable.
+            has_filters: Boolean indicating if the result was filtered (which skips caching).
+        """
         if has_filters or not self._enable_cache:
             return
 
         if self.requires_study_key:
-            if self._cache is not None:
+            if isinstance(self._cache, dict) and study is not None:
                 self._cache[study] = result
         else:
             self._cache = result
@@ -35,17 +55,35 @@ class CacheMixin:
         study: Optional[str],
         refresh: bool,
         other_filters: Dict[str, Any],
-        cache: Any,
-    ) -> Optional[Any]:
+        cache: Optional[Union[List[T], Dict[str, List[T]]]],
+    ) -> Optional[List[T]]:
+        """
+        Check if the requested data is already available in the local cache.
+
+        Args:
+            study: The study key being requested.
+            refresh: Boolean flag to force a cache refresh.
+            other_filters: Additional filters; caching is bypassed if these are present.
+            cache: The current cache object to inspect.
+
+        Returns:
+            The cached list of items if a valid hit is found; otherwise, None.
+        """
         if not self._enable_cache:
             return None
 
         if self.requires_study_key:
             # Strict check usually done before, but here we just check cache
-            if cache is not None and not other_filters and not refresh and study in cache:
+            if (
+                isinstance(cache, dict)
+                and study is not None
+                and not other_filters
+                and not refresh
+                and study in cache
+            ):
                 return cache[study]
         else:
-            if cache is not None and not other_filters and not refresh:
+            if isinstance(cache, list) and not other_filters and not refresh:
                 return cache
         return None
 

--- a/src/imednet/core/endpoint/mixins/list.py
+++ b/src/imednet/core/endpoint/mixins/list.py
@@ -16,7 +16,7 @@ from .params import ParamMixin
 from .parsing import ParsingMixin, T
 
 
-class ListEndpointMixin(ParamMixin, CacheMixin, ParsingMixin[T], EndpointABC[T]):
+class ListEndpointMixin(ParamMixin, CacheMixin[T], ParsingMixin[T], EndpointABC[T]):
     """Mixin implementing ``list`` helpers."""
 
     PAGE_SIZE: int = DEFAULT_PAGE_SIZE


### PR DESCRIPTION
This refactor addresses the strict typing boundary violation in `CacheMixin`. 

Previously, `_cache` and cache-processing methods (`_get_local_cache`, `_update_local_cache`, and `_check_cache_hit`) were utilizing `Any` type annotations, preventing type-checking safety inside one of the core memory caching endpoints. 

The `CacheMixin` was refactored to be explicitly Generic over `T` (a bounded `JsonModel`) to match the structural shape enforced by `GenericEndpoint`. All usage of `Any` was removed in favor of `Optional[Union[List[T], Dict[str, List[T]]]]`. Further, `isinstance` guards were integrated within `CacheMixin` to ensure safe access patterns across `dict` (studyKey partitioning) and `list` outputs.

Google-style docstrings were added to strictly typed cache functions to increase readability and architectural documentation standards.

---
*PR created automatically by Jules for task [9666601115405931337](https://jules.google.com/task/9666601115405931337) started by @fderuiter*