### PR TITLE
🖋️ Scribe: Document .env.example setup in quick start guides

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,9 +87,13 @@ pip install git+https://github.com/fderuiter/imednet-python-sdk.git@main
 
 ## Quick Start
 
-Set your credentials as environment variables before running the examples:
+Set your credentials as environment variables before running the examples. You can use a `.env` file or export them directly:
 
 ```bash
+# Option 1: Use a .env file
+cp .env.example .env
+
+# Option 2: Export directly in your shell
 export IMEDNET_API_KEY="your_api_key"
 export IMEDNET_SECURITY_KEY="your_security_key"
 # Optional: Custom base URL for the API endpoint

--- a/docs/async_quick_start.rst
+++ b/docs/async_quick_start.rst
@@ -9,10 +9,14 @@ Install the package from PyPI:
 
    pip install imednet
 
-Set your credentials as environment variables:
+Set your credentials as environment variables. You can use a ``.env`` file or export them directly:
 
 .. code-block:: bash
 
+   # Option 1: Use a .env file
+   cp .env.example .env
+
+   # Option 2: Export directly in your shell
    export IMEDNET_API_KEY="your_api_key"
    export IMEDNET_SECURITY_KEY="your_security_key"
 

--- a/docs/quick_start.rst
+++ b/docs/quick_start.rst
@@ -9,10 +9,14 @@ Install the package from PyPI:
 
    pip install imednet
 
-Set your credentials as environment variables (see :doc:`configuration` for details):
+Set your credentials as environment variables. You can use a ``.env`` file or export them directly (see :doc:`configuration` for details):
 
 .. code-block:: bash
 
+   # Option 1: Use a .env file
+   cp .env.example .env
+
+   # Option 2: Export directly in your shell
    export IMEDNET_API_KEY="your_api_key"
    export IMEDNET_SECURITY_KEY="your_security_key"
 


### PR DESCRIPTION
💡 **What:** Added explicit instructions to copy `.env.example` to `.env` or export variables directly before running example scripts in `README.md` and the Sphinx quick start guides.

🎯 **Why:** The examples use `dotenv.load_dotenv()`, which silently fails if `.env` does not exist. This results in the SDK throwing `ValueError: API key and security key are required`, confusing new users who might think they followed the instructions correctly.

🧠 **Cognitive Impact:** Fixes a broken onboarding path and prevents first-run crashes for developers who rely on `.env` files for configuration.

📖 **Preview:**
```bash
# Option 1: Use a .env file
cp .env.example .env

# Option 2: Export directly in your shell
export IMEDNET_API_KEY="your_api_key"
export IMEDNET_SECURITY_KEY="your_security_key"
```

---
*PR created automatically by Jules for task [3192173367718125951](https://jules.google.com/task/3192173367718125951) started by @fderuiter*