### PR TITLE
test: 🛡️ Shield: add tests for SDK _init_workflows failure cases

### DIFF
--- a/src/imednet/cli/utils/__init__.py
+++ b/src/imednet/cli/utils/__init__.py
@@ -1,13 +1,7 @@
 from .args import STUDY_KEY_ARG, parse_filter_args
 from .commands import register_list_command
 from .context import fetching_status, get_sdk
-from .output import (
-    _STATUS_COLOR_MAP,
-    _format_cell_value,
-    _truncate,
-    console,
-    display_list,
-)
+from .output import _STATUS_COLOR_MAP, _format_cell_value, _truncate, console, display_list
 
 __all__ = [
     "STUDY_KEY_ARG",

--- a/src/imednet/core/http_client_base.py
+++ b/src/imednet/core/http_client_base.py
@@ -7,11 +7,7 @@ from typing import Any, Generic, Optional, TypeVar, Union, cast
 import httpx
 
 from imednet.auth.strategy import AuthStrategy
-from imednet.constants import (
-    CONTENT_TYPE_JSON,
-    HEADER_ACCEPT,
-    HEADER_CONTENT_TYPE,
-)
+from imednet.constants import CONTENT_TYPE_JSON, HEADER_ACCEPT, HEADER_CONTENT_TYPE
 from imednet.core.http.executor import BaseRequestExecutor
 
 from .base_client import BaseClient, Tracer

--- a/tests/unit/test_core_context.py
+++ b/tests/unit/test_core_context.py
@@ -1,10 +1,6 @@
 import pytest
 
-from imednet.core.context import (
-    get_current_study,
-    reset_study_context,
-    set_study_context,
-)
+from imednet.core.context import get_current_study, reset_study_context, set_study_context
 from imednet.errors.validation import ConfigurationError
 
 

--- a/tests/unit/test_sdk_entrypoint.py
+++ b/tests/unit/test_sdk_entrypoint.py
@@ -205,3 +205,77 @@ def test_poll_job_convenience_sync(monkeypatch) -> None:
 
     assert sdk.poll_job("S1", "B1", interval=10, timeout=100) == "JOBOBJ"
     assert calls["run"] == ("S1", "B1", 10, 100)
+
+
+def test_missing_workflow_exports_no_workflows(monkeypatch) -> None:
+    def fake_import_module(name):
+        if name == "imednet_workflows.namespace":
+
+            class FakeModule:
+                pass
+
+            return FakeModule()
+        import importlib
+
+        return importlib.import_module(name)
+
+    monkeypatch.setattr("imednet.sdk.import_module", fake_import_module)
+
+    import pytest
+
+    with pytest.raises(ImportError, match="does not export 'Workflows'"):
+        _create_sdk()
+
+
+def test_missing_workflow_exports_bad_workflows(monkeypatch) -> None:
+    def fake_import_module(name):
+        if name == "imednet_workflows.namespace":
+
+            class FakeModule:
+                pass
+
+            class FakeWorkflows:
+                def __init__(self, sdk):
+                    raise AttributeError("simulated error")
+
+            FakeModule.Workflows = FakeWorkflows
+            return FakeModule()
+        import importlib
+
+        return importlib.import_module(name)
+
+    monkeypatch.setattr("imednet.sdk.import_module", fake_import_module)
+
+    import pytest
+
+    with pytest.raises(ImportError, match="Failed to instantiate Workflows"):
+        _create_sdk()
+
+
+def test_missing_workflow_exports_unexpected_module_not_found(monkeypatch) -> None:
+    def fake_import_module(name):
+        raise ModuleNotFoundError("Some other module not found", name="other_module")
+
+    monkeypatch.setattr("imednet.sdk.import_module", fake_import_module)
+
+    import pytest
+
+    with pytest.raises(ModuleNotFoundError, match="Some other module not found"):
+        _create_sdk()
+
+
+def test_missing_workflow_exports_fallback(monkeypatch) -> None:
+    import sys
+
+    monkeypatch.setitem(sys.modules, "imednet.workflows.namespace", None)
+
+    def fake_import_module(name):
+        raise ModuleNotFoundError("mocked missing", name=name)
+
+    monkeypatch.setattr("imednet.sdk.import_module", fake_import_module)
+
+    sdk = _create_sdk()
+    import pytest
+
+    with pytest.raises(ImportError, match="requires the optional 'imednet-workflows' package"):
+        _ = sdk.workflows.some_workflow


### PR DESCRIPTION
🛑 **Vulnerability:** The gap or risk identified: `src/imednet/sdk.py` contains complex, critical logic (`_init_workflows()`) for lazily loading an optional dependency (`imednet-workflows`). The failure paths, such as the module not exporting `Workflows`, failing during instantiation, or unrelated `ModuleNotFoundError`s being swallowed, were not covered by tests. This creates a risk where silent failures or unexpected exceptions could break SDK instantiation or workflow execution.

🛡️ **Defense:** The test added/modified: Added four focused unit tests to `tests/unit/test_sdk_entrypoint.py` to cover all edge cases of `_init_workflows()`. These tests simulate `ImportError`, `ModuleNotFoundError`, malformed modules (missing `Workflows` class), and instantiation errors using `monkeypatch`.

🔬 **Verification:** How to run this specific test: `poetry run pytest tests/unit/test_sdk_entrypoint.py`

📊 **Impact:** Increases coverage of `_init_workflows()` in `src/imednet/sdk.py` to near 100% and protects the critical optional dependency loading logic from regressions.

---
*PR created automatically by Jules for task [8130753413460898672](https://jules.google.com/task/8130753413460898672) started by @fderuiter*