### PR TITLE
🛡️ Shield: [test improvement/fix]

### DIFF
--- a/tests/unit/test_utils_pandas.py
+++ b/tests/unit/test_utils_pandas.py
@@ -2,6 +2,7 @@ import ast
 from unittest.mock import MagicMock
 
 import pandas as pd
+import pytest
 
 from imednet.models.records import Record
 from imednet.utils.pandas import export_records_csv, records_to_dataframe
@@ -62,3 +63,15 @@ def test_export_records_csv_no_flatten(tmp_path) -> None:
     assert "record_data" in df.columns
     assert ast.literal_eval(str(df.loc[0, "record_data"])) == {"AGE": 30}
     sdk.records.list.assert_called_once_with(study_key="STUDY")
+
+
+def test_records_to_dataframe_import_error(monkeypatch) -> None:
+    monkeypatch.setattr("imednet.utils.pandas.pd", None)
+    with pytest.raises(ImportError, match="pandas is required for records_to_dataframe"):
+        records_to_dataframe([])
+
+
+def test_export_records_csv_import_error(monkeypatch) -> None:
+    monkeypatch.setattr("imednet.utils.pandas.pd", None)
+    with pytest.raises(ImportError, match="pandas is required for export_records_csv"):
+        export_records_csv(None, "STUDY", "out.csv")


### PR DESCRIPTION
🛑 Vulnerability: The `imednet.utils.pandas` module contains fallback error handling for when the `pandas` dependency is not installed, but these paths (lines 27 and 52) were untested because `pandas` is a test dependency.
🛡️ Defense: Added `test_records_to_dataframe_import_error` and `test_export_records_csv_import_error` using `pytest`'s `monkeypatch` to set `imednet.utils.pandas.pd` to `None`, simulating the missing dependency and ensuring the `ImportError` is correctly raised.
🔬 Verification: Run `poetry run pytest tests/unit/test_utils_pandas.py`
📊 Impact: Increases test coverage of `src/imednet/utils/pandas.py` to 100% and guarantees expected error behavior in network-restricted or minimal environments.

---
*PR created automatically by Jules for task [269326538898561288](https://jules.google.com/task/269326538898561288) started by @fderuiter*