### PR TITLE
🖋️ Scribe: Explicitly document .env creation in quickstart guides

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,14 @@ pip install git+https://github.com/fderuiter/imednet-python-sdk.git@main
 
 ## Quick Start
 
-Set your credentials as environment variables before running the examples:
+Set your credentials before running the examples. You can use a `.env` file:
+
+```bash
+cp .env.example .env
+# Edit .env with your keys
+```
+
+Or export them directly:
 
 ```bash
 export IMEDNET_API_KEY="your_api_key"

--- a/docs/quick_start.rst
+++ b/docs/quick_start.rst
@@ -9,7 +9,14 @@ Install the package from PyPI:
 
    pip install imednet
 
-Set your credentials as environment variables (see :doc:`configuration` for details):
+Set your credentials before running the examples (see :doc:`configuration` for details). You can use a `.env` file:
+
+.. code-block:: bash
+
+   cp .env.example .env
+   # Edit .env with your keys
+
+Or export them directly:
 
 .. code-block:: bash
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -5,7 +5,14 @@ This directory contains examples demonstrating how to use the iMednet Python SDK
 ## Prerequisites
 
 Before running the examples, you need to set up your environment with your iMednet API credentials.
-Set your credentials as environment variables in your shell:
+You can use a `.env` file:
+
+```bash
+cp .env.example .env
+# Edit .env with your keys
+```
+
+Or export them directly:
 
 ```bash
 export IMEDNET_API_KEY="your_api_key_here"


### PR DESCRIPTION
💡 **What:** Added explicit instructions to copy `.env.example` to `.env` in `README.md`, `docs/quick_start.rst`, and `examples/README.md` before the quickstart Python code snippets.
🎯 **Why:** The Python snippets all use `load_dotenv()`. Users who follow the previous instructions ("Set your credentials as environment variables... `export IMEDNET_API_KEY=...`") may skip or forget the export and then run the Python code directly. Since no `.env` file exists, `load_dotenv()` silently passes, and `load_config()` raises `ValueError: API key and security key are required`, breaking the onboarding path.
🧠 **Cognitive Impact:** Reduces confusion by providing the `cp .env.example .env` option first, ensuring the code snippets using `load_dotenv()` work flawlessly.
📖 **Preview:**
Set your credentials before running the examples. You can use a `.env` file:
```bash
cp .env.example .env
# Edit .env with your keys
```

---
*PR created automatically by Jules for task [367070173987299508](https://jules.google.com/task/367070173987299508) started by @fderuiter*