### PR TITLE
feat: 🛠️ SyntheticRecordGenerator — Variable-type-aware test payload generation from UATSpecification

### DIFF
--- a/examples/uat_generate_records.py
+++ b/examples/uat_generate_records.py
@@ -1,0 +1,100 @@
+"""Example usage of SyntheticRecordGenerator."""
+
+from datetime import date
+from unittest.mock import MagicMock
+from imednet_workflows.uat import (
+    UATSpecification,
+    UATSubjectSpec,
+    UATFormSpec,
+    UATVariableSpec,
+    SyntheticRecordGenerator,
+    RecordTestType,
+    VariableTestStrategy,
+    StudySnapshot
+)
+
+def main():
+    # 1. Create a mocked StudySnapshot (normally from StudySchemaInspector)
+    snapshot = MagicMock(spec=StudySnapshot)
+    snapshot.active_sites.return_value = [MagicMock(site_name="North Site")]
+
+    # 2. Define a UAT Specification
+    spec = UATSpecification(
+        study_key="DEMO-STUDY",
+        study_name="Demo Study",
+        global_date_value=date.today(),
+        subject_specs=[
+            UATSubjectSpec(site_name="North Site", subject_count=5, subject_key_prefix="UAT-")
+        ],
+        form_specs=[
+            UATFormSpec(
+                form_key="F_DM",
+                form_name="Demographics",
+                form_type="Enrollment",
+                test_type=RecordTestType.REGISTER_SUBJECT,
+                subject_count=2,
+                variables=[
+                    UATVariableSpec(
+                        variable_name="AGE",
+                        variable_key="V_AGE",
+                        variable_type="Number",
+                        form_key="F_DM",
+                        min_value=18,
+                        max_value=99
+                    ),
+                    UATVariableSpec(
+                        variable_name="GENDER",
+                        variable_key="V_GENDER",
+                        variable_type="Coded",
+                        form_key="F_DM",
+                        coded_values=["Male", "Female", "Other"]
+                    )
+                ]
+            ),
+            UATFormSpec(
+                form_key="F_VS",
+                form_name="Vital Signs",
+                form_type="Standard",
+                test_type=RecordTestType.UPDATE_SCHEDULED_RECORD,
+                interval_name="Visit 1",
+                subject_count=3,
+                variables=[
+                    UATVariableSpec(
+                        variable_name="WEIGHT",
+                        variable_key="V_WEIGHT",
+                        variable_type="Float",
+                        form_key="F_VS",
+                        strategy=VariableTestStrategy.SYNTHETIC,
+                        min_value=50.0,
+                        max_value=120.0
+                    ),
+                    UATVariableSpec(
+                        variable_name="COMMENT",
+                        variable_key="V_COMMENT",
+                        variable_type="TextArea",
+                        form_key="F_VS"
+                    )
+                ]
+            )
+        ]
+    )
+
+    # 3. Initialize generator with a seed for reproducibility
+    generator = SyntheticRecordGenerator(seed=12345)
+
+    # 4. Generate payloads
+    record_sets = generator.generate(spec, snapshot)
+
+    # 5. Inspect output
+    for record_set in record_sets:
+        print(f"--- Form: {record_set.form_name} ({record_set.form_key}) ---")
+        print(f"Test Type: {record_set.test_type}")
+        print(f"Payloads Generated: {len(record_set.payloads)}")
+        for i, payload in enumerate(record_set.payloads):
+            print(f"  Payload {i+1}: {payload}")
+        if record_set.warnings:
+            print(f"  Warnings: {record_set.warnings}")
+        print()
+
+if __name__ == "__main__":
+    main()

--- a/packages/plugins-workflows/pyproject.toml
+++ b/packages/plugins-workflows/pyproject.toml
@@ -12,6 +12,11 @@ dependencies = [
     "typer[all]>=0.15.2,<0.16.0"
 ]
 
+[project.optional-dependencies]
+uat = [
+    "faker>=20.0,<30.0"
+]
+
 [project.entry-points."imednet.plugins"]
 workflows = "imednet_workflows.namespace:Workflows"
 

--- a/packages/plugins-workflows/src/imednet_workflows/uat/__init__.py
+++ b/packages/plugins-workflows/src/imednet_workflows/uat/__init__.py
@@ -1,6 +1,7 @@
 """UAT specification models."""
 
 from .engine import EditCheckResultStatus, EditCheckVerificationReport, UATExecutionEngine
