### PR TITLE
🛡️ Shield: Add sad path tests for missing optional dependencies

### DIFF
--- a/tests/unit/test_record_mapper.py
+++ b/tests/unit/test_record_mapper.py
@@ -2,6 +2,7 @@ from datetime import datetime
 from typing import Any
 from unittest.mock import MagicMock
 
+import pytest
 from pydantic import BaseModel, ValidationError
 
 from imednet.models.records import Record
@@ -229,3 +230,10 @@ def test_parse_records_counts_errors() -> None:
 
     assert rows == []
     assert count == 2
+
+
+def test_dataframe_raises_importerror_when_pandas_missing(monkeypatch) -> None:
+    monkeypatch.setattr("imednet.workflows.record_mapper.pd", None)
+    mapper = RecordMapper(MagicMock())
+    with pytest.raises(ImportError, match="pandas is required for RecordMapper.dataframe"):
+        mapper.dataframe("STUDY")

--- a/tests/unit/test_utils_pandas.py
+++ b/tests/unit/test_utils_pandas.py
@@ -2,6 +2,7 @@ import ast
 from unittest.mock import MagicMock
 
 import pandas as pd
+import pytest
 
 from imednet.models.records import Record
 from imednet.utils.pandas import export_records_csv, records_to_dataframe
@@ -62,3 +63,15 @@ def test_export_records_csv_no_flatten(tmp_path) -> None:
     assert "record_data" in df.columns
     assert ast.literal_eval(str(df.loc[0, "record_data"])) == {"AGE": 30}
     sdk.records.list.assert_called_once_with(study_key="STUDY")
+
+
+def test_records_to_dataframe_raises_importerror_when_pandas_missing(monkeypatch):
+    monkeypatch.setattr("imednet.utils.pandas.pd", None)
+    with pytest.raises(ImportError, match="pandas is required for records_to_dataframe"):
+        records_to_dataframe([])
+
+
+def test_export_records_csv_raises_importerror_when_pandas_missing(monkeypatch):
+    monkeypatch.setattr("imednet.utils.pandas.pd", None)
+    with pytest.raises(ImportError, match="pandas is required for export_records_csv"):
+        export_records_csv(None, "STUDY", "path.csv")


### PR DESCRIPTION
🛑 **Vulnerability:** Several utility functions (`records_to_dataframe`, `export_records_csv`, `RecordMapper.dataframe`) handle missing `pandas` installations by raising an `ImportError`. These "sad paths" were completely untested, leaving room for regressions where error messages could change or fallbacks break silently.
🛡️ **Defense:** Added robust unit tests to verify the expected `ImportError` is raised when `pandas` is not installed. Used `monkeypatch` to simulate `pd = None` gracefully without polluting global module state.
🔬 **Verification:** Run `poetry run pytest tests/unit/test_utils_pandas.py tests/unit/test_record_mapper.py` to see the new tests pass. Coverage for `src/imednet/utils/pandas.py` and `src/imednet/workflows/record_mapper.py` is now improved.
📊 **Impact:** Increases test coverage and guarantees consistent failure states for end-users running the SDK without the `[pandas]` extra installed.

---
*PR created automatically by Jules for task [10154131835472415504](https://jules.google.com/task/10154131835472415504) started by @fderuiter*