### PR TITLE
🏗️ Architect: Extract `JobPoller` logic to separate Synchronous and Asynchronous classes

### DIFF
--- a/src/imednet/sdk_convenience.py
+++ b/src/imednet/sdk_convenience.py
@@ -21,7 +21,7 @@ from imednet.models.subjects import Subject
 from imednet.models.users import User
 from imednet.models.variables import Variable
 from imednet.models.visits import Visit
-from imednet.workflows.job_poller import JobPoller
+from imednet.workflows.job_poller import AsyncJobPoller, JobPoller
 
 if TYPE_CHECKING:
     from imednet.endpoints.codings import CodingsEndpoint
@@ -225,7 +225,7 @@ class SDKConvenienceMixin:
     ) -> JobStatus:
         """Poll a job until it reaches a terminal state."""
 
-        return JobPoller(self.jobs.get, False).run(study_key, batch_id, interval, timeout)
+        return JobPoller(self.jobs.get).run(study_key, batch_id, interval, timeout)
 
     async def async_poll_job(
         self: SDKProtocol,
@@ -237,6 +237,4 @@ class SDKConvenienceMixin:
     ) -> JobStatus:
         """Asynchronously poll a job until it reaches a terminal state."""
 
-        return await JobPoller(self.jobs.async_get, True).run_async(
-            study_key, batch_id, interval, timeout
-        )
+        return await AsyncJobPoller(self.jobs.async_get).run(study_key, batch_id, interval, timeout)

--- a/src/imednet/workflows/__init__.py
+++ b/src/imednet/workflows/__init__.py
@@ -1,6 +1,6 @@
 """Workflow helpers built on top of the iMednet SDK."""
 
-from .job_poller import JobPoller, JobTimeoutError
+from .job_poller import AsyncJobPoller, JobPoller, JobTimeoutError
 from .query_management import QueryManagementWorkflow
 from .record_mapper import RecordMapper
 from .record_update import RecordUpdateWorkflow