+from .generator import GeneratedRecordSet, SyntheticRecordGenerator
 from .inspector import StudySchemaInspector, StudySnapshot
 from .models import (
     RecordTestType,
@@ -23,4 +24,6 @@ __all__ = [
     "UATExecutionEngine",
     "EditCheckResultStatus",
     "EditCheckVerificationReport",
+    "GeneratedRecordSet",
+    "SyntheticRecordGenerator",
 ]

--- a/packages/plugins-workflows/src/imednet_workflows/uat/generator.py
+++ b/packages/plugins-workflows/src/imednet_workflows/uat/generator.py
@@ -1,0 +1,355 @@
+"""Synthetic record payload generator for UAT."""
+
+from __future__ import annotations
+
+import logging
+import random
+from datetime import date, datetime, timezone
+from typing import Any, Dict, List, Optional
+
+from pydantic import Field
+
+from imednet.spi.models import ImednetBaseModel
+
+from .inspector import StudySnapshot
+from .models import (
+    RecordTestType,
+    UATFormSpec,
+    UATSpecification,
+    UATVariableSpec,
+    VariableTestStrategy,
+)
+
+logger = logging.getLogger(__name__)
+
+try:
+    from faker import Faker
+except ImportError:
+    Faker = None  # type: ignore
+
+
+class GeneratedRecordSet(ImednetBaseModel):
+    """Output of the generator for a single form spec."""
+
+    form_key: str
+    form_name: str
+    test_type: RecordTestType
+    payloads: List[Dict[str, Any]]  # ready to pass to records.create()
+    subject_keys: List[str]  # subject keys that were used/will be used
+    warnings: List[str] = Field(default_factory=list)  # non-fatal issues (skipped vars, etc.)
+
+
+class SyntheticRecordGenerator:
+    """Generate synthetic record payloads from a UATSpecification and StudySnapshot.
+
+    Parameters
+    ----------
+    seed : Optional[int]
+        Random seed for reproducible generation. None means non-deterministic.
+    locale : str
+        Faker locale for text data. Default "en_US".
+    """
+
+    def __init__(
+        self,
+        seed: Optional[int] = None,
+        locale: str = "en_US",
+    ) -> None:
+        """Initialize the generator.
+
+        Args:
+            seed: Optional seed for reproducibility.
+            locale: Faker locale for text data.
+        """
+        self._rng = random.Random(seed)
+        self._seed = seed
+        self._locale = locale
+        self._faker: Any | None = None
+        if Faker is not None:
+            self._faker = Faker(locale)
+            if seed is not None:
+                self._faker.seed_instance(seed)
+
+    def _get_faker(self) -> Any:
+        if self._faker is None:
+            raise ImportError(
+                "faker is required for synthetic data generation. "
+                "Install with `pip install imednet-workflows[uat]`"
+            )
+        return self._faker
+
+    def generate(
+        self,
+        spec: UATSpecification,
+        snapshot: StudySnapshot,
+    ) -> List[GeneratedRecordSet]:
+        """Generate all record payloads for the enabled forms in the spec.
+
+        Returns one GeneratedRecordSet per enabled UATFormSpec, in the correct
+        submission order: RegisterSubject records first, then scheduled/unscheduled.
+        """
+        results: List[GeneratedRecordSet] = []
+        subject_pool = self._get_subject_pool(spec)
+
+        # Phase 1: Enrollment/registration forms
+        for form_spec in spec.forms_by_type(RecordTestType.REGISTER_SUBJECT):
+            results.append(self._generate_registration_set(spec, form_spec, snapshot, subject_pool))
+
+        # Phase 2: Scheduled forms
+        for form_spec in spec.forms_by_type(RecordTestType.UPDATE_SCHEDULED_RECORD):
+            results.append(self._generate_scheduled_set(spec, form_spec, snapshot, subject_pool))
+
+        # Phase 3: Unscheduled forms
+        for form_spec in spec.forms_by_type(RecordTestType.CREATE_NEW_RECORD):
+            results.append(self._generate_unscheduled_set(spec, form_spec, snapshot, subject_pool))
+
+        return results
+
+    def _get_subject_pool(self, spec: UATSpecification) -> List[str]:
+        pool = []
+        for s_spec in spec.subject_specs:
+            for i in range(s_spec.subject_count):
+                pool.append(f"{s_spec.subject_key_prefix}{i + 1:03d}")
+        if not pool:
+            pool = ["UAT-TEST-001"]
+        return pool
+
+    def _generate_value(self, var_spec: UATVariableSpec, spec: UATSpecification) -> Optional[str]:
+        """Generate a single value for a variable according to its strategy."""
+        if var_spec.strategy == VariableTestStrategy.SKIP:
+            return None
+        if var_spec.strategy == VariableTestStrategy.FIXED:
+            return str(var_spec.fixed_value) if var_spec.fixed_value is not None else ""
+
+        return self._synthesize_value(var_spec, spec)
+
+    def _synthesize_value(self, var_spec: UATVariableSpec, spec: UATSpecification) -> str:
+        v_type = var_spec.variable_type
+
+        if v_type == "Text":
+            max_len = var_spec.max_length or spec.global_text_length or 10
+            return self._get_faker().lexify("?" * max_len)
+
+        if v_type in ("Number", "Integer"):
+            min_v = var_spec.min_value if var_spec.min_value is not None else 1
+            max_v = var_spec.max_value if var_spec.max_value is not None else 100
+            return str(self._rng.randint(int(min_v), int(max_v)))
+
+        if v_type in ("Float", "Decimal"):
+            min_v = var_spec.min_value if var_spec.min_value is not None else 1.0
+            max_v = var_spec.max_value if var_spec.max_value is not None else 100.0
+            val = self._rng.uniform(min_v, max_v)
+            return f"{val:.2f}"
+
+        if v_type == "Date":
+            if spec.global_date_value:
+                return spec.global_date_value.isoformat()
+            return date.today().isoformat()
+
+        if v_type == "DateTime":
+            return datetime.now(timezone.utc).isoformat()
+
+        if v_type == "Coded":
+            if var_spec.coded_values:
+                return self._rng.choice(var_spec.coded_values)
+            return ""
+
+        if v_type in ("Boolean", "Yes/No"):
+            return self._rng.choice(["Yes", "No"])
+
+        if v_type == "Checkbox":
+            if var_spec.coded_values:
+                count = self._rng.randint(1, min(3, len(var_spec.coded_values)))
+                choices = self._rng.sample(var_spec.coded_values, count)
+                return "`".join(choices)
+            return ""
+
+        if v_type == "TextArea":
+            return self._get_faker().paragraph(nb_sentences=3)
+
+        if v_type in ("Signature", "File"):
+            return ""
+
+        logger.warning(
+            f"Unrecognized variable type '{v_type}' for variable '{var_spec.variable_name}'. "
+            "Defaulting to short text."
+        )
+        return self._get_faker().lexify("???????")
+
+    def _generate_data_payloads(
+        self, spec: UATSpecification, form_spec: UATFormSpec, subject_pool: List[str]
+    ) -> tuple[List[Dict[str, Any]], List[str], List[str]]:
+        warnings = []
+        coded_all_vars = [
+            v for v in form_spec.variables if v.strategy == VariableTestStrategy.CODED_ALL
+        ]
+
+        if len(coded_all_vars) > 1:
+            warnings.append(
+                f"Multiple CODED_ALL variables found in form {form_spec.form_key}. "
+                "Falling back to one payload per subject."
+            )
+            coded_all_vars = []
+
+        if coded_all_vars:
+            var_spec = coded_all_vars[0]
+            payloads = []
+            used_subjects = []
+            for i, code in enumerate(var_spec.coded_values):
+                subj_key = subject_pool[i % len(subject_pool)]
+                used_subjects.append(subj_key)
+                data = {}
+                for v in form_spec.variables:
+                    if v.variable_key == var_spec.variable_key:
+                        data[v.variable_name] = code
+                    else:
+                        val = self._generate_value(v, spec)
+                        if val is not None:
+                            data[v.variable_name] = val
+                payloads.append(data)
+            return payloads, warnings, used_subjects
+
+        if any(v.strategy == VariableTestStrategy.BOUNDARY for v in form_spec.variables):
+            payloads = []
+            used_subjects = []
+            # Min boundary
+            data_min = {}
+            for v in form_spec.variables:
+                if v.strategy == VariableTestStrategy.BOUNDARY and v.variable_type in (
+                    "Number",
+                    "Integer",
+                    "Float",
+                    "Decimal",
+                ):
+                    data_min[v.variable_name] = str(v.min_value) if v.min_value is not None else "1"
+                else:
+                    val = self._generate_value(v, spec)
+                    if val is not None:
+                        data_min[v.variable_name] = val
+            payloads.append(data_min)
+            used_subjects.append(subject_pool[0])
+
+            # Max boundary
+            data_max = {}
+            for v in form_spec.variables:
+                if v.strategy == VariableTestStrategy.BOUNDARY and v.variable_type in (
+                    "Number",
+                    "Integer",
+                    "Float",
+                    "Decimal",
+                ):
+                    data_max[v.variable_name] = (
+                        str(v.max_value) if v.max_value is not None else "100"
+                    )
+                else:
+                    val = self._generate_value(v, spec)
+                    if val is not None:
+                        data_max[v.variable_name] = val
+            payloads.append(data_max)
+            used_subjects.append(subject_pool[1 % len(subject_pool)])
+            return payloads, warnings, used_subjects
+
+        payloads = []
+        used_subjects = []
+        for i in range(form_spec.subject_count):
+            subj_key = subject_pool[i % len(subject_pool)]
+            used_subjects.append(subj_key)
+            data = {}
+            for v in form_spec.variables:
+                val = self._generate_value(v, spec)
+                if val is not None:
+                    data[v.variable_name] = val
+            payloads.append(data)
+        return payloads, warnings, used_subjects
+
+    def _generate_registration_set(
+        self,
+        spec: UATSpecification,
+        form_spec: UATFormSpec,
+        snapshot: StudySnapshot,
+        subject_pool: List[str],
+    ) -> GeneratedRecordSet:
+        data_payloads, warnings, subject_keys = self._generate_data_payloads(
+            spec, form_spec, subject_pool
+        )
+
+        subj_spec = spec.subject_specs[0] if spec.subject_specs else None
+        site_name = (
+            subj_spec.site_name
+            if subj_spec
+            else (
+                snapshot.active_sites()[0].site_name if snapshot.active_sites() else "Default Site"
+            )
+        )
+
+        final_payloads = []
+        for data in data_payloads:
+            final_payloads.append(
+                {"formKey": form_spec.form_key, "siteName": site_name, "data": data}
+            )
+
+        return GeneratedRecordSet(
+            form_key=form_spec.form_key,
+            form_name=form_spec.form_name,
+            test_type=form_spec.test_type,
+            payloads=final_payloads,
+            subject_keys=subject_keys,
+            warnings=warnings,
+        )
+
+    def _generate_scheduled_set(
+        self,
+        spec: UATSpecification,
+        form_spec: UATFormSpec,
+        snapshot: StudySnapshot,
+        subject_pool: List[str],
+    ) -> GeneratedRecordSet:
+        data_payloads, warnings, subject_keys = self._generate_data_payloads(
+            spec, form_spec, subject_pool
+        )
+
+        final_payloads = []
+        for i, data in enumerate(data_payloads):
+            final_payloads.append(
+                {
+                    "formKey": form_spec.form_key,
+                    "subjectKey": subject_keys[i],
+                    "intervalName": form_spec.interval_name or "Default Interval",
+                    "data": data,
+                }
+            )
+
+        return GeneratedRecordSet(
+            form_key=form_spec.form_key,
+            form_name=form_spec.form_name,
+            test_type=form_spec.test_type,
+            payloads=final_payloads,
+            subject_keys=subject_keys,
+            warnings=warnings,
+        )
+
+    def _generate_unscheduled_set(
+        self,
+        spec: UATSpecification,
+        form_spec: UATFormSpec,
+        snapshot: StudySnapshot,
+        subject_pool: List[str],
+    ) -> GeneratedRecordSet:
+        data_payloads, warnings, subject_keys = self._generate_data_payloads(
+            spec, form_spec, subject_pool
+        )
+
+        final_payloads = []
+        for i, data in enumerate(data_payloads):
+            final_payloads.append(
+                {"formKey": form_spec.form_key, "subjectKey": subject_keys[i], "data": data}
+            )
+
+        return GeneratedRecordSet(
+            form_key=form_spec.form_key,
+            form_name=form_spec.form_name,
+            test_type=form_spec.test_type,
+            payloads=final_payloads,
+            subject_keys=subject_keys,
+            warnings=warnings,
+        )

--- a/tests/unit/workflows/test_uat_generator.py
+++ b/tests/unit/workflows/test_uat_generator.py
@@ -1,0 +1,337 @@
+"""Unit tests for SyntheticRecordGenerator."""
+
+import pytest
+from datetime import date
+from unittest.mock import MagicMock
+
+from imednet_workflows.uat.generator import SyntheticRecordGenerator, GeneratedRecordSet
+from imednet_workflows.uat.models import (
+    UATSpecification, UATFormSpec, UATVariableSpec, UATSubjectSpec,
+    RecordTestType, VariableTestStrategy
+)
+from imednet_workflows.uat.inspector import StudySnapshot
+
+@pytest.fixture
+def mock_snapshot():
+    snapshot = MagicMock(spec=StudySnapshot)
+    snapshot.active_sites.return_value = [MagicMock(site_name="Test Site")]
+    return snapshot
+
+@pytest.fixture
+def basic_spec():
+    return UATSpecification(
+        study_key="STUDY01",
+        study_name="Test Study",
+        subject_specs=[UATSubjectSpec(site_name="Test Site", subject_count=2, subject_key_prefix="SUBJ-")],
+        form_specs=[
+            UATFormSpec(
+                form_key="F_REG",
+                form_name="Registration",
+                form_type="Enrollment",
+                test_type=RecordTestType.REGISTER_SUBJECT,
+                subject_count=1,
+                variables=[
+                    UATVariableSpec(
+                        variable_name="SUBJID",
+                        variable_key="V1",
+                        variable_type="Text",
+                        form_key="F_REG",
+                        strategy=VariableTestStrategy.SYNTHETIC,
+                        max_length=5
+                    )
+                ]
+            )
+        ]
+    )
+
+def test_generate_registration(basic_spec, mock_snapshot):
+    generator = SyntheticRecordGenerator(seed=42)
+    results = generator.generate(basic_spec, mock_snapshot)
+
+    assert len(results) == 1
+    res = results[0]
+    assert res.form_key == "F_REG"
+    assert len(res.payloads) == 1
+    assert res.payloads[0]["formKey"] == "F_REG"
+    assert res.payloads[0]["siteName"] == "Test Site"
+    assert "SUBJID" in res.payloads[0]["data"]
+    assert len(res.payloads[0]["data"]["SUBJID"]) == 5
+
+def test_fixed_strategy(mock_snapshot):
+    spec = UATSpecification(
+        study_key="S1",
+        study_name="S1",
+        form_specs=[
+            UATFormSpec(
+                form_key="F1",
+                form_name="F1",
+                form_type="Standard",
+                test_type=RecordTestType.CREATE_NEW_RECORD,
+                subject_count=1,
+                variables=[
+                    UATVariableSpec(
+                        variable_name="VAR1",
+                        variable_key="V1",
+                        variable_type="Text",
+                        form_key="F1",
+                        strategy=VariableTestStrategy.FIXED,
+                        fixed_value="FIXED_VAL"
+                    )
+                ]
+            )
+        ]
+    )
+    generator = SyntheticRecordGenerator()
+    results = generator.generate(spec, mock_snapshot)
+    assert results[0].payloads[0]["data"]["VAR1"] == "FIXED_VAL"
+
+def test_skip_strategy(mock_snapshot):
+    spec = UATSpecification(
+        study_key="S1",
+        study_name="S1",
+        form_specs=[
+            UATFormSpec(
+                form_key="F1",
+                form_name="F1",
+                form_type="Standard",
+                test_type=RecordTestType.CREATE_NEW_RECORD,
+                subject_count=1,
+                variables=[
+                    UATVariableSpec(
+                        variable_name="VAR1",
+                        variable_key="V1",
+                        variable_type="Text",
+                        form_key="F1",
+                        strategy=VariableTestStrategy.SKIP
+                    )
+                ]
+            )
+        ]
+    )
+    generator = SyntheticRecordGenerator()
+    results = generator.generate(spec, mock_snapshot)
+    assert "VAR1" not in results[0].payloads[0]["data"]
+
+def test_boundary_strategy(mock_snapshot):
+    spec = UATSpecification(
+        study_key="S1",
+        study_name="S1",
+        form_specs=[
+            UATFormSpec(
+                form_key="F1",
+                form_name="F1",
+                form_type="Standard",
+                test_type=RecordTestType.CREATE_NEW_RECORD,
+                subject_count=1, # Boundary generates 2 payloads regardless
+                variables=[
+                    UATVariableSpec(
+                        variable_name="NUM",
+                        variable_key="V1",
+                        variable_type="Number",
+                        form_key="F1",
+                        strategy=VariableTestStrategy.BOUNDARY,
+                        min_value=10,
+                        max_value=20
+                    )
+                ]
+            )
+        ]
+    )
+    generator = SyntheticRecordGenerator()
+    results = generator.generate(spec, mock_snapshot)
+    assert len(results[0].payloads) == 2
+    assert results[0].payloads[0]["data"]["NUM"] == "10.0"
+    assert results[0].payloads[1]["data"]["NUM"] == "20.0"
+
+def test_coded_all_strategy(mock_snapshot):
+    spec = UATSpecification(
+        study_key="S1",
+        study_name="S1",
+        form_specs=[
+            UATFormSpec(
+                form_key="F1",
+                form_name="F1",
+                form_type="Standard",
+                test_type=RecordTestType.CREATE_NEW_RECORD,
+                subject_count=1,
+                variables=[
+                    UATVariableSpec(
+                        variable_name="CODED",
+                        variable_key="V1",
+                        variable_type="Coded",
+                        form_key="F1",
+                        strategy=VariableTestStrategy.CODED_ALL,
+                        coded_values=["A", "B", "C"]
+                    )
+                ]
+            )
+        ]
+    )
+    generator = SyntheticRecordGenerator()
+    results = generator.generate(spec, mock_snapshot)
+    assert len(results[0].payloads) == 3
+    assert results[0].payloads[0]["data"]["CODED"] == "A"
+    assert results[0].payloads[1]["data"]["CODED"] == "B"
+    assert results[0].payloads[2]["data"]["CODED"] == "C"
+
+def test_coded_all_warning(mock_snapshot):
+    spec = UATSpecification(
+        study_key="S1",
+        study_name="S1",
+        form_specs=[
+            UATFormSpec(
+                form_key="F1",
+                form_name="F1",
+                form_type="Standard",
+                test_type=RecordTestType.CREATE_NEW_RECORD,
+                subject_count=1,
+                variables=[
+                    UATVariableSpec(
+                        variable_name="C1",
+                        variable_key="V1",
+                        variable_type="Coded",
+                        form_key="F1",
+                        strategy=VariableTestStrategy.CODED_ALL,
+                        coded_values=["A", "B"]
+                    ),
+                    UATVariableSpec(
+                        variable_name="C2",
+                        variable_key="V2",
+                        variable_type="Coded",
+                        form_key="F1",
+                        strategy=VariableTestStrategy.CODED_ALL,
+                        coded_values=["X", "Y"]
+                    )
+                ]
+            )
+        ]
+    )
+    generator = SyntheticRecordGenerator()
+    results = generator.generate(spec, mock_snapshot)
+    assert len(results[0].warnings) > 0
+    assert len(results[0].payloads) == 1 # Fallback to 1 subject
+
+def test_seed_reproducibility(basic_spec, mock_snapshot):
+    gen1 = SyntheticRecordGenerator(seed=123)
+    res1 = gen1.generate(basic_spec, mock_snapshot)
+
+    gen2 = SyntheticRecordGenerator(seed=123)
+    res2 = gen2.generate(basic_spec, mock_snapshot)
+
+    assert res1[0].payloads[0]["data"] == res2[0].payloads[0]["data"]
+
+def test_faker_missing_error(basic_spec, mock_snapshot, monkeypatch):
+    import imednet_workflows.uat.generator as generator_mod
+    monkeypatch.setattr(generator_mod, "Faker", None)
+
+    # We need to re-instantiate or bypass the check in __init__ if we want to test _get_faker
+    # Actually SyntheticRecordGenerator.__init__ checks Faker is not None.
+
+    generator = SyntheticRecordGenerator()
+    monkeypatch.setattr(generator, "_faker", None)
+
+    with pytest.raises(ImportError, match="faker is required"):
+        generator._get_faker()
+
+def test_various_types(mock_snapshot):
+    spec = UATSpecification(
+        study_key="S1",
+        study_name="S1",
+        global_date_value=date(2023, 1, 1),
+        form_specs=[
+            UATFormSpec(
+                form_key="F1",
+                form_name="F1",
+                form_type="Standard",
+                test_type=RecordTestType.CREATE_NEW_RECORD,
+                subject_count=1,
+                variables=[
+                    UATVariableSpec(variable_name="N", variable_key="V1", variable_type="Number", form_key="F1"),
+                    UATVariableSpec(variable_name="F", variable_key="V2", variable_type="Float", form_key="F1"),
+                    UATVariableSpec(variable_name="D", variable_key="V3", variable_type="Date", form_key="F1"),
+                    UATVariableSpec(variable_name="DT", variable_key="V4", variable_type="DateTime", form_key="F1"),
+                    UATVariableSpec(variable_name="B", variable_key="V5", variable_type="Boolean", form_key="F1"),
+                    UATVariableSpec(variable_name="CB", variable_key="V6", variable_type="Checkbox", form_key="F1", coded_values=["X", "Y"]),
+                    UATVariableSpec(variable_name="TA", variable_key="V7", variable_type="TextArea", form_key="F1"),
+                ]
+            )
+        ]
+    )
+    generator = SyntheticRecordGenerator(seed=42)
+    results = generator.generate(spec, mock_snapshot)
+    data = results[0].payloads[0]["data"]
+
+    assert isinstance(data["N"], str)
+    assert "." in data["F"]
+    assert data["D"] == "2023-01-01"
+    assert "T" in data["DT"]
+    assert data["B"] in ("Yes", "No")
+    assert any(c in data["CB"] for c in ("X", "Y"))
+    assert len(data["TA"]) > 0
+
+def test_subject_pool_logic(mock_snapshot):
+    spec = UATSpecification(
+        study_key="S1",
+        study_name="S1",
+        subject_specs=[UATSubjectSpec(site_name="S1", subject_count=3, subject_key_prefix="TEST-")],
+        form_specs=[
+            UATFormSpec(
+                form_key="F1",
+                form_name="F1",
+                form_type="Standard",
+                test_type=RecordTestType.UPDATE_SCHEDULED_RECORD,
+                subject_count=5, # Should wrap around pool
+                variables=[]
+            )
+        ]
+    )
+    generator = SyntheticRecordGenerator()
+    results = generator.generate(spec, mock_snapshot)
+    res = results[0]
+    assert res.subject_keys == ["TEST-001", "TEST-002", "TEST-003", "TEST-001", "TEST-002"]
+    assert res.payloads[0]["subjectKey"] == "TEST-001"
+    assert res.payloads[4]["subjectKey"] == "TEST-002"
+
+def test_unrecognized_type(mock_snapshot, caplog):
+    spec = UATSpecification(
+        study_key="S1",
+        study_name="S1",
+        form_specs=[
+            UATFormSpec(
+                form_key="F1",
+                form_name="F1",
+                form_type="Standard",
+                test_type=RecordTestType.CREATE_NEW_RECORD,
+                subject_count=1,
+                variables=[
+                    UATVariableSpec(variable_name="UNK", variable_key="V1", variable_type="UNKNOWN", form_key="F1"),
+                    UATVariableSpec(variable_name="SIG", variable_key="V2", variable_type="Signature", form_key="F1"),
+                ]
+            )
+        ]
+    )
+    generator = SyntheticRecordGenerator()
+    results = generator.generate(spec, mock_snapshot)
+    assert "UNK" in results[0].payloads[0]["data"]
+    assert results[0].payloads[0]["data"]["SIG"] == ""
+    assert "Unrecognized variable type" in caplog.text
+
+def test_no_subjects_pool_default(mock_snapshot):
+    spec = UATSpecification(
+        study_key="S1",
+        study_name="S1",
+        subject_specs=[],
+        form_specs=[
+            UATFormSpec(
+                form_key="F1",
+                form_name="F1",
+                form_type="Standard",
+                test_type=RecordTestType.CREATE_NEW_RECORD,
+                subject_count=1,
+                variables=[]
+            )
+        ]
+    )
+    generator = SyntheticRecordGenerator()
+    results = generator.generate(spec, mock_snapshot)
+    assert results[0].subject_keys == ["UAT-TEST-001"]


### PR DESCRIPTION
Implemented the SyntheticRecordGenerator class to facilitate automated UAT testing by generating valid, type-aware API payloads. The generator handles various strategies and variable types, ensuring reproducible and comprehensive test data generation.

Fixes #1207

---
*PR created automatically by Jules for task [17531824561122107943](https://jules.google.com/task/17531824561122107943) started by @fderuiter*