### PR TITLE
✍️ Scribe: explicit .env setup in Quick Start docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,9 +87,13 @@ pip install git+https://github.com/fderuiter/imednet-python-sdk.git@main
 
 ## Quick Start
 
-Set your credentials as environment variables before running the examples:
+Set your credentials by copying the environment template or exporting them directly:
 
 ```bash
+# Option 1: Use a .env file (recommended)
+cp .env.example .env
+
+# Option 2: Export directly to your shell
 export IMEDNET_API_KEY="your_api_key"
 export IMEDNET_SECURITY_KEY="your_security_key"
 # Optional: Custom base URL for the API endpoint

--- a/docs/async_quick_start.rst
+++ b/docs/async_quick_start.rst
@@ -9,10 +9,14 @@ Install the package from PyPI:
 
    pip install imednet
 
-Set your credentials as environment variables:
+Set your credentials by copying the environment template or exporting them directly:
 
 .. code-block:: bash
 
+   # Option 1: Use a .env file (recommended)
+   cp .env.example .env
+
+   # Option 2: Export directly to your shell
    export IMEDNET_API_KEY="your_api_key"
    export IMEDNET_SECURITY_KEY="your_security_key"
 

--- a/docs/quick_start.rst
+++ b/docs/quick_start.rst
@@ -9,10 +9,14 @@ Install the package from PyPI:
 
    pip install imednet
 
-Set your credentials as environment variables (see :doc:`configuration` for details):
+Set your credentials by copying the environment template or exporting them directly (see :doc:`configuration` for details):
 
 .. code-block:: bash
 
+   # Option 1: Use a .env file (recommended)
+   cp .env.example .env
+
+   # Option 2: Export directly to your shell
    export IMEDNET_API_KEY="your_api_key"
    export IMEDNET_SECURITY_KEY="your_security_key"
 


### PR DESCRIPTION
💡 **What:** Added an explicit `cp .env.example .env` step to the Quick Start sections in `README.md`, `docs/quick_start.rst`, and `docs/async_quick_start.rst`.
🎯 **Why:** `dotenv.load_dotenv()` silently fails if the `.env` file does not exist. If users skip creating it, the examples crash with missing credential errors, breaking the onboarding path.
🧠 **Cognitive Impact:** Reduces confusion and debugging time for new users by providing a clear, copy-pasteable step to set up their local environment correctly before running the first lines of code.
📖 **Preview:**
```bash
# Option 1: Use a .env file (recommended)
cp .env.example .env

# Option 2: Export directly to your shell
export IMEDNET_API_KEY="your_api_key"
export IMEDNET_SECURITY_KEY="your_security_key"
```

---
*PR created automatically by Jules for task [8660993769691544048](https://jules.google.com/task/8660993769691544048) started by @fderuiter*