### PR TITLE
docs: ✍️ Scribe: fix broken optional dependency installation commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,12 +66,12 @@ To use export features, workflow plugins, or Airflow provider integrations, inst
 
 ```bash
 # Install all export dependencies
-pip install "imednet[pandas,sqlalchemy,pyarrow,excel]"
+pip install pandas sqlalchemy pyarrow openpyxl
 
 # Or pick specific ones
-pip install "imednet[sqlalchemy]"  # For SQL export
-pip install "imednet[pyarrow]"     # For Parquet export
-pip install "imednet[excel]"       # For Excel export
+pip install sqlalchemy  # For SQL export
+pip install pyarrow     # For Parquet export
+pip install pandas openpyxl  # For Excel export
 
 # Workflow plugin package
 pip install imednet-workflows

--- a/packages/core/src/imednet/utils/pandas.py
+++ b/packages/core/src/imednet/utils/pandas.py
@@ -25,10 +25,7 @@ def records_to_dataframe(records: List[Record], *, flatten: bool = False) -> pd.
     """
     if pd is None:
         raise ImportError(
-            (
-                "pandas is required for records_to_dataframe. Install "
-                "with 'pip install \"imednet[pandas]\"'."
-            )
+            ("pandas is required for records_to_dataframe. Install " "with 'pip install pandas'.")
         )
 
     rows = [r.model_dump(by_alias=False) for r in records]
@@ -50,10 +47,7 @@ def export_records_csv(
     """
     if pd is None:
         raise ImportError(
-            (
-                "pandas is required for export_records_csv. Install with "
-                "'pip install \"imednet[pandas]\"'."
-            )
+            ("pandas is required for export_records_csv. Install with " "'pip install pandas'.")
         )
 
     records = sdk.records.list(study_key=study_key)


### PR DESCRIPTION
💡 What: Replaced bracket notation for optional dependencies (e.g., pip install "imednet[pandas]") with explicit library installation commands (e.g., pip install pandas imednet-workflows) across the README, `pandas.py` util, and CLI export functions.
🎯 Why: The `pyproject.toml` file does not define optional dependency groups (like `[pandas]` or `[excel]`). Attempting to run `pip install "imednet[pandas]"` results in a `does not provide the extra` warning/error from pip, causing new users to fail at the installation step for data export features.
🧠 Cognitive Impact: Ensures developers can successfully install the required dependencies for data export on their first attempt without confusing pip errors.
📖 Preview: 
```bash
# Install all export dependencies
pip install pandas sqlalchemy pyarrow openpyxl
```

---
*PR created automatically by Jules for task [6723450584004537643](https://jules.google.com/task/6723450584004537643) started by @fderuiter*