### PR TITLE
docs: Use grounded URLs instead of dummy examples in documentation

### DIFF
--- a/.jules/scribe.md
+++ b/.jules/scribe.md
@@ -1,0 +1,7 @@
+## SCRIBE JOURNAL
+## 2024-05-11 - [Use Grounded URLs in Docs]
+**Insight:** Using dummy URLs like `https://example.com` in documentation confuses users who copy-paste snippets.
+**Guideline:** Always use the actual default base URL `https://edc.prod.imednetapi.com` in `.env.example`, `README.md`, and other documentation.
+## 2024-05-11 - [Use Grounded URLs in Docs]
+**Insight:** Using dummy URLs like `https://example.com` in documentation confuses users who copy-paste snippets.
+**Guideline:** Always use the actual default base URL `https://edc.prod.imednetapi.com` in `.env.example`, `README.md`, and other documentation.

--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ cp .env.example .env
 export IMEDNET_API_KEY="your_api_key"
 export IMEDNET_SECURITY_KEY="your_security_key"
 # Optional: Custom base URL for the API endpoint
-# export IMEDNET_BASE_URL="https://example.com"
+# export IMEDNET_BASE_URL="https://edc.prod.imednetapi.com"
 ```
 
 ### Synchronous Example

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -52,7 +52,7 @@ Edit the file to add your keys::
 
     IMEDNET_API_KEY=your_api_key
     IMEDNET_SECURITY_KEY=your_security_key
-    IMEDNET_BASE_URL=https://example.com
+    IMEDNET_BASE_URL=https://edc.prod.imednetapi.com
 
 The CLI loads this file automatically. Other scripts can call
 ``dotenv.load_dotenv()`` to mimic this behaviour.


### PR DESCRIPTION
💡 **What:** Replaced the generic dummy URL `https://example.com` in `README.md` and `docs/configuration.rst` with the actual default production base URL `https://edc.prod.imednetapi.com`. Added a critical learning to `.jules/scribe.md` enforcing this practice.
🎯 **Why:** Using `https://example.com` can be misleading, especially for new developers who might copy-paste snippets. Using a realistic fallback URL prevents broken onboarding paths.
🧠 **Cognitive Impact:** Reduces confusion by showing a concrete example of what a valid iMednet API base URL looks like in the quick start and configuration guides.
📖 **Preview:**
```bash
    IMEDNET_API_KEY=your_api_key
    IMEDNET_SECURITY_KEY=your_security_key
    IMEDNET_BASE_URL=https://edc.prod.imednetapi.com
```

---
*PR created automatically by Jules for task [8968928641173780876](https://jules.google.com/task/8968928641173780876) started by @fderuiter*