### PR TITLE
🛠️ Refactor: Endpoint Caching - Extract to CacheMixin

### DIFF
--- a/src/imednet/core/endpoint/abc.py
+++ b/src/imednet/core/endpoint/abc.py
@@ -43,12 +43,6 @@ class EndpointABC(ABC, ClientProvider, Generic[T]):
     Defaults to "id". Override in subclasses if needed.
     """
 
-    _enable_cache: bool = False
-    """
-    Whether this endpoint supports caching.
-    Defaults to False. Override in subclasses if needed.
-    """
-
     @abstractmethod
     def _build_path(self, *segments: Any) -> str:
         """

--- a/src/imednet/core/endpoint/base.py
+++ b/src/imednet/core/endpoint/base.py
@@ -106,7 +106,6 @@ class GenericListGetEndpoint(
         async_client: Optional[AsyncRequestorProtocol] = None,
     ) -> None:
         super().__init__(client, ctx, async_client)
-        self._cache: Optional[List[T] | Dict[str, List[T]]] = None
 
     @property
     def study_key_strategy(self) -> StudyKeyStrategy:
@@ -162,25 +161,10 @@ class GenericListGetEndpoint(
         return ParamState(study=study, params=params, other_filters=other_filters)
 
     def _get_local_cache(self) -> Optional[List[T] | Dict[str, List[T]]]:
-        if not self._enable_cache:
-            return None
-
-        if self.requires_study_key and self._cache is None:
-            self._cache = {}
-        return self._cache
+        return None
 
     def _update_local_cache(self, result: List[T], study: str | None, has_filters: bool) -> None:
-        if has_filters or not self._enable_cache:
-            return
-
-        if self.requires_study_key:
-            if self._cache is None:
-                self._cache = {}
-            if isinstance(self._cache, dict) and study is not None:
-                self._cache[study] = result
-            return
-
-        self._cache = result
+        pass
 
     def _check_cache_hit(
         self,
@@ -189,22 +173,6 @@ class GenericListGetEndpoint(
         other_filters: Dict[str, Any],
         cache: Optional[List[T] | Dict[str, List[T]]],
     ) -> Optional[List[T]]:
-        if not self._enable_cache:
-            return None
-
-        if self.requires_study_key:
-            if (
-                isinstance(cache, dict)
-                and study is not None
-                and not other_filters
-                and not refresh
-                and study in cache
-            ):
-                return cache[study]
-            return None
-
-        if isinstance(cache, list) and not other_filters and not refresh:
-            return cache
         return None
 
     def _prepare_list_request(

--- a/src/imednet/core/endpoint/cache_mixin.py
+++ b/src/imednet/core/endpoint/cache_mixin.py
@@ -1,0 +1,59 @@
+"""Mixin for endpoint caching logic."""
+
+from typing import Any, Dict, Generic, List, Optional, TypeVar
+
+from imednet.models.json_base import JsonModel
+
+T = TypeVar("T", bound=JsonModel)
+
+
+class CachedEndpointMixin(Generic[T]):
+    """
+    Mixin providing local caching behavior for endpoints.
+    """
+
+    requires_study_key: bool
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        super().__init__(*args, **kwargs)  # type: ignore[call-arg]
+        self._cache: Optional[List[T] | Dict[str, List[T]]] = None
+
+    def _get_local_cache(self) -> Optional[List[T] | Dict[str, List[T]]]:
+        if getattr(self, "requires_study_key", False) and self._cache is None:
+            self._cache = {}
+        return self._cache
+
+    def _update_local_cache(self, result: List[T], study: str | None, has_filters: bool) -> None:
+        if has_filters:
+            return
+
+        if getattr(self, "requires_study_key", False):
+            if self._cache is None:
+                self._cache = {}
+            if isinstance(self._cache, dict) and study is not None:
+                self._cache[study] = result
+            return
+
+        self._cache = result
+
+    def _check_cache_hit(
+        self,
+        study: Optional[str],
+        refresh: bool,
+        other_filters: Dict[str, Any],
+        cache: Optional[List[T] | Dict[str, List[T]]],
+    ) -> Optional[List[T]]:
+        if getattr(self, "requires_study_key", False):
+            if (
+                isinstance(cache, dict)
+                and study is not None
+                and not other_filters
+                and not refresh
+                and study in cache
+            ):
+                return cache[study]
+            return None
+
+        if isinstance(cache, list) and not other_filters and not refresh:
+            return cache
+        return None

--- a/src/imednet/core/endpoint/protocols.py
+++ b/src/imednet/core/endpoint/protocols.py
@@ -26,7 +26,6 @@ class EndpointProtocol(Protocol):
     PATH: str
     MODEL: Type[JsonModel]
     _id_param: str
-    _enable_cache: bool
     requires_study_key: bool
     PAGE_SIZE: int
 

--- a/src/imednet/endpoints/forms.py
+++ b/src/imednet/endpoints/forms.py
@@ -1,12 +1,14 @@
 """Endpoint for managing forms (eCRFs) in a study."""
 
 from imednet.core.endpoint.base import GenericListGetEndpoint
+from imednet.core.endpoint.cache_mixin import CachedEndpointMixin
 from imednet.core.endpoint.edc_mixin import EdcEndpointMixin
 from imednet.core.endpoint.strategies import PopStudyKeyStrategy
 from imednet.models.forms import Form
 
 
 class FormsEndpoint(
+    CachedEndpointMixin,
     EdcEndpointMixin,
     GenericListGetEndpoint[Form],
 ):
@@ -20,5 +22,4 @@ class FormsEndpoint(
     MODEL = Form
     _id_param = "formId"
     STUDY_KEY_STRATEGY = PopStudyKeyStrategy()
-    _enable_cache = True
     PAGE_SIZE = 500

--- a/src/imednet/endpoints/forms.py
+++ b/src/imednet/endpoints/forms.py
@@ -8,7 +8,7 @@ from imednet.models.forms import Form
 
 
 class FormsEndpoint(
-    CachedEndpointMixin,
+    CachedEndpointMixin[Form],
     EdcEndpointMixin,
     GenericListGetEndpoint[Form],
 ):

--- a/src/imednet/endpoints/intervals.py
+++ b/src/imednet/endpoints/intervals.py
@@ -1,12 +1,14 @@
 """Endpoint for managing intervals (visit definitions) in a study."""
 
 from imednet.core.endpoint.base import GenericListGetEndpoint
+from imednet.core.endpoint.cache_mixin import CachedEndpointMixin
 from imednet.core.endpoint.edc_mixin import EdcEndpointMixin
 from imednet.core.endpoint.strategies import PopStudyKeyStrategy
 from imednet.models.intervals import Interval
 
 
 class IntervalsEndpoint(
+    CachedEndpointMixin,
     EdcEndpointMixin,
     GenericListGetEndpoint[Interval],
 ):
@@ -20,5 +22,4 @@ class IntervalsEndpoint(
     MODEL = Interval
     _id_param = "intervalId"
     STUDY_KEY_STRATEGY = PopStudyKeyStrategy()
-    _enable_cache = True
     PAGE_SIZE = 500

--- a/src/imednet/endpoints/intervals.py
+++ b/src/imednet/endpoints/intervals.py
@@ -8,7 +8,7 @@ from imednet.models.intervals import Interval
 
 
 class IntervalsEndpoint(
-    CachedEndpointMixin,
+    CachedEndpointMixin[Interval],
     EdcEndpointMixin,
     GenericListGetEndpoint[Interval],
 ):

--- a/src/imednet/endpoints/studies.py
+++ b/src/imednet/endpoints/studies.py
@@ -7,7 +7,7 @@ from imednet.models.studies import Study
 
 
 class StudiesEndpoint(
-    CachedEndpointMixin,
+    CachedEndpointMixin[Study],
     EdcEndpointMixin,
     GenericListGetEndpoint[Study],
 ):

--- a/src/imednet/endpoints/studies.py
+++ b/src/imednet/endpoints/studies.py
@@ -1,11 +1,13 @@
 """Endpoint for managing studies in the iMedNet system."""
 
 from imednet.core.endpoint.base import GenericListGetEndpoint
+from imednet.core.endpoint.cache_mixin import CachedEndpointMixin
 from imednet.core.endpoint.edc_mixin import EdcEndpointMixin
 from imednet.models.studies import Study
 
 
 class StudiesEndpoint(
+    CachedEndpointMixin,
     EdcEndpointMixin,
     GenericListGetEndpoint[Study],
 ):
@@ -18,5 +20,4 @@ class StudiesEndpoint(
     PATH = ""
     MODEL = Study
     _id_param = "studyKey"
-    _enable_cache = True
     requires_study_key: bool = False

--- a/src/imednet/endpoints/variables.py
+++ b/src/imednet/endpoints/variables.py
@@ -1,12 +1,14 @@
 """Endpoint for managing variables (data points on eCRFs) in a study."""
 
 from imednet.core.endpoint.base import GenericListGetEndpoint
+from imednet.core.endpoint.cache_mixin import CachedEndpointMixin
 from imednet.core.endpoint.edc_mixin import EdcEndpointMixin
 from imednet.core.endpoint.strategies import PopStudyKeyStrategy
 from imednet.models.variables import Variable
 
 
 class VariablesEndpoint(
+    CachedEndpointMixin,
     EdcEndpointMixin,
     GenericListGetEndpoint[Variable],
 ):
@@ -20,5 +22,4 @@ class VariablesEndpoint(
     MODEL = Variable
     _id_param = "variableId"
     STUDY_KEY_STRATEGY = PopStudyKeyStrategy()
-    _enable_cache = True
     PAGE_SIZE = 500

--- a/src/imednet/endpoints/variables.py
+++ b/src/imednet/endpoints/variables.py
@@ -8,7 +8,7 @@ from imednet.models.variables import Variable
 
 
 class VariablesEndpoint(
-    CachedEndpointMixin,
+    CachedEndpointMixin[Variable],
     EdcEndpointMixin,
     GenericListGetEndpoint[Variable],
 ):

--- a/tests/unit/core/test_abc.py
+++ b/tests/unit/core/test_abc.py
@@ -36,7 +36,6 @@ def test_endpoint_abc_properties():
     assert endpoint.MODEL == MockModel
     assert endpoint.requires_study_key is True
     assert endpoint._id_param == "id"
-    assert endpoint._enable_cache is False
 
 
 def test_endpoint_abc_methods():


### PR DESCRIPTION
♻️ **DRY Gains:** Centralized explicit caching initialization and method hook implementation into `CachedEndpointMixin`. Removed repeated class attributes across caching endpoints.
🧱 **SOLID:** Decoupled caching state (`_cache`, `_enable_cache`) from the base interfaces (`EndpointABC`, `GenericListGetEndpoint`). Endpoints that need caching now compose it in using the Mixin (Single Responsibility / Composition over Inheritance).
📉 **Diff:** Removed legacy caching properties and dummy logic, resulting in a cleaner and properly separated architecture.

---
*PR created automatically by Jules for task [5526562430089598711](https://jules.google.com/task/5526562430089598711) started by @fderuiter*