### PR TITLE
docs: ✍️ Scribe: Update project structure in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,7 +226,10 @@ the specified table name. See ``docs/cli.rst`` for full examples.
 .
 ├── docs/       - Sphinx documentation
 ├── examples/   - Usage samples
-├── imednet/    - SDK package
+├── packages/   - Workspace packages
+│   ├── core/              - Main SDK package
+│   ├── plugins-workflows/ - Workflow plugins package
+│   └── providers-airflow/ - Airflow providers package
 ├── scripts/    - Helper scripts
 └── tests/      - Unit and integration tests
 ```


### PR DESCRIPTION
💡 **What:** Updated the ASCII project structure tree in `README.md` to show the new `packages/` monorepo layout (including `core/`, `plugins-workflows/`, and `providers-airflow/`) instead of the outdated `imednet/` directory.
🎯 **Why:** The project recently migrated to a monorepo workspace structure. The `README.md` was still incorrectly pointing users to the `imednet/` directory as the SDK package, which no longer exists at the root level.
🧠 **Cognitive Impact:** Prevents confusion and broken onboarding paths for new developers. By accurately mapping the project structure, developers can immediately understand where the core SDK lives vs. workflow plugins and Airflow providers, significantly reducing their "Time to Understand".
📖 **Preview:**
```
.
├── docs/       - Sphinx documentation
├── examples/   - Usage samples
├── packages/   - Workspace packages
│   ├── core/              - Main SDK package
│   ├── plugins-workflows/ - Workflow plugins package
│   └── providers-airflow/ - Airflow providers package
├── scripts/    - Helper scripts
└── tests/      - Unit and integration tests
```

---
*PR created automatically by Jules for task [935352066392667647](https://jules.google.com/task/935352066392667647) started by @fderuiter*