### PR TITLE
docs: ✍️ Scribe: Missing dotenv fallbacks in examples

### DIFF
--- a/docs/async_quick_start.rst
+++ b/docs/async_quick_start.rst
@@ -31,6 +31,8 @@ Set your credentials by copying the environment template or exporting them direc
    # Option 2: Export directly to your shell
    export IMEDNET_API_KEY="your_api_key"
    export IMEDNET_SECURITY_KEY="your_security_key"
+   # Optional: Custom base URL for the API endpoint
+   # export IMEDNET_BASE_URL="https://edc.prod.imednetapi.com"
 
 List studies asynchronously and poll a job:
 

--- a/docs/quick_start.rst
+++ b/docs/quick_start.rst
@@ -26,6 +26,8 @@ Set your credentials by copying the environment template or exporting them direc
    # Option 2: Export directly to your shell
    export IMEDNET_API_KEY="your_api_key"
    export IMEDNET_SECURITY_KEY="your_security_key"
+   # Optional: Custom base URL for the API endpoint
+   # export IMEDNET_BASE_URL="https://edc.prod.imednetapi.com"
 
 Enable structured logging and list studies:
 

--- a/examples/async_quick_start.py
+++ b/examples/async_quick_start.py
@@ -21,6 +21,8 @@ Example::
     # Or export directly:
     export IMEDNET_API_KEY="your_api_key"
     export IMEDNET_SECURITY_KEY="your_security_key"
+    # Optional: Custom base URL for the API endpoint
+    # export IMEDNET_BASE_URL="https://edc.prod.imednetapi.com"
     poetry run python examples/async_quick_start.py
 """
 

--- a/examples/build_form_payload.py
+++ b/examples/build_form_payload.py
@@ -4,6 +4,10 @@ Hybrid Entry Point for iMedNet Form Builder.
 
 Usage:
   cp .env.example .env
+  # Or export directly:
+  # export IMEDNET_API_KEY="your_api_key"
+  # export IMEDNET_SECURITY_KEY="your_security_key"
+  # export IMEDNET_BASE_URL="https://edc.prod.imednetapi.com"
 
   # Headless Mode (CLI)
   poetry run python examples/build_form_payload.py \

--- a/examples/quick_start.py
+++ b/examples/quick_start.py
@@ -18,6 +18,8 @@ Example:
     # Or export directly:
     export IMEDNET_API_KEY="your_api_key"
     export IMEDNET_SECURITY_KEY="your_security_key"
+    # Optional: Custom base URL for the API endpoint
+    # export IMEDNET_BASE_URL="https://edc.prod.imednetapi.com"
     poetry run python examples/quick_start.py
 """
 


### PR DESCRIPTION
💡 **What:** Added fallback shell export instructions (including `IMEDNET_BASE_URL`) directly alongside `load_dotenv()` usage in `docs/quick_start.rst`, `docs/async_quick_start.rst`, `examples/quick_start.py`, `examples/async_quick_start.py`, and `examples/build_form_payload.py`.
🎯 **Why:** `dotenv.load_dotenv()` fails silently if no `.env` file exists. If a user skips `cp .env.example .env` and there are no documented shell exports to fall back on, the application crashes with missing variable errors, frustrating first-time users.
🧠 **Cognitive Impact:** Fixes first-run crashes. Removes ambiguity about how to configure the application when not using a `.env` file, reducing the "Time to Understand" configuration requirements.
📖 **Preview:** 
```bash
  # Option 1: Use a .env file (recommended)
  cp .env.example .env

  # Option 2: Export directly to your shell
  export IMEDNET_API_KEY="your_api_key"
  export IMEDNET_SECURITY_KEY="your_security_key"
  # Optional: Custom base URL for the API endpoint
  # export IMEDNET_BASE_URL="https://edc.prod.imednetapi.com"
```

---
*PR created automatically by Jules for task [16280606349452140816](https://jules.google.com/task/16280606349452140816) started by @fderuiter*