### PR TITLE
🖋️ Scribe: Document parse_bool edge cases

### DIFF
--- a/src/imednet/utils/validators.py
+++ b/src/imednet/utils/validators.py
@@ -43,6 +43,18 @@ def parse_bool(v: Any) -> bool:
     """
     Normalize boolean values from various representations.
     Accepts bool, str, int, float and returns a bool.
+
+    Defaults to False for unknown or unparseable types (e.g. None, [], object()).
+    String representations like '1.0', 'inf', and 'nan' are treated as truthy
+    via float fallback.
+
+    Example:
+        >>> parse_bool("yes")
+        True
+        >>> parse_bool("1.0")
+        True
+        >>> parse_bool(None)
+        False
     """
     if isinstance(v, bool):
         return v


### PR DESCRIPTION
💡 **What:** Added a comprehensive docstring with doctest examples to the `parse_bool` utility function in `src/imednet/utils/validators.py`.
🎯 **Why:** The previous docstring was vague ("Accepts bool, str, int, float and returns a bool") and failed to explain critical edge case behaviors, such as how it falls back to `False` for unknown types (e.g., `None`, lists) and treats certain float-like strings (e.g., `'1.0'`) as truthy. This forces developers to read the implementation to understand how it handles unexpected API responses.
🧠 **Cognitive Impact:** Significantly reduces cognitive load and debugging time for developers tracing data normalization issues. By documenting these non-obvious fallbacks and providing concrete examples, developers can instantly understand how `parse_bool` will react to bad data without reading the source.

📖 **Preview:**
```python
    """
    Normalize boolean values from various representations.
    Accepts bool, str, int, float and returns a bool.
    
    Defaults to False for unknown or unparseable types (e.g. None, [], object()).
    String representations like '1.0', 'inf', and 'nan' are treated as truthy 
    via float fallback.
    
    Example:
        >>> parse_bool("yes")
        True
        >>> parse_bool("1.0")
        True
        >>> parse_bool(None)
        False
    """
```

---
*PR created automatically by Jules for task [12797019412724851936](https://jules.google.com/task/12797019412724851936) started by @fderuiter*