### PR TITLE
docs: ✍️ Scribe: Remove repository-specific installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,11 +126,13 @@ pip install git+https://github.com/fderuiter/imednet-python-sdk.git@main
 
 ## Quick Start
 
-Set your credentials by copying the environment template or exporting them directly:
+Set your credentials by creating a `.env` file or exporting them directly:
 
 ```bash
 # Option 1: Use a .env file (recommended)
-cp .env.example .env
+echo "IMEDNET_API_KEY=your_api_key_here" > .env
+echo "IMEDNET_SECURITY_KEY=your_security_key_here" >> .env
+# echo "IMEDNET_BASE_URL=https://edc.prod.imednetapi.com" >> .env
 
 # Option 2: Export directly to your shell
 export IMEDNET_API_KEY="your_api_key"
@@ -151,7 +153,7 @@ from imednet.utils import configure_json_logging
 configure_json_logging()
 
 # Load credentials from .env file or environment variables
-# Note: Ensure you've run `cp .env.example .env` or exported keys to your shell.
+# Note: Ensure you've created a `.env` file or exported keys to your shell.
 load_dotenv()
 cfg = load_config()
 
@@ -181,7 +183,7 @@ async def main() -> None:
     configure_json_logging()
 
     # Load credentials from .env file or environment variables
-    # Note: Ensure you've run `cp .env.example .env` or exported keys to your shell.
+    # Note: Ensure you've created a `.env` file or exported keys to your shell.
     load_dotenv()
     cfg = load_config()
 

--- a/docs/async_quick_start.rst
+++ b/docs/async_quick_start.rst
@@ -21,12 +21,14 @@ Install the package from PyPI:
 
    pip install imednet
 
-Set your credentials by copying the environment template or exporting them directly:
+Set your credentials by creating a `.env` file or exporting them directly:
 
 .. code-block:: bash
 
    # Option 1: Use a .env file (recommended)
-   cp .env.example .env
+   echo "IMEDNET_API_KEY=your_api_key_here" > .env
+echo "IMEDNET_SECURITY_KEY=your_security_key_here" >> .env
+# echo "IMEDNET_BASE_URL=https://edc.prod.imednetapi.com" >> .env
 
    # Option 2: Export directly to your shell
    export IMEDNET_API_KEY="your_api_key"
@@ -45,7 +47,7 @@ List studies asynchronously and poll a job:
 
    async def main() -> None:
        configure_json_logging()
-       # Note: Ensure you've run `cp .env.example .env` or exported keys to your shell.
+       # Note: Ensure you've created a `.env` file or exported keys to your shell.
        load_dotenv()
        cfg = load_config()
        async with AsyncImednetSDK(

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -43,16 +43,11 @@ Environment Variables
 Using a .env File
 -----------------
 
-You can create a ``.env`` file in the project root to store these variables.
-A template is provided in ``.env.example``::
+You can create a ``.env`` file in the project root to store these variables::
 
-    cp .env.example .env
-
-Edit the file to add your keys::
-
-    IMEDNET_API_KEY=your_api_key
-    IMEDNET_SECURITY_KEY=your_security_key
-    IMEDNET_BASE_URL=https://edc.prod.imednetapi.com
+    echo "IMEDNET_API_KEY=your_api_key_here" > .env
+    echo "IMEDNET_SECURITY_KEY=your_security_key_here" >> .env
+    echo "IMEDNET_BASE_URL=https://edc.prod.imednetapi.com" >> .env
 
 The CLI loads this file automatically. Other scripts can call
 ``dotenv.load_dotenv()`` to mimic this behaviour.

--- a/docs/quick_start.rst
+++ b/docs/quick_start.rst
@@ -17,12 +17,14 @@ Optional plugin packages:
    pip install "apache-airflow>=2.3.0,<4.0.0" apache-airflow-providers-imednet
    pip install "apache-airflow>=2.3.0,<4.0.0" "apache-airflow-providers-imednet[amazon]"  # for ImednetToS3Operator
 
-Set your credentials by copying the environment template or exporting them directly (see :doc:`configuration` for details):
+Set your credentials by creating a ``.env`` file or exporting them directly (see :doc:`configuration` for details):
 
 .. code-block:: bash
 
    # Option 1: Use a .env file (recommended)
-   cp .env.example .env
+   echo "IMEDNET_API_KEY=your_api_key_here" > .env
+echo "IMEDNET_SECURITY_KEY=your_security_key_here" >> .env
+# echo "IMEDNET_BASE_URL=https://edc.prod.imednetapi.com" >> .env
 
    # Option 2: Export directly to your shell
    export IMEDNET_API_KEY="your_api_key"
@@ -39,7 +41,7 @@ Enable structured logging and list studies:
    from imednet.utils import configure_json_logging
 
    configure_json_logging()
-   # Note: Ensure you've run `cp .env.example .env` or exported keys to your shell.
+   # Note: Ensure you've created a `.env` file or exported keys to your shell.
    load_dotenv()
    cfg = load_config()
    with ImednetSDK(

--- a/examples/README.md
+++ b/examples/README.md
@@ -5,11 +5,13 @@ This directory contains examples demonstrating how to use the iMednet Python SDK
 ## Prerequisites
 
 Before running the examples, you need to set up your environment with your iMednet API credentials.
-Set your credentials by copying the environment template or exporting them directly:
+Set your credentials by creating a `.env` file or exporting them directly:
 
 ```bash
 # Option 1: Use a .env file (recommended)
