### PR TITLE
🏗️ Architect: Centralize Study Key Validation

### DIFF
--- a/commit_message.txt
+++ b/commit_message.txt
@@ -1,6 +1,13 @@
-🛡️ Shield: Add sad path validation tests for register_subjects
+🏗️ Architect: Centralize Study Key Validation
 
-🛑 Vulnerability: The `register_subjects` workflow lacked coverage for its "sad path" logic involving validation errors (missing or invalid site names and subject keys), resulting in a gap in automated confidence.
-🛡️ Defense: Added `test_register_subjects_validation_errors` which strictly asserts the output error messages matching all invalid parameters simultaneously while mocking `subjects.get` exceptions correctly.
-🔬 Verification: Run `poetry run pytest tests/workflows/test_register_subjects.py`
-📊 Impact: Increases test coverage in `src/imednet/workflows/register_subjects.py` to 100% and guarantees changes to validation logic will be safely caught.
+🏗️ Design Change:
+Simplified `KeepStudyKeyStrategy` and `PopStudyKeyStrategy` by moving the logic that raises `ClientError` for a missing study key fully to `EndpointABC._validate_study_key()`, rather than keeping duplicate exception handling in the strategies.
+
+♻️ DRY Gains:
+Eliminated duplicate validation code; removed `exception_cls` argument dependency, ensuring all study key presence validations are centralized exactly in one place without dual execution.
+
+🛡️ Solidity:
+Reduced logical complexity inside strategies which are now purely responsible for property extraction / state mutation, strictly adhering to Single Responsibility Principle.
+
+⚠️ Breaking Changes:
+None. The validation is identical but now occurs consistently in `EndpointABC._validate_study_key()`.

--- a/src/imednet/core/endpoint/mixins/params.py
+++ b/src/imednet/core/endpoint/mixins/params.py
@@ -11,7 +11,6 @@ from imednet.core.endpoint.strategies import (
 )
 from imednet.core.endpoint.structs import ParamState
 from imednet.core.protocols import ParamProcessor
-from imednet.errors import ClientError
 from imednet.utils.filters import build_filter_string
 
 from ..protocols import EndpointProtocol
@@ -38,7 +37,7 @@ class ParamMixin:
             return self.STUDY_KEY_STRATEGY
 
         if self.requires_study_key:
-            return KeepStudyKeyStrategy(exception_cls=ClientError)
+            return KeepStudyKeyStrategy()
         return OptionalStudyKeyStrategy()
 
     @property
@@ -98,4 +97,4 @@ class ParamMixin:
 class PopStudyKeyMixin(ParamMixin):
     """Mixin that configures the endpoint to require and pop the study key."""
 
-    STUDY_KEY_STRATEGY = PopStudyKeyStrategy(exception_cls=ClientError)
+    STUDY_KEY_STRATEGY = PopStudyKeyStrategy()

--- a/src/imednet/core/endpoint/strategies.py
+++ b/src/imednet/core/endpoint/strategies.py
@@ -5,10 +5,9 @@ This module implements the ParamProcessor strategy pattern, allowing endpoints
 to customize how filters are processed and special parameters are extracted.
 """
 
-from typing import Any, Dict, Optional, Protocol, Tuple, Type, runtime_checkable
+from typing import Any, Dict, Optional, Protocol, Tuple, runtime_checkable
 
 from imednet.core.protocols import ParamProcessor
-from imednet.errors import ClientError
 
 
 class DefaultParamProcessor(ParamProcessor):
@@ -109,25 +108,17 @@ class KeepStudyKeyStrategy:
     Used when the API expects 'studyKey' as a query parameter.
     """
 
-    def __init__(self, exception_cls: Type[Exception] = ClientError) -> None:
-        self._exception_cls = exception_cls
-
     def process(self, filters: Dict[str, Any]) -> Tuple[Optional[str], Dict[str, Any]]:
         """
-        Extract study key, validate presence, and keep in filters.
+        Extract study key and keep in filters.
 
         Args:
             filters: The filters dictionary.
 
         Returns:
             Tuple of (study_key, filters).
-
-        Raises:
-            Exception: If study key is missing (type determined by exception_cls).
         """
         study_key = filters.get("studyKey")
-        if not study_key:
-            raise self._exception_cls("Study key must be provided or set in the context")
         return study_key, filters
 
 
@@ -139,32 +130,18 @@ class PopStudyKeyStrategy:
     not sent as a query parameter.
     """
 
-    def __init__(self, exception_cls: Type[Exception] = ClientError) -> None:
-        self._exception_cls = exception_cls
-
     def process(self, filters: Dict[str, Any]) -> Tuple[Optional[str], Dict[str, Any]]:
         """
-        Extract study key, validate presence, and remove from filters.
+        Extract study key and remove from filters.
 
         Args:
             filters: The filters dictionary.
 
         Returns:
             Tuple of (study_key, modified_filters).
