### PR TITLE
🔒 [Shield] Fix CSV injection bypass in lists

### DIFF
--- a/src/imednet/utils/security.py
+++ b/src/imednet/utils/security.py
@@ -12,9 +12,14 @@ def sanitize_csv_formula(value: Any) -> Any:
     Sanitize a value to prevent CSV/Excel Formula Injection.
 
     Prefixes strings starting with =, +, -, or @ (even after whitespace) with a single quote.
+    Lists and tuples are recursively sanitized.
     """
     if isinstance(value, str) and value.lstrip().startswith(("=", "+", "-", "@")):
         return f"'{value}"
+    elif isinstance(value, list):
+        return [sanitize_csv_formula(v) for v in value]
+    elif isinstance(value, tuple):
+        return tuple(sanitize_csv_formula(v) for v in value)
     return value
 
 

--- a/tests/unit/utils/test_security.py
+++ b/tests/unit/utils/test_security.py
@@ -63,3 +63,15 @@ def test_validate_header_value_valid(input_val):
 def test_validate_header_value_invalid(input_val):
     with pytest.raises(ClientError, match="Header value must not contain newlines"):
         validate_header_value(input_val)
+
+
+@pytest.mark.parametrize(
+    "input_val, expected",
+    [
+        (["=cmd", "safe"], ["'=cmd", "safe"]),
+        (("unsafe", "+1"), ("unsafe", "'+1")),
+        ([["-nested"], "@also_nested"], [["'-nested"], "'@also_nested"]),
+    ],
+)
+def test_sanitize_csv_formula_collections(input_val, expected):
+    assert sanitize_csv_formula(input_val) == expected


### PR DESCRIPTION
🎯 **What:**
Updated `sanitize_csv_formula` in `src/imednet/utils/security.py` to recursively sanitize elements if the input value is a list or a tuple. Added a parameterized test case in `tests/unit/utils/test_security.py` to verify this behavior.

⚠️ **Risk:**
Without this, lists containing malicious formula strings (e.g., `["=cmd", "safe"]`) bypass the string-specific check in `sanitize_csv_formula` and get exported into CSVs directly.

🛡️ **Solution:**
Added recursive logic to `sanitize_csv_formula` for `list` and `tuple` types, which ensures elements within those collections are properly prefixed with a single quote if they start with dangerous characters like `=`, `+`, `-`, or `@`.

---
*PR created automatically by Jules for task [10496292685836002953](https://jules.google.com/task/10496292685836002953) started by @fderuiter*