### PR TITLE
🖋️ Scribe: Fix dead link in live_tests documentation

### DIFF
--- a/docs/live_tests.rst
+++ b/docs/live_tests.rst
@@ -8,7 +8,7 @@ execute against a real iMednet environment and are skipped unless
 interacting with a running server.
 
 The suite can auto-discover required IDs when environment variables are unset.
-See :doc:`api/imednet.discovery` for details on locating study, form, site, subject,
+See :mod:`imednet.discovery` for details on locating study, form, site, subject,
 and interval identifiers at runtime.
 
 See :doc:`test_skip_conditions` for a summary of all variables and optional


### PR DESCRIPTION
💡 **What:** Changed the Sphinx cross-reference in `docs/live_tests.rst` from `:doc:\`api/imednet.discovery\`` to `:mod:\`imednet.discovery\``.
🎯 **Why:** The previous reference resulted in a broken link and an 'unknown document' warning during the `make docs` build process, as `sphinx-apidoc` handles API generation differently.
🧠 **Cognitive Impact:** Fixes a broken documentation path, allowing developers to successfully build docs without warnings and navigate correctly to the `imednet.discovery` module reference from the live tests overview.
📖 **Preview:**
```rst
See :mod:`imednet.discovery` for details on locating study, form, site, subject,
```

---
*PR created automatically by Jules for task [4438210445918381940](https://jules.google.com/task/4438210445918381940) started by @fderuiter*