### PR TITLE
ci: Add Streamlit publish job to GitHub Actions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,6 +7,7 @@ on:
       - "imednet-v*.*.*"
       - "imednet-workflows-v*.*.*"
       - "apache-airflow-providers-imednet-v*.*.*"
+      - "imednet-streamlit-v*.*.*"
   pull_request:
     branches: [main]
 
@@ -138,6 +139,13 @@ jobs:
           path: packages/providers-airflow/dist/
           retention-days: 1
 
+      - name: Upload Streamlit Artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: dist-streamlit
+          path: packages/plugins-streamlit/dist/
+          retention-days: 1
+
   # ------------------------------------------------------------------
   # JOB 3: TEST MATRIX (Tests the BUILT library)
   # ------------------------------------------------------------------
@@ -229,6 +237,7 @@ jobs:
     needs: test
     if: startsWith(github.ref, 'refs/tags/imednet-v')
     runs-on: ubuntu-latest
+    environment: pypi
     permissions:
       id-token: write # Mandatory for trusted publishing
     steps:
@@ -246,6 +255,7 @@ jobs:
     needs: test
     if: startsWith(github.ref, 'refs/tags/imednet-workflows-v')
     runs-on: ubuntu-latest
+    environment: pypi
     permissions:
       id-token: write # Mandatory for trusted publishing
     steps:
@@ -263,6 +273,7 @@ jobs:
     needs: test
     if: startsWith(github.ref, 'refs/tags/apache-airflow-providers-imednet-v')
     runs-on: ubuntu-latest
+    environment: pypi
     permissions:
       id-token: write # Mandatory for trusted publishing
     steps:
@@ -270,6 +281,24 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: dist-providers
+          path: dist
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+
+  publish-streamlit:
+    name: Publish imednet-streamlit to PyPI
+    needs: test
+    if: startsWith(github.ref, 'refs/tags/imednet-streamlit-v')
+    runs-on: ubuntu-latest
+    environment: pypi
+    permissions:
+      id-token: write # Mandatory for trusted publishing
+    steps:
+      - name: Download Streamlit Artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: dist-streamlit
           path: dist
 
       - name: Publish to PyPI


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow to add support for building and publishing the new `imednet-streamlit` package. The workflow now handles artifacts and PyPI publishing for this package, similar to the existing packages. Additionally, the PyPI publishing steps for all packages are now explicitly set to use the `pypi` environment for improved security and clarity.

**Streamlit package support:**

* Added `imednet-streamlit-v*.*.*` to the list of tag patterns that trigger the workflow, enabling automated builds and releases for the new Streamlit package.
* Added steps to upload the Streamlit package build artifact (`dist-streamlit`) during the build process.
* Introduced a new `publish-streamlit` job that downloads the Streamlit artifact and publishes it to PyPI when a release tag is pushed.

**PyPI publishing improvements:**

* Set the `environment: pypi` property for all PyPI publishing jobs, including the new Streamlit job, to ensure they run in the correct deployment environment. [[1]](diffhunk://#diff-7829468e86c1cc5d5133195b5cb48e1ff6c75e3e9203777f6b2e379d9e4882b3R240) [[2]](diffhunk://#diff-7829468e86c1cc5d5133195b5cb48e1ff6c75e3e9203777f6b2e379d9e4882b3R258) [[3]](diffhunk://#diff-7829468e86c1cc5d5133195b5cb48e1ff6c75e3e9203777f6b2e379d9e4882b3R276) [[4]](diffhunk://#diff-7829468e86c1cc5d5133195b5cb48e1ff6c75e3e9203777f6b2e379d9e4882b3R288-R305)