### PR TITLE
feat: 🔒 Streamlit session isolation and cache hardening

### DIFF
--- a/packages/plugins-streamlit/src/imednet_streamlit/auth.py
+++ b/packages/plugins-streamlit/src/imednet_streamlit/auth.py
@@ -25,9 +25,15 @@ def _build_sdk(api_key: str, security_key: str) -> None:
 
 
 def _mark_disconnected() -> None:
-    """TODO: Add docstring."""
+    """Mark the session as disconnected and clear the cached SDK.
+
+    This ensures that any subsequent interaction requires a fresh connection,
+    and prevents stale SDK instances from being used after a context switch.
+    """
     st.session_state[_KEY_CONNECTED] = False
     st.session_state.pop(_KEY_SDK, None)
+    # Also clear cache to prevent stale data leaks across contexts
+    st.cache_data.clear()
 
 
 import os
@@ -111,9 +117,18 @@ def render_auth_sidebar() -> bool:
             st.warning("No studies available. Contact Global Admin to provision environments.")
             return False
 
-        study_key = st.selectbox("Select Authorized Study", options=studies, key=_KEY_STUDY_KEY)
+        study_key = st.selectbox(
+            "Select Authorized Study",
+            options=studies,
+            key=_KEY_STUDY_KEY,
+            on_change=_mark_disconnected,
+        )
 
-        if st.button("Connect"):
+        if st.session_state.get(_KEY_CONNECTED):
+            if st.button("Disconnect", type="primary"):
+                clear_credentials()
+                st.rerun()
+        elif st.button("Connect"):
             api_key, security_key = get_tenant_credentials(study_key)
             if not api_key or not security_key:
                 st.error("Managed credentials for this tenant are missing.")
@@ -181,3 +196,5 @@ def clear_credentials() -> None:
     """
     for key in (_KEY_API_KEY, _KEY_SECURITY_KEY, _KEY_STUDY_KEY, _KEY_SDK, _KEY_CONNECTED):
         st.session_state.pop(key, None)
+    # Ensure cache is also purged when credentials are cleared
+    st.cache_data.clear()

--- a/tests/unit/streamlit/test_session_and_cache.py
+++ b/tests/unit/streamlit/test_session_and_cache.py
@@ -1,0 +1,172 @@
+"""Tests for session isolation and cache behavior in Streamlit."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+from streamlit.testing.v1 import AppTest
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+APP_PATH = REPO_ROOT / "packages" / "plugins-streamlit" / "src" / "imednet_streamlit" / "app.py"
+
+
+@pytest.fixture
+def mock_auth_env():
+    """Set up mocks for authentication and studies."""
+    with (
+        patch("imednet_streamlit.auth.get_provisioned_studies", return_value=["STUDY-A", "STUDY-B"]),
+        patch(
+            "imednet_streamlit.auth.get_tenant_credentials",
+            side_effect=lambda s: ("key-" + s, "sec-" + s),
+        ) as mock_get_creds,
+        patch("imednet_streamlit.auth.ImednetSDK") as mock_sdk,
+        patch.dict(os.environ, {"IMEDNET_BROWSER_TEST": "1"}),
+        patch("streamlit.cache_data.clear") as mock_cache_clear,
+    ):
+        yield mock_sdk, mock_cache_clear, mock_get_creds
+
+
+def test_scenario_1_fresh_vs_connected_session(mock_auth_env) -> None:
+    """Scenario 1: fresh session starts unauthenticated and connects after flow."""
+    at = AppTest.from_file(str(APP_PATH))
+    at.run()
+
+    # Should not be connected initially
+    assert "_imednet_connected" not in at.session_state or at.session_state["_imednet_connected"] is not True
+
+    # Select the study and click connect
+    at.sidebar.selectbox(key="_imednet_study_key").select("STUDY-A")
+    connect_btn = next(b for b in at.sidebar.button if b.label == "Connect")
+    connect_btn.click()
+    at.run()
+
+    assert at.session_state["_imednet_connected"] is True
+    assert at.session_state["_imednet_study_key"] == "STUDY-A"
+
+
+def test_scenario_2_disconnect_clears_state(mock_auth_env) -> None:
+    """Scenario 2: clearing credentials removes session artifacts."""
+    _, mock_cache_clear, _ = mock_auth_env
+    from imednet_streamlit.auth import clear_credentials
+
+    state = {
+        "_imednet_api_key": "abc",
+        "_imednet_security_key": "def",
+        "_imednet_study_key": "STUDY-A",
+        "_imednet_sdk": object(),
+        "_imednet_connected": True,
+    }
+    with patch("imednet_streamlit.auth.st.session_state", state):
+        clear_credentials()
+        assert "_imednet_connected" not in state
+        assert "_imednet_sdk" not in state
+        assert "_imednet_study_key" not in state
+        assert mock_cache_clear.called
+
+
+def test_scenario_3_study_switch_disconnects(mock_auth_env) -> None:
+    """Scenario 3: switching study context should disconnect the session."""
+    at = AppTest.from_file(str(APP_PATH))
+    at.run()
+    at.sidebar.selectbox(key="_imednet_study_key").select("STUDY-A")
+    connect_btn = next(b for b in at.sidebar.button if b.label == "Connect")
+    connect_btn.click()
+    at.run()
+
+    assert at.session_state["_imednet_connected"] is True
+
+    # Switch study
+    at.sidebar.selectbox(key="_imednet_study_key").select("STUDY-B")
+    at.run()
+
+    # SHOULD be disconnected now because we don't want to use STUDY-A SDK with STUDY-B key
+    connected = at.session_state["_imednet_connected"] if "_imednet_connected" in at.session_state else False
+    assert connected is False
+
+
+def test_scenario_4_cache_isolation(mock_auth_env) -> None:
+    """Scenario 4: cache results are isolated (implicitly via SDK/study parameters)."""
+    with patch("imednet_streamlit.auth.get_sdk"), patch("imednet_streamlit.auth.get_study_key"):
+        from imednet_streamlit.pages.queries import _fetch_queries
+
+    mock_sdk_a = MagicMock()
+    mock_sdk_b = MagicMock()
+
+    with patch("imednet_workflows.query_management.QueryManagementWorkflow") as mock_workflow_cls:
+        _fetch_queries(mock_sdk_a, "STUDY-A")
+        assert mock_workflow_cls.call_count == 1
+
+        _fetch_queries(mock_sdk_a, "STUDY-A")
+        assert mock_workflow_cls.call_count == 1
+
+        _fetch_queries(mock_sdk_b, "STUDY-B")
+        assert mock_workflow_cls.call_count == 2
+
+
+def test_scenario_5_error_recovery(mock_auth_env) -> None:
+    """Scenario 5: errors do not permanently poison the session."""
+    _, _, mock_get_creds = mock_auth_env
+    at = AppTest.from_file(str(APP_PATH))
+    at.run()
+
+    at.sidebar.selectbox(key="_imednet_study_key").select("STUDY-A")
+
+    # 1. Simulate failure (missing credentials)
+    mock_get_creds.side_effect = None
+    mock_get_creds.return_value = (None, None)
+
+    connect_btn = next(b for b in at.sidebar.button if b.label == "Connect")
+    connect_btn.click()
+    at.run()
+
+    # Should show error and NOT be connected
+    all_error_values = [e.value for e in at.error] + [e.value for e in at.sidebar.error]
+    assert any("missing" in v for v in all_error_values)
+    connected = at.session_state["_imednet_connected"] if "_imednet_connected" in at.session_state else False
+    assert connected is not True
+
+    # 2. Recover - provide valid credentials
+    mock_get_creds.return_value = ("valid-key", "valid-sec")
+
+    connect_btn = next(b for b in at.sidebar.button if b.label == "Connect")
+    connect_btn.click()
+    at.run()
+
+    # Should now be connected
+    assert at.session_state["_imednet_connected"] is True
+    all_success_values = [s.value for s in at.success] + [s.value for s in at.sidebar.success]
+    assert any("Connected ✓" in v for v in all_success_values)
+
+
+def test_scenario_6_multi_session_isolation(mock_auth_env) -> None:
+    """Scenario 6: concurrent user sessions remain independent."""
+    at1 = AppTest.from_file(str(APP_PATH))
+    at2 = AppTest.from_file(str(APP_PATH))
+
+    at1.run()
+    at2.run()
+
+    # Connect session 1
+    at1.sidebar.selectbox(key="_imednet_study_key").select("STUDY-A")
+    connect_btn1 = next(b for b in at1.sidebar.button if b.label == "Connect")
+    connect_btn1.click()
+    at1.run()
+
+    assert at1.session_state["_imednet_connected"] is True
+
+    # Check session 2 status
+    connected2 = at2.session_state["_imednet_connected"] if "_imednet_connected" in at2.session_state else False
+    assert connected2 is not True
+
+    # Connect session 2 to a different study
+    at2.sidebar.selectbox(key="_imednet_study_key").select("STUDY-B")
+    connect_btn2 = next(b for b in at2.sidebar.button if b.label == "Connect")
+    connect_btn2.click()
+    at2.run()
+
+    assert at2.session_state["_imednet_connected"] is True
+    assert at1.session_state["_imednet_study_key"] == "STUDY-A"
+    assert at2.session_state["_imednet_study_key"] == "STUDY-B"

