### PR TITLE
docs: ✍️ Scribe: Add make docs troubleshooting to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -286,6 +286,9 @@ Contributions are welcome! See the
 **Missing or invalid required environment variable(s)**
 If you see an error like `Error: IMEDNET_API_KEY and IMEDNET_SECURITY_KEY environment variables must be set.` (CLI) or `API key and security key are required` (SDK), or an "Unauthorized" or "Forbidden" (403) API error, ensure you have set valid keys in your shell or in a `.env` file in the directory where you run the script (avoid using "dummy" keys). See [Configuration](#configuration).
 
+**Command not found: sphinx-apidoc when running make docs**
+If building documentation with `make docs` fails with `Command not found: sphinx-apidoc`, run `poetry install --all-extras` first to install all necessary documentation plugins and dependencies.
+
 **ModuleNotFoundError when running the CLI locally**
 If you are running the `imednet` CLI from source (e.g., `poetry run imednet`) and see a `ModuleNotFoundError` (such as `No module named 'imednet'`), ensure you have installed the project dependencies by running `poetry install` in the project root.
 


### PR DESCRIPTION
💡 **What:** Added troubleshooting for `make docs` failing with `Command not found: sphinx-apidoc` to `README.md` and added a journal entry.
🎯 **Why:** To resolve a recurring missing dependency error when new developers try to build documentation.
🧠 **Cognitive Impact:** Prevents frustration and clarifies that documentation dependencies require an extra install flag (`--all-extras`).
📖 **Preview:**
```markdown
**Command not found: sphinx-apidoc when running make docs**
If building documentation with `make docs` fails with `Command not found: sphinx-apidoc`, run `poetry install --all-extras` first to install all necessary documentation plugins and dependencies.
```

---
*PR created automatically by Jules for task [11160830870897397588](https://jules.google.com/task/11160830870897397588) started by @fderuiter*