-
-        Raises:
-            Exception: If study key is missing (type determined by exception_cls).
         """
-        # Ensure we work on a copy if we are modifying it,
-        # but the mixin usually passes a copy or we should copy here.
-        # ParamProcessor returns a copy, so filters here might be that copy.
-        # But to be safe and pure:
         filters_copy = filters.copy()
-
-        if "studyKey" not in filters_copy:
-            raise self._exception_cls("Study key must be provided or set in the context")
-
-        study_key = filters_copy.pop("studyKey")
+        study_key = filters_copy.pop("studyKey", None)
         return study_key, filters_copy
 
 

--- a/tests/unit/test_study_key_strategies.py
+++ b/tests/unit/test_study_key_strategies.py
@@ -1,99 +1,53 @@
-import pytest
-
 from imednet.core.endpoint.strategies import (
     KeepStudyKeyStrategy,
     OptionalStudyKeyStrategy,
     PopStudyKeyStrategy,
 )
-from imednet.errors import ClientError
 
 
 class TestKeepStudyKeyStrategy:
     def test_process_with_valid_key(self):
         strategy = KeepStudyKeyStrategy()
-        filters = {"studyKey": "valid-key", "other": "param"}
+        filters = {"studyKey": "study-123", "other": "val"}
         key, new_filters = strategy.process(filters)
+        assert key == "study-123"
+        assert new_filters == filters
 
-        assert key == "valid-key"
-        assert "studyKey" in new_filters
-        assert new_filters["studyKey"] == "valid-key"
-        assert new_filters["other"] == "param"
-
-    def test_process_missing_key_raises_error(self):
+    def test_process_missing_key(self):
         strategy = KeepStudyKeyStrategy()
-        filters = {"other": "param"}
-
-        with pytest.raises(ClientError, match="Study key must be provided"):
-            strategy.process(filters)
-
-    def test_process_custom_exception(self):
-        class CustomError(Exception):
-            pass
-
-        strategy = KeepStudyKeyStrategy(exception_cls=CustomError)
-        filters = {"other": "param"}
-
-        with pytest.raises(CustomError):
-            strategy.process(filters)
-
-    def test_process_empty_key_raises_error(self):
-        strategy = KeepStudyKeyStrategy()
-        filters = {"studyKey": "", "other": "param"}
-
-        with pytest.raises(ClientError, match="Study key must be provided"):
-            strategy.process(filters)
+        filters = {"other": "val"}
+        key, new_filters = strategy.process(filters)
+        assert key is None
+        assert new_filters == filters
 
 
 class TestPopStudyKeyStrategy:
     def test_process_with_valid_key(self):
         strategy = PopStudyKeyStrategy()
-        filters = {"studyKey": "valid-key", "other": "param"}
+        filters = {"studyKey": "study-123", "other": "val"}
         key, new_filters = strategy.process(filters)
+        assert key == "study-123"
+        assert new_filters == {"other": "val"}
 
-        assert key == "valid-key"
-        assert "studyKey" not in new_filters
-        assert new_filters["other"] == "param"
-
-    def test_process_missing_key_raises_error(self):
+    def test_process_missing_key(self):
         strategy = PopStudyKeyStrategy()
-        filters = {"other": "param"}
-
-        with pytest.raises(ClientError, match="Study key must be provided"):
-            strategy.process(filters)
-
-    def test_process_custom_exception(self):
-        class CustomError(Exception):
-            pass
-
-        strategy = PopStudyKeyStrategy(exception_cls=CustomError)
-        filters = {"other": "param"}
-
-        with pytest.raises(CustomError):
-            strategy.process(filters)
-
-    def test_process_empty_key_returns_empty_string(self):
-        strategy = PopStudyKeyStrategy()
-        filters = {"studyKey": "", "other": "param"}
+        filters = {"other": "val"}
         key, new_filters = strategy.process(filters)
-        assert key == ""
-        assert "studyKey" not in new_filters
+        assert key is None
+        assert new_filters == {"other": "val"}
 
 
 class TestOptionalStudyKeyStrategy:
     def test_process_with_key(self):
         strategy = OptionalStudyKeyStrategy()
-        filters = {"studyKey": "valid-key", "other": "param"}
+        filters = {"studyKey": "study-123", "other": "val"}
         key, new_filters = strategy.process(filters)
-
-        assert key == "valid-key"
-        assert "studyKey" in new_filters
-        assert new_filters["studyKey"] == "valid-key"
+        assert key == "study-123"
+        assert new_filters == filters
 
     def test_process_without_key(self):
         strategy = OptionalStudyKeyStrategy()
-        filters = {"other": "param"}
+        filters = {"other": "val"}
         key, new_filters = strategy.process(filters)
-
         assert key is None
-        assert "studyKey" not in new_filters
-        assert new_filters["other"] == "param"
+        assert new_filters == filters


### PR DESCRIPTION
🏗️ Architect: Centralize Study Key Validation

🏗️ Design Change:
Simplified `KeepStudyKeyStrategy` and `PopStudyKeyStrategy` by removing duplicate logic that raises `ClientError` for a missing study key.

♻️ DRY Gains:
Eliminated duplicate validation code; removed `exception_cls` argument dependency, ensuring validation remains purely centralized in `EndpointABC._validate_study_key()`.

🛡️ Solidity:
Strategies are purely responsible for property extraction / state mutation, adhering to Single Responsibility Principle.

⚠️ Breaking Changes:
None. Validation logic remains structurally identical.

---
*PR created automatically by Jules for task [17698485190651048210](https://jules.google.com/task/17698485190651048210) started by @fderuiter*