--- a/tests/unit/streamlit_plugin/test_auth.py
+++ b/tests/unit/streamlit_plugin/test_auth.py
@@ -21,6 +21,14 @@ class _SidebarContext:
         return None
 
 
+class _FakeCacheData:
+    """TODO: Add docstring."""
+
+    def clear(self) -> None:
+        """TODO: Add docstring."""
+        pass
+
+
 class _FakeStreamlit:
     """TODO: Add docstring."""
 
@@ -39,6 +47,7 @@ class _FakeStreamlit:
         self.error_messages: list[str] = []
         self.warning_messages: list[str] = []
         self.info_messages: list[str] = []
+        self.cache_data = _FakeCacheData()
 
         self.user = {"email": "test@enterprise.com", "is_logged_in": logged_in} if logged_in else {}
         self.login_called = False
@@ -54,14 +63,18 @@ class _FakeStreamlit:
         self.session_state[key] = ""
         return ""
 
-    def selectbox(self, label: str, options: list[str], key: str) -> str:
+    def selectbox(self, label: str, options: list[str], key: str, **kwargs: object) -> str:
         """TODO: Add docstring."""
         self.session_state[key] = self._selected_study
         return self._selected_study
 
-    def button(self, _: str) -> bool:
+    def button(self, _: str, **kwargs: object) -> bool:
         """TODO: Add docstring."""
         return self._connect_clicked
+
+    def rerun(self) -> None:
+        """TODO: Add docstring."""
+        pass
 
     def success(self, message: str) -> None:
         """TODO: Add docstring."""


### PR DESCRIPTION
This PR adds robust session isolation and cache management to the Streamlit plugin. Key improvements include automatic session disconnection and cache purging when switching studies, ensuring that users never accidentally view data from a previous study context using a stale SDK instance. A new test suite validates these behaviors across 6 distinct scenarios using Streamlit's `AppTest` framework.

Fixes #1174

---
*PR created automatically by Jules for task [8727989976940495510](https://jules.google.com/task/8727989976940495510) started by @fderuiter*