### PR TITLE
docs: ✍️ Scribe: [Add .env fallback documentation to quickstarts]

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,7 @@ from imednet.utils import configure_json_logging
 configure_json_logging()
 
 # Load credentials from .env file or environment variables
+# Note: Ensure you've run `cp .env.example .env` or exported keys to your shell.
 load_dotenv()
 cfg = load_config()
 
@@ -144,6 +145,7 @@ async def main() -> None:
     configure_json_logging()
 
     # Load credentials from .env file or environment variables
+    # Note: Ensure you've run `cp .env.example .env` or exported keys to your shell.
     load_dotenv()
     cfg = load_config()
 

--- a/docs/async_quick_start.rst
+++ b/docs/async_quick_start.rst
@@ -45,6 +45,7 @@ List studies asynchronously and poll a job:
 
    async def main() -> None:
        configure_json_logging()
+       # Note: Ensure you've run `cp .env.example .env` or exported keys to your shell.
        load_dotenv()
        cfg = load_config()
        async with AsyncImednetSDK(

--- a/docs/quick_start.rst
+++ b/docs/quick_start.rst
@@ -38,6 +38,7 @@ Enable structured logging and list studies:
    from imednet.utils import configure_json_logging
 
    configure_json_logging()
+   # Note: Ensure you've run `cp .env.example .env` or exported keys to your shell.
    load_dotenv()
    cfg = load_config()
    with ImednetSDK(

--- a/examples/async_quick_start.py
+++ b/examples/async_quick_start.py
@@ -31,6 +31,7 @@ async def main() -> None:
     """Run a minimal async SDK example using environment variables."""
     configure_json_logging()
     # Load environment variables from .env file if it exists
+    # Note: Ensure you've run `cp .env.example .env` or exported keys to your shell.
     load_dotenv()
 
     try:

--- a/examples/quick_start.py
+++ b/examples/quick_start.py
@@ -28,6 +28,7 @@ def main() -> None:
     """Run a minimal SDK example using environment variables."""
     configure_json_logging()
     # Load environment variables from .env file if it exists
+    # Note: Ensure you've run `cp .env.example .env` or exported keys to your shell.
     load_dotenv()
 
     try:


### PR DESCRIPTION
💡 **What:** 
Added explicit `cp .env.example .env` instructions directly as comments in the python code blocks for `docs/quick_start.rst`, `docs/async_quick_start.rst`, `README.md`, `examples/quick_start.py`, and `examples/async_quick_start.py`.

🎯 **Why:** 
`dotenv.load_dotenv()` fails silently if no `.env` file is present. If users directly copy-paste the python snippets without running the bash shell exports beforehand, they receive cryptic "Missing required environment variable" errors that make the example code seem broken.

🧠 **Cognitive Impact:** 
Fixes a common "broken path" in onboarding. Reduces confusion by making the python code blocks entirely self-documenting regarding their environmental dependencies, avoiding reliance on previous document context.

📖 **Preview:** 
```python
    # Load environment variables from .env file if it exists
    # Note: Ensure you've run `cp .env.example .env` or exported keys to your shell.
    load_dotenv()
```

---
*PR created automatically by Jules for task [18391427851014310927](https://jules.google.com/task/18391427851014310927) started by @fderuiter*