### PR TITLE
🖋️ Scribe: Document IMEDNET_BASE_URL in Quick Start

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,8 @@ Set your credentials as environment variables before running the examples:
 ```bash
 export IMEDNET_API_KEY="your_api_key"
 export IMEDNET_SECURITY_KEY="your_security_key"
+# Optional: Custom base URL for the API endpoint
+# export IMEDNET_BASE_URL="https://example.com"
 ```
 
 ### Synchronous Example


### PR DESCRIPTION
💡 **What:** Added `IMEDNET_BASE_URL` to the `README.md` Quick Start bash example.
🎯 **Why:** The codebase and `.env.example` support `IMEDNET_BASE_URL` to point to different API environments, but it was missing from the Quick Start block.
🧠 **Cognitive Impact:** Helps developers immediately understand how to connect the SDK to non-default environments without having to dig through the config codebase or secondary documentation pages.
📖 **Preview:**
```bash
export IMEDNET_API_KEY="your_api_key"
export IMEDNET_SECURITY_KEY="your_security_key"
# Optional: Custom base URL for the API endpoint
# export IMEDNET_BASE_URL="https://example.com"
```

---
*PR created automatically by Jules for task [5546643260279601976](https://jules.google.com/task/5546643260279601976) started by @fderuiter*