### PR TITLE
🏗️ Architect: Endpoint Caching Encapsulation

### DIFF
--- a/src/imednet/core/endpoint/abc.py
+++ b/src/imednet/core/endpoint/abc.py
@@ -43,12 +43,6 @@ class EndpointABC(ABC, ClientProvider, Generic[T]):
     Defaults to "id". Override in subclasses if needed.
     """
 
-    _enable_cache: bool = False
-    """
-    Whether this endpoint supports caching.
-    Defaults to False. Override in subclasses if needed.
-    """
-
     @abstractmethod
     def _build_path(self, *segments: Any) -> str:
         """

--- a/src/imednet/core/endpoint/base.py
+++ b/src/imednet/core/endpoint/base.py
@@ -106,7 +106,6 @@ class GenericListGetEndpoint(
         async_client: Optional[AsyncRequestorProtocol] = None,
     ) -> None:
         super().__init__(client, ctx, async_client)
-        self._cache: Optional[List[T] | Dict[str, List[T]]] = None
 
     @property
     def study_key_strategy(self) -> StudyKeyStrategy:
@@ -162,25 +161,10 @@ class GenericListGetEndpoint(
         return ParamState(study=study, params=params, other_filters=other_filters)
 
     def _get_local_cache(self) -> Optional[List[T] | Dict[str, List[T]]]:
-        if not self._enable_cache:
-            return None
-
-        if self.requires_study_key and self._cache is None:
-            self._cache = {}
-        return self._cache
+        return None
 
     def _update_local_cache(self, result: List[T], study: str | None, has_filters: bool) -> None:
-        if has_filters or not self._enable_cache:
-            return
-
-        if self.requires_study_key:
-            if self._cache is None:
-                self._cache = {}
-            if isinstance(self._cache, dict) and study is not None:
-                self._cache[study] = result
-            return
-
-        self._cache = result
+        pass
 
     def _check_cache_hit(
         self,
@@ -189,22 +173,6 @@ class GenericListGetEndpoint(
         other_filters: Dict[str, Any],
         cache: Optional[List[T] | Dict[str, List[T]]],
     ) -> Optional[List[T]]:
-        if not self._enable_cache:
-            return None
-
-        if self.requires_study_key:
-            if (
-                isinstance(cache, dict)
-                and study is not None
-                and not other_filters
-                and not refresh
-                and study in cache
-            ):
-                return cache[study]
-            return None
-
-        if isinstance(cache, list) and not other_filters and not refresh:
-            return cache
         return None
 
     def _prepare_list_request(

--- a/src/imednet/core/endpoint/cache_mixin.py
+++ b/src/imednet/core/endpoint/cache_mixin.py
@@ -1,0 +1,61 @@
+from typing import Any, Dict, Generic, List, Optional, TypeVar
+
+T = TypeVar("T")
+
+class CachedEndpointMixin(Generic[T]):
+    """
+    Mixin providing caching functionality for endpoints.
+
+    Manages cache state and lazy initialization to keep base classes
+    agnostic of caching details.
+    """
+
+    _enable_cache: bool
+    _cache: Optional[List[T] | Dict[str, List[T]]]
+    requires_study_key: bool
+
+    def _get_local_cache(self) -> Optional[List[T] | Dict[str, List[T]]]:
+        if not getattr(self, "_enable_cache", False):
+            return None
+
+        if getattr(self, "requires_study_key", True) and getattr(self, "_cache", None) is None:
+            self._cache = {}
+        return getattr(self, "_cache", None)
+
+    def _update_local_cache(self, result: List[T], study: str | None, has_filters: bool) -> None:
+        if has_filters or not getattr(self, "_enable_cache", False):
+            return
+
+        if getattr(self, "requires_study_key", True):
+            if getattr(self, "_cache", None) is None:
+                self._cache = {}
+            if isinstance(getattr(self, "_cache", None), dict) and study is not None:
+                self._cache[study] = result  # type: ignore
+            return
+
+        self._cache = result
+
+    def _check_cache_hit(
+        self,
+        study: Optional[str],
+        refresh: bool,
+        other_filters: Dict[str, Any],
+        cache: Optional[List[T] | Dict[str, List[T]]],
+    ) -> Optional[List[T]]:
+        if not getattr(self, "_enable_cache", False):
+            return None
+
+        if getattr(self, "requires_study_key", True):
+            if (
+                isinstance(cache, dict)
+                and study is not None
+                and not other_filters
+                and not refresh
+                and study in cache
+            ):
+                return cache[study]
+            return None
+
+        if isinstance(cache, list) and not other_filters and not refresh:
+            return cache
+        return None

--- a/src/imednet/core/endpoint/protocols.py
+++ b/src/imednet/core/endpoint/protocols.py
@@ -26,7 +26,6 @@ class EndpointProtocol(Protocol):
     PATH: str
     MODEL: Type[JsonModel]
     _id_param: str
-    _enable_cache: bool
     requires_study_key: bool
     PAGE_SIZE: int
 

--- a/src/imednet/endpoints/forms.py
+++ b/src/imednet/endpoints/forms.py
@@ -1,12 +1,14 @@
 """Endpoint for managing forms (eCRFs) in a study."""
 
 from imednet.core.endpoint.base import GenericListGetEndpoint
+from imednet.core.endpoint.cache_mixin import CachedEndpointMixin
 from imednet.core.endpoint.edc_mixin import EdcEndpointMixin
 from imednet.core.endpoint.strategies import PopStudyKeyStrategy
 from imednet.models.forms import Form
 
 
 class FormsEndpoint(
+    CachedEndpointMixin[Form],
     EdcEndpointMixin,
     GenericListGetEndpoint[Form],
 ):

--- a/src/imednet/endpoints/intervals.py
+++ b/src/imednet/endpoints/intervals.py
@@ -1,12 +1,14 @@
 """Endpoint for managing intervals (visit definitions) in a study."""
 
 from imednet.core.endpoint.base import GenericListGetEndpoint
+from imednet.core.endpoint.cache_mixin import CachedEndpointMixin
 from imednet.core.endpoint.edc_mixin import EdcEndpointMixin
 from imednet.core.endpoint.strategies import PopStudyKeyStrategy
 from imednet.models.intervals import Interval
 
 
 class IntervalsEndpoint(
+    CachedEndpointMixin[Interval],
     EdcEndpointMixin,
     GenericListGetEndpoint[Interval],
 ):

--- a/src/imednet/endpoints/studies.py
+++ b/src/imednet/endpoints/studies.py
@@ -1,11 +1,13 @@
 """Endpoint for managing studies in the iMedNet system."""
 
 from imednet.core.endpoint.base import GenericListGetEndpoint
+from imednet.core.endpoint.cache_mixin import CachedEndpointMixin
 from imednet.core.endpoint.edc_mixin import EdcEndpointMixin
 from imednet.models.studies import Study
 
 
 class StudiesEndpoint(
+    CachedEndpointMixin[Study],
     EdcEndpointMixin,
     GenericListGetEndpoint[Study],
 ):

--- a/src/imednet/endpoints/variables.py
+++ b/src/imednet/endpoints/variables.py
@@ -1,12 +1,14 @@
 """Endpoint for managing variables (data points on eCRFs) in a study."""
 
 from imednet.core.endpoint.base import GenericListGetEndpoint
+from imednet.core.endpoint.cache_mixin import CachedEndpointMixin
 from imednet.core.endpoint.edc_mixin import EdcEndpointMixin
 from imednet.core.endpoint.strategies import PopStudyKeyStrategy
 from imednet.models.variables import Variable
 
 
 class VariablesEndpoint(
+    CachedEndpointMixin[Variable],
     EdcEndpointMixin,
     GenericListGetEndpoint[Variable],
 ):

--- a/tests/unit/core/test_abc.py
+++ b/tests/unit/core/test_abc.py
@@ -36,7 +36,6 @@ def test_endpoint_abc_properties():
     assert endpoint.MODEL == MockModel
     assert endpoint.requires_study_key is True
     assert endpoint._id_param == "id"
-    assert endpoint._enable_cache is False
 
 
 def test_endpoint_abc_methods():


### PR DESCRIPTION
### 🏗️ Design Change:
Extracted caching state management and logic (`_cache`, `_get_local_cache`, etc.) out of the base `GenericListGetEndpoint` and into a dedicated `CachedEndpointMixin`. `GenericListGetEndpoint` now implements these methods as pure no-ops, providing an interface without an implementation. Cached endpoints opt-in by inheriting from the mixin.

### ♻️ DRY Gains:
Centralized caching control. Endpoints that don't need caching (like `RecordsEndpoint`) no longer inherit unused cache initialization logic or state variables.

### 🛡️ Solidity:
Strict adherence to the Single Responsibility Principle and Interface Segregation. The base class handles endpoint lifecycle and REST routing, while the mixin handles memory management.

### ⚠️ Breaking Changes:
None. The public API remains functionally identical. Internal subclasses relying on `self._cache` must now inherit from `CachedEndpointMixin`.

---
*PR created automatically by Jules for task [14527203853583609165](https://jules.google.com/task/14527203853583609165) started by @fderuiter*