### PR TITLE
docs: ✍️ Scribe: add troubleshooting section for silent dotenv load failures

### DIFF
--- a/README.md
+++ b/README.md
@@ -291,6 +291,9 @@ Contributions are welcome! See the
 **Missing or invalid required environment variable(s)**
 If you see an error like `Error: IMEDNET_API_KEY and IMEDNET_SECURITY_KEY environment variables must be set.` (CLI) or `API key and security key are required` (SDK), or an "Unauthorized" or "Forbidden" (403) API error, ensure you have set valid keys in your shell or in a `.env` file in the directory where you run the script (avoid using "dummy" keys). See [Configuration](#configuration).
 
+**Silent `.env` load failures**
+If you are using `dotenv.load_dotenv()` and it seems your keys are not being loaded despite having a `.env` file, ensure you have actually copied the example file (`cp .env.example .env`). The `load_dotenv()` function will silently do nothing if the `.env` file is missing or in a different directory, leading to "missing required keys" errors.
+
 **Command not found: sphinx-apidoc when running make docs**
 If building documentation with `make docs` fails with `Command not found: sphinx-apidoc`, run `poetry install --all-extras` first to install all necessary documentation plugins and dependencies.
 

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -98,3 +98,7 @@ Troubleshooting
 **Missing required environment variable(s)**
 
 If you see an error like ``Error: IMEDNET_API_KEY and IMEDNET_SECURITY_KEY environment variables must be set.`` (CLI) or ``API key and security key are required`` (SDK), or an "Unauthorized" API error, ensure you have set these variables in your shell or in a ``.env`` file in the directory where you run the script. See `Using a .env File`_ for details.
+
+**Silent .env load failures**
+
+If you are using ``dotenv.load_dotenv()`` and your keys are not loaded, ensure you actually created the file via ``cp .env.example .env``. The ``load_dotenv()`` function fails silently if the file is missing or in the wrong directory, leading to required keys errors.


### PR DESCRIPTION
Added a Troubleshooting section for silent dotenv load failures. This addresses a common issue where users miss the `cp .env.example .env` step and receive confusing missing credential errors because `load_dotenv()` fails silently.

---
*PR created automatically by Jules for task [8270332665639053185](https://jules.google.com/task/8270332665639053185) started by @fderuiter*