### PR TITLE
🖋️ Scribe: Document .env setup for quick start examples

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -5,9 +5,13 @@ This directory contains examples demonstrating how to use the iMednet Python SDK
 ## Prerequisites
 
 Before running the examples, you need to set up your environment with your iMednet API credentials.
-Set your credentials as environment variables in your shell:
+Set your credentials by copying the environment template or exporting them directly:
 
 ```bash
+# Option 1: Use a .env file (recommended)
+cp .env.example .env
+
+# Option 2: Export directly to your shell
 export IMEDNET_API_KEY="your_api_key_here"
 export IMEDNET_SECURITY_KEY="your_security_key_here"
 # Optional: Set base URL if using a custom instance

--- a/examples/async_quick_start.py
+++ b/examples/async_quick_start.py
@@ -17,6 +17,8 @@ Provide ``IMEDNET_JOB_STUDY_KEY`` and ``IMEDNET_BATCH_ID`` to poll a job.
 
 Example::
 
+    cp .env.example .env
+    # Or export directly:
     export IMEDNET_API_KEY="your_api_key"
     export IMEDNET_SECURITY_KEY="your_security_key"
     poetry run python examples/async_quick_start.py
@@ -26,8 +28,6 @@ Example::
 async def main() -> None:
     """Run a minimal async SDK example using environment variables."""
     configure_json_logging()
-    load_dotenv()
-
     # Load environment variables from .env file if it exists
     load_dotenv()
 

--- a/examples/build_form_payload.py
+++ b/examples/build_form_payload.py
@@ -3,6 +3,8 @@
 Hybrid Entry Point for iMedNet Form Builder.
 
 Usage:
+  cp .env.example .env
+
   # Headless Mode (CLI)
   poetry run python examples/build_form_payload.py \
       --preset "Demo Form" --form-id 123 --revision 5

--- a/examples/quick_start.py
+++ b/examples/quick_start.py
@@ -14,6 +14,8 @@ script. Optionally set ``IMEDNET_BASE_URL`` for non-default instances.
 
 Example:
 
+    cp .env.example .env
+    # Or export directly:
     export IMEDNET_API_KEY="your_api_key"
     export IMEDNET_SECURITY_KEY="your_security_key"
     poetry run python examples/quick_start.py
@@ -23,8 +25,6 @@ Example:
 def main() -> None:
     """Run a minimal SDK example using environment variables."""
     configure_json_logging()
-    load_dotenv()
-
     # Load environment variables from .env file if it exists
     load_dotenv()
 


### PR DESCRIPTION
💡 **What:** 
Added explicit `cp .env.example .env` instructions to `examples/README.md` and the module docstrings of `examples/quick_start.py`, `examples/async_quick_start.py`, and `examples/build_form_payload.py`. Removed duplicated `load_dotenv()` calls where they existed side-by-side. Also added a journal entry in `.jules/scribe.md`.

🎯 **Why:** 
When new developers run code examples that rely on `dotenv.load_dotenv()`, it fails silently if `.env` does not exist. This leads to confusing `ValueError: API key and security key are required` errors. Explicitly documenting the `cp` step alongside the `export` option fixes this broken path.

🧠 **Cognitive Impact:** 
Fixes first-run crashes for developers using the example scripts. By providing clear copy-paste commands to set up the local environment file, we reduce the time-to-understand and eliminate the "Why isn't my API key being read?" confusion. Removing the duplicated `load_dotenv()` also reduces unnecessary code noise.

📖 **Preview:** 
```python
Example:

    cp .env.example .env
    # Or export directly:
    export IMEDNET_API_KEY="your_api_key"
    export IMEDNET_SECURITY_KEY="your_security_key"
    poetry run python examples/quick_start.py
```

---
*PR created automatically by Jules for task [13490223422099736012](https://jules.google.com/task/13490223422099736012) started by @fderuiter*