-cp .env.example .env
+echo "IMEDNET_API_KEY=your_api_key_here" > .env
+echo "IMEDNET_SECURITY_KEY=your_security_key_here" >> .env
+# echo "IMEDNET_BASE_URL=https://edc.prod.imednetapi.com" >> .env
 
 # Option 2: Export directly to your shell
 export IMEDNET_API_KEY="your_api_key_here"

--- a/examples/async_quick_start.py
+++ b/examples/async_quick_start.py
@@ -17,7 +17,9 @@ Provide ``IMEDNET_JOB_STUDY_KEY`` and ``IMEDNET_BATCH_ID`` to poll a job.
 
 Example::
 
-    cp .env.example .env
+    echo "IMEDNET_API_KEY=your_api_key_here" > .env
+echo "IMEDNET_SECURITY_KEY=your_security_key_here" >> .env
+# echo "IMEDNET_BASE_URL=https://edc.prod.imednetapi.com" >> .env
     # Or export directly:
     export IMEDNET_API_KEY="your_api_key"
     export IMEDNET_SECURITY_KEY="your_security_key"
@@ -31,7 +33,7 @@ async def main() -> None:
     """Run a minimal async SDK example using environment variables."""
     configure_json_logging()
     # Load environment variables from .env file if it exists
-    # Note: Ensure you've run `cp .env.example .env` or exported keys to your shell.
+    # Note: Ensure you've created a `.env` file or exported keys to your shell.
     load_dotenv()
 
     try:

--- a/examples/build_form_payload.py
+++ b/examples/build_form_payload.py
@@ -3,7 +3,9 @@
 Hybrid Entry Point for iMedNet Form Builder.
 
 Usage:
-  cp .env.example .env
+  echo "IMEDNET_API_KEY=your_api_key_here" > .env
+echo "IMEDNET_SECURITY_KEY=your_security_key_here" >> .env
+# echo "IMEDNET_BASE_URL=https://edc.prod.imednetapi.com" >> .env
   # Or export directly:
   # export IMEDNET_API_KEY="your_api_key"
   # export IMEDNET_SECURITY_KEY="your_security_key"

--- a/examples/quick_start.py
+++ b/examples/quick_start.py
@@ -14,7 +14,9 @@ script. Optionally set ``IMEDNET_BASE_URL`` for non-default instances.
 
 Example:
 
-    cp .env.example .env
+    echo "IMEDNET_API_KEY=your_api_key_here" > .env
+echo "IMEDNET_SECURITY_KEY=your_security_key_here" >> .env
+# echo "IMEDNET_BASE_URL=https://edc.prod.imednetapi.com" >> .env
     # Or export directly:
     export IMEDNET_API_KEY="your_api_key"
     export IMEDNET_SECURITY_KEY="your_security_key"
@@ -28,7 +30,7 @@ def main() -> None:
     """Run a minimal SDK example using environment variables."""
     configure_json_logging()
     # Load environment variables from .env file if it exists
-    # Note: Ensure you've run `cp .env.example .env` or exported keys to your shell.
+    # Note: Ensure you've created a `.env` file or exported keys to your shell.
     load_dotenv()
 
     try:


### PR DESCRIPTION
Replaced instructions to `cp .env.example .env` with explicit terminal commands (e.g., `echo "..." > .env`) to create a `.env` file across the README, Quick Starts, and examples.

The previous instructions assumed users had cloned the repository. This created a broken onboarding path for users installing the SDK via `pip install imednet`, as `.env.example` is not included in the PyPI distribution. Fixes a first-run crash for new users who encountered "file not found" errors when trying to run Quick Start examples immediately after pip installation.

---
*PR created automatically by Jules for task [16978687689664910157](https://jules.google.com/task/16978687689664910157) started by @fderuiter*