@@ -12,6 +12,7 @@ __all__ = [
     "QueryManagementWorkflow",
     "RecordMapper",
     "RecordUpdateWorkflow",
+    "AsyncJobPoller",
     "JobPoller",
     "JobTimeoutError",
     "RegisterSubjectsWorkflow",

--- a/src/imednet/workflows/job_poller.py
+++ b/src/imednet/workflows/job_poller.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import time
-from typing import Any, Callable, cast
+from typing import Awaitable, Callable
 
 from ..constants import TERMINAL_JOB_STATES
 from ..models import JobStatus
@@ -14,16 +14,8 @@ class JobTimeoutError(TimeoutError):
     """Raised when a job does not finish before the timeout."""
 
 
-class JobPoller:
-    """Poll a job until it reaches a terminal state."""
-
-    def __init__(
-        self,
-        get_job: Callable[[str, str], Any],
-        is_async: bool,
-    ) -> None:
-        self._get_job = get_job
-        self._async = is_async
+class BaseJobPoller:
+    """Base class for polling a job until it reaches a terminal state."""
 
     def _check_complete(self, status: JobStatus, batch_id: str) -> JobStatus:
         if status.state.upper() in TERMINAL_JOB_STATES:
@@ -36,18 +28,22 @@ class JobPoller:
         if time.monotonic() - start_time >= timeout:
             raise JobTimeoutError(f"Timeout ({timeout}s) waiting for job {batch_id}")
 
-    def _poll_sync(
-        self,
-        study_key: str,
-        batch_id: str,
-        interval: int,
-        timeout: int,
+
+class JobPoller(BaseJobPoller):
+    """Synchronously poll a job until completion."""
+
+    def __init__(self, get_job: Callable[[str, str], JobStatus]) -> None:
+        self._get_job = get_job
+
+    def run(
+        self, study_key: str, batch_id: str, interval: int = 5, timeout: int = 300
     ) -> JobStatus:
+        """Synchronously poll a job until completion."""
         start = time.monotonic()
 
         while True:
             result = self._get_job(study_key, batch_id)
-            status = self._check_complete(cast(JobStatus, result), batch_id)
+            status = self._check_complete(result, batch_id)
 
             if status.state.upper() in TERMINAL_JOB_STATES:
                 return status
@@ -55,41 +51,25 @@ class JobPoller:
             self._check_timeout(start, timeout, batch_id)
             time.sleep(interval)
 
-    async def _poll_async(
-        self,
-        study_key: str,
-        batch_id: str,
-        interval: int,
-        timeout: int,
+
+class AsyncJobPoller(BaseJobPoller):
+    """Asynchronously poll a job until completion."""
+
+    def __init__(self, get_job: Callable[[str, str], Awaitable[JobStatus]]) -> None:
+        self._get_job = get_job
+
+    async def run(
+        self, study_key: str, batch_id: str, interval: int = 5, timeout: int = 300
     ) -> JobStatus:
+        """Asynchronously poll a job until completion."""
         start = time.monotonic()
 
         while True:
             result = await self._get_job(study_key, batch_id)
-            status = self._check_complete(cast(JobStatus, result), batch_id)
+            status = self._check_complete(result, batch_id)
 
             if status.state.upper() in TERMINAL_JOB_STATES:
                 return status
 
             self._check_timeout(start, timeout, batch_id)
             await asyncio.sleep(interval)
-
-    def run(
-        self, study_key: str, batch_id: str, interval: int = 5, timeout: int = 300
-    ) -> JobStatus:
-        """Synchronously poll a job until completion."""
-
-        if self._async:
-            raise RuntimeError("Use run_async for asynchronous polling")
-
-        return self._poll_sync(study_key, batch_id, interval, timeout)
-
-    async def run_async(
-        self, study_key: str, batch_id: str, interval: int = 5, timeout: int = 300
-    ) -> JobStatus:
-        """Asynchronously poll a job until completion."""
-
-        if not self._async:
-            raise RuntimeError("Use run for synchronous polling")
-
-        return await self._poll_async(study_key, batch_id, interval, timeout)

--- a/src/imednet/workflows/record_update.py
+++ b/src/imednet/workflows/record_update.py
@@ -5,7 +5,7 @@ from typing import TYPE_CHECKING, Any, Dict, List, Literal, Union, cast
 
 from ..models import Job
 from ..validation.cache import AsyncSchemaValidator, SchemaCache, SchemaValidator
-from .job_poller import JobPoller
+from .job_poller import AsyncJobPoller, JobPoller
 
 if TYPE_CHECKING:
     from ..sdk import ImednetSDK
@@ -75,7 +75,7 @@ class RecordUpdateWorkflow:
         if not job.batch_id:
             raise ValueError("Submission successful but no batch_id received.")
 
-        poller = JobPoller(self._sdk.jobs.get, is_async=False)
+        poller = JobPoller(self._sdk.jobs.get)
         return poller.run(study_key, job.batch_id, poll_interval, timeout)
 
     async def async_create_or_update_records(
@@ -97,8 +97,8 @@ class RecordUpdateWorkflow:
         if not job.batch_id:
             raise ValueError("Submission successful but no batch_id received.")
 
-        poller = JobPoller(self._sdk.jobs.async_get, is_async=True)
-        return await poller.run_async(study_key, job.batch_id, poll_interval, timeout)
+        poller = AsyncJobPoller(self._sdk.jobs.async_get)
+        return await poller.run(study_key, job.batch_id, poll_interval, timeout)
 
     def submit_record_batch(self, *args: Any, **kwargs: Any) -> Job:  # pragma: no cover
         warnings.warn(

--- a/tests/unit/test_job_poller.py
+++ b/tests/unit/test_job_poller.py
@@ -4,39 +4,39 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 
 from imednet.models.jobs import JobStatus
-from imednet.workflows.job_poller import JobPoller, JobTimeoutError
+from imednet.workflows.job_poller import AsyncJobPoller, JobPoller, JobTimeoutError
 
 
-@pytest.mark.parametrize("async_mode", [False, True])
-def test_job_poller_success(async_mode: bool, monkeypatch: pytest.MonkeyPatch) -> None:
+def test_job_poller_success(monkeypatch: pytest.MonkeyPatch) -> None:
     states = [
-        JobStatus(batch_id="1", state="PROCESSING", progress=10),
-        JobStatus(batch_id="1", state="COMPLETED", progress=100),
+        JobStatus(batchId="1", state="PROCESSING", progress=10, jobId="1", resultUrl=""),
+        JobStatus(batchId="1", state="COMPLETED", progress=100, jobId="1", resultUrl=""),
     ]
-    if async_mode:
-        get_job = AsyncMock(side_effect=lambda s, b: states.pop(0))
-        monkeypatch.setattr(asyncio, "sleep", AsyncMock())
-        poller = JobPoller(get_job, True)
-        result = asyncio.run(poller.run_async("ST", "1", interval=0, timeout=5))
-    else:
-        get_job = MagicMock(side_effect=lambda s, b: states.pop(0))
-        monkeypatch.setattr("time.sleep", lambda *_: None)
-        poller = JobPoller(get_job, False)
-        result = poller.run("ST", "1", interval=0, timeout=5)
+    get_job = MagicMock(side_effect=lambda s, b: states.pop(0))
+    monkeypatch.setattr("time.sleep", lambda *_: None)
+    poller = JobPoller(get_job)
+    result = poller.run("ST", "1", interval=0, timeout=5)
     assert result.state == "COMPLETED"
 
 
-@pytest.mark.parametrize("async_mode", [False, True])
-def test_job_poller_timeout(async_mode: bool, monkeypatch: pytest.MonkeyPatch) -> None:
-    job = JobStatus(batch_id="1", state="PROCESSING")
-    if async_mode:
-        get_job = AsyncMock(return_value=job)
-        monkeypatch.setattr(asyncio, "sleep", AsyncMock())
-        poller = JobPoller(get_job, True)
-    else:
-        get_job = MagicMock(return_value=job)
-        monkeypatch.setattr("time.sleep", lambda *_: None)
-        poller = JobPoller(get_job, False)
+@pytest.mark.asyncio
+async def test_async_job_poller_success(monkeypatch: pytest.MonkeyPatch) -> None:
+    states = [
+        JobStatus(batchId="1", state="PROCESSING", progress=10, jobId="1", resultUrl=""),
+        JobStatus(batchId="1", state="COMPLETED", progress=100, jobId="1", resultUrl=""),
+    ]
+    get_job = AsyncMock(side_effect=lambda s, b: states.pop(0))
+    monkeypatch.setattr(asyncio, "sleep", AsyncMock())
+    poller = AsyncJobPoller(get_job)
+    result = await poller.run("ST", "1", interval=0, timeout=5)
+    assert result.state == "COMPLETED"
+
+
+def test_job_poller_timeout(monkeypatch: pytest.MonkeyPatch) -> None:
+    job = JobStatus(batchId="1", state="PROCESSING", progress=10, jobId="1", resultUrl="")
+    get_job = MagicMock(return_value=job)
+    monkeypatch.setattr("time.sleep", lambda *_: None)
+    poller = JobPoller(get_job)
 
     tick = {"v": 0}
 
@@ -46,62 +46,74 @@ def test_job_poller_timeout(async_mode: bool, monkeypatch: pytest.MonkeyPatch) -
 
     monkeypatch.setattr("time.monotonic", monotonic)
     with pytest.raises(JobTimeoutError):
-        if async_mode:
-            asyncio.run(poller.run_async("S", "1", interval=0, timeout=2))
-        else:
-            poller.run("S", "1", interval=0, timeout=2)
+        poller.run("S", "1", interval=0, timeout=2)
 
 
-@pytest.mark.parametrize("async_mode", [False, True])
-def test_job_poller_failed(async_mode: bool, monkeypatch: pytest.MonkeyPatch) -> None:
+@pytest.mark.asyncio
+async def test_async_job_poller_timeout(monkeypatch: pytest.MonkeyPatch) -> None:
+    job = JobStatus(batchId="1", state="PROCESSING", progress=10, jobId="1", resultUrl="")
+    get_job = AsyncMock(return_value=job)
+    monkeypatch.setattr(asyncio, "sleep", AsyncMock())
+    poller = AsyncJobPoller(get_job)
+
+    tick = {"v": 0}
+
+    def monotonic() -> int:
+        tick["v"] += 1
+        return tick["v"]
+
+    monkeypatch.setattr("time.monotonic", monotonic)
+    with pytest.raises(JobTimeoutError):
+        await poller.run("S", "1", interval=0, timeout=2)
+
+
+def test_job_poller_failed(monkeypatch: pytest.MonkeyPatch) -> None:
     states = [
-        JobStatus(batch_id="1", state="PROCESSING"),
-        JobStatus(batch_id="1", state="FAILED"),
+        JobStatus(batchId="1", state="PROCESSING", progress=10, jobId="1", resultUrl=""),
+        JobStatus(batchId="1", state="FAILED", progress=10, jobId="1", resultUrl=""),
     ]
-    if async_mode:
-        get_job = AsyncMock(side_effect=lambda s, b: states.pop(0))
-        monkeypatch.setattr(asyncio, "sleep", AsyncMock())
-        poller = JobPoller(get_job, True)
-    else:
-        get_job = MagicMock(side_effect=lambda s, b: states.pop(0))
-        monkeypatch.setattr("time.sleep", lambda *_: None)
-        poller = JobPoller(get_job, False)
+    get_job = MagicMock(side_effect=lambda s, b: states.pop(0))
+    monkeypatch.setattr("time.sleep", lambda *_: None)
+    poller = JobPoller(get_job)
 
     with pytest.raises(RuntimeError):
-        if async_mode:
-            asyncio.run(poller.run_async("S", "1", interval=0, timeout=5))
-        else:
-            poller.run("S", "1", interval=0, timeout=5)
-
-
-def test_job_poller_run_sync_in_async_mode() -> None:
-    get_job = AsyncMock()
-    poller = JobPoller(get_job, True)
-    with pytest.raises(RuntimeError, match="Use run_async for asynchronous polling"):
         poller.run("S", "1", interval=0, timeout=5)
 
 
-def test_job_poller_run_async_in_sync_mode() -> None:
-    get_job = MagicMock()
-    poller = JobPoller(get_job, False)
-    with pytest.raises(RuntimeError, match="Use run for synchronous polling"):
-        asyncio.run(poller.run_async("S", "1", interval=0, timeout=5))
-
-
-@pytest.mark.parametrize("async_mode", [False, True])
-def test_job_poller_cancelled(async_mode: bool, monkeypatch: pytest.MonkeyPatch) -> None:
+@pytest.mark.asyncio
+async def test_async_job_poller_failed(monkeypatch: pytest.MonkeyPatch) -> None:
     states = [
-        JobStatus(batch_id="1", state="PROCESSING", progress=50),
-        JobStatus(batch_id="1", state="CANCELLED", progress=50),
+        JobStatus(batchId="1", state="PROCESSING", progress=10, jobId="1", resultUrl=""),
+        JobStatus(batchId="1", state="FAILED", progress=10, jobId="1", resultUrl=""),
     ]
-    if async_mode:
-        get_job = AsyncMock(side_effect=lambda s, b: states.pop(0))
-        monkeypatch.setattr(asyncio, "sleep", AsyncMock())
-        poller = JobPoller(get_job, True)
-        result = asyncio.run(poller.run_async("ST", "1", interval=0, timeout=5))
-    else:
-        get_job = MagicMock(side_effect=lambda s, b: states.pop(0))
-        monkeypatch.setattr("time.sleep", lambda *_: None)
-        poller = JobPoller(get_job, False)
-        result = poller.run("ST", "1", interval=0, timeout=5)
+    get_job = AsyncMock(side_effect=lambda s, b: states.pop(0))
+    monkeypatch.setattr(asyncio, "sleep", AsyncMock())
+    poller = AsyncJobPoller(get_job)
+
+    with pytest.raises(RuntimeError):
+        await poller.run("S", "1", interval=0, timeout=5)
+
+
+def test_job_poller_cancelled(monkeypatch: pytest.MonkeyPatch) -> None:
+    states = [
+        JobStatus(batchId="1", state="PROCESSING", progress=50, jobId="1", resultUrl=""),
+        JobStatus(batchId="1", state="CANCELLED", progress=50, jobId="1", resultUrl=""),
+    ]
+    get_job = MagicMock(side_effect=lambda s, b: states.pop(0))
+    monkeypatch.setattr("time.sleep", lambda *_: None)
+    poller = JobPoller(get_job)
+    result = poller.run("ST", "1", interval=0, timeout=5)
+    assert result.state == "CANCELLED"
+
+
+@pytest.mark.asyncio
+async def test_async_job_poller_cancelled(monkeypatch: pytest.MonkeyPatch) -> None:
+    states = [
+        JobStatus(batchId="1", state="PROCESSING", progress=50, jobId="1", resultUrl=""),
+        JobStatus(batchId="1", state="CANCELLED", progress=50, jobId="1", resultUrl=""),
+    ]
+    get_job = AsyncMock(side_effect=lambda s, b: states.pop(0))
+    monkeypatch.setattr(asyncio, "sleep", AsyncMock())
+    poller = AsyncJobPoller(get_job)
+    result = await poller.run("ST", "1", interval=0, timeout=5)
     assert result.state == "CANCELLED"

--- a/tests/unit/test_sdk_convenience_async.py
+++ b/tests/unit/test_sdk_convenience_async.py
@@ -113,17 +113,16 @@ async def test_async_poll_job_convenience(monkeypatch) -> None:
     calls = {}
 
     class FakePoller:
-        def __init__(self, get_func, is_async):
-            calls["init"] = (get_func, is_async)
+        def __init__(self, get_func):
+            calls["init"] = get_func
 
-        async def run_async(self, study_key, batch_id, interval, timeout):
+        async def run(self, study_key, batch_id, interval, timeout):
             calls["run"] = (study_key, batch_id, interval, timeout)
             return "JOBOBJ"
 
     import imednet.sdk_convenience
 
-    monkeypatch.setattr(imednet.sdk_convenience, "JobPoller", FakePoller)
+    monkeypatch.setattr(imednet.sdk_convenience, "AsyncJobPoller", FakePoller)
 
     assert await sdk.async_poll_job("S1", "B1", interval=10, timeout=100) == "JOBOBJ"
     assert calls["run"] == ("S1", "B1", 10, 100)
-    assert calls["init"][1] is True

--- a/tests/unit/test_sdk_entrypoint.py
+++ b/tests/unit/test_sdk_entrypoint.py
@@ -195,8 +195,8 @@ def test_poll_job_convenience_sync(monkeypatch) -> None:
     calls = {}
 
     class FakePoller:
-        def __init__(self, get_func, is_async):
-            calls["init"] = (get_func, is_async)
+        def __init__(self, get_func):
+            calls["init"] = get_func
 
         def run(self, study_key, batch_id, interval, timeout):
             calls["run"] = (study_key, batch_id, interval, timeout)
@@ -208,4 +208,3 @@ def test_poll_job_convenience_sync(monkeypatch) -> None:
 
     assert sdk.poll_job("S1", "B1", interval=10, timeout=100) == "JOBOBJ"
     assert calls["run"] == ("S1", "B1", 10, 100)
-    assert calls["init"][1] is False


### PR DESCRIPTION
## 🏗️ Design Change:
Refactored `JobPoller` to eliminate the implicit runtime parameter `is_async` which raised RuntimeErrors conditionally. Shared core logic extracted into `BaseJobPoller`.

## ♻️ DRY Gains:
Eliminated the branching `is_async` condition in workflow layers and SDK convenience wrappers. Tests now cleanly test either strictly synchronous or purely asynchronous polling behavior.

## 🛡️ Solidity:
Replaced the `Any` typing on the generic callable `get_job` with the correctly typed return types: `JobStatus` for Sync and `Awaitable[JobStatus]` for Async polling methods. Eliminates dynamic class branching based on parameters.

## ⚠️ Breaking Changes:
- Removed `run_async` from `JobPoller`. Asynchronous polling must now be performed by `AsyncJobPoller(func).run()`.
- The `is_async` parameter is no longer supported on initialization.

---
*PR created automatically by Jules for task [4374652698416769487](https://jules.google.com/task/4374652698416769487) started by @fderuiter*