### PR TITLE
feat: BulkRecordSubmissionWorkflow implementation

### DIFF
--- a/packages/plugins-workflows/src/imednet_workflows/uat/__init__.py
+++ b/packages/plugins-workflows/src/imednet_workflows/uat/__init__.py
@@ -11,6 +11,12 @@ from .models import (
     UATVariableSpec,
     VariableTestStrategy,
 )
+from .submission import (
+    BatchSubmission,
+    BulkRecordSubmissionWorkflow,
+    BulkSubmissionError,
+    SubmissionResult,
+)
 
 __all__ = [
     "RecordTestType",
@@ -26,4 +32,8 @@ __all__ = [
     "EditCheckVerificationReport",
     "GeneratedRecordSet",
     "SyntheticRecordGenerator",
+    "BatchSubmission",
+    "BulkRecordSubmissionWorkflow",
+    "BulkSubmissionError",
+    "SubmissionResult",
 ]

--- a/packages/plugins-workflows/src/imednet_workflows/uat/submission.py
+++ b/packages/plugins-workflows/src/imednet_workflows/uat/submission.py
@@ -60,6 +60,12 @@ class BulkSubmissionError(Exception):
     """Raised when Phase 1 registration jobs fail, blocking Phase 2 submission."""
 
     def __init__(self, message: str, failed_batches: List[BatchSubmission]) -> None:
+        """Initialize the error.
+
+        Args:
+            message: The error message.
+            failed_batches: List of batches that failed during submission.
+        """
         super().__init__(message)
         self.failed_batches = failed_batches
 

--- a/packages/plugins-workflows/src/imednet_workflows/uat/submission.py
+++ b/packages/plugins-workflows/src/imednet_workflows/uat/submission.py
@@ -221,7 +221,7 @@ class BulkRecordSubmissionWorkflow:
             # Update the job state in the batch object
             batch.job.state = status.state
 
-            if not status.is_successful:
+            if not status.state or status.state.upper() not in ("COMPLETED", "SUCCESS"):
                 failed_batches.append(batch)
 
         if failed_batches:

--- a/packages/plugins-workflows/src/imednet_workflows/uat/submission.py
+++ b/packages/plugins-workflows/src/imednet_workflows/uat/submission.py
@@ -1,0 +1,235 @@
+"""Two-phase bulk record submission workflow for UAT."""
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime, timezone
+from typing import Any, Dict, Iterator, List, Literal, Optional, Set, Union
+
+from pydantic import Field
+
+from imednet.spi.facade import ImednetFacade
+from imednet.spi.models import ImednetBaseModel, Job
+from imednet_workflows.job_poller import JobPoller
+
+from .generator import GeneratedRecordSet
+from .models import RecordTestType
+
+logger = logging.getLogger(__name__)
+
+
+class BatchSubmission(ImednetBaseModel):
+    """Tracks a single API call to records.create()."""
+
+    phase: Literal["registration", "data"]
+    form_key: Optional[str] = None
+    form_name: Optional[str] = None
+    record_count: int
+    job: Job
+    submitted_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
+
+
+class SubmissionResult(ImednetBaseModel):
+    """Aggregate result of a full UAT submission run."""
+
+    study_key: str
+    started_at: datetime
+    completed_at: Optional[datetime] = None
+    registration_batches: List[BatchSubmission] = Field(default_factory=list)
+    data_batches: List[BatchSubmission] = Field(default_factory=list)
+    skipped_forms: List[str] = Field(default_factory=list)
+    warnings: List[str] = Field(default_factory=list)
+
+    @property
+    def all_batches(self) -> List[BatchSubmission]:
+        """Return all submission batches from both phases."""
+        return self.registration_batches + self.data_batches
+
+    @property
+    def all_batch_ids(self) -> List[str]:
+        """Return all batch IDs from all submitted jobs."""
+        return [b.job.batch_id for b in self.all_batches if b.job.batch_id]
+
+    @property
+    def total_records_submitted(self) -> int:
+        """Return the total count of records submitted across all batches."""
+        return sum(b.record_count for b in self.all_batches)
+
+
+class BulkSubmissionError(Exception):
+    """Raised when Phase 1 registration jobs fail, blocking Phase 2 submission."""
+
+    def __init__(self, message: str, failed_batches: List[BatchSubmission]) -> None:
+        super().__init__(message)
+        self.failed_batches = failed_batches
+
+
+class BulkRecordSubmissionWorkflow:
+    """Two-phase bulk record submission for UAT scenarios.
+
+    Phase 1: Submit all RegisterSubjectRequest payloads and await job completion.
+    Phase 2: Submit all UpdateScheduledRecordRequest and CreateNewRecordRequest payloads.
+
+    Parameters
+    ----------
+    sdk : ImednetFacade
+        Initialized synchronous SDK instance.
+    batch_size : int
+        Maximum number of records per API call. Default: 100.
+    await_registration : bool
+        If True, block until all Phase 1 jobs reach terminal state before
+        submitting Phase 2 records. Default: True.
+    registration_timeout : float
+        Seconds to wait for Phase 1 jobs. Default: 600.
+    skip_existing_subjects : bool
+        If True, query the API for existing UAT-tagged subjects and skip
+        registration for any that already exist. Default: True.
+    """
+
+    def __init__(
+        self,
+        sdk: ImednetFacade,
+        batch_size: int = 100,
+        await_registration: bool = True,
+        registration_timeout: float = 600.0,
+        skip_existing_subjects: bool = True,
+    ) -> None:
+        """Initialize the workflow."""
+        self.sdk = sdk
+        self.batch_size = batch_size
+        self.await_registration = await_registration
+        self.registration_timeout = registration_timeout
+        self.skip_existing_subjects = skip_existing_subjects
+
+    def submit(
+        self,
+        study_key: str,
+        record_sets: List[GeneratedRecordSet],
+        *,
+        email_notify: Optional[Union[bool, str]] = None,
+        keyword_tag: str = "UAT",
+    ) -> SubmissionResult:
+        """Execute the two-phase submission.
+
+        Returns a SubmissionResult with all jobs and metadata.
+        Raises BulkSubmissionError if Phase 1 jobs fail and Phase 2 depends on them.
+        """
+        result = SubmissionResult(
+            study_key=study_key,
+            started_at=datetime.now(timezone.utc),
+        )
+
+        registration_sets = [
+            rs for rs in record_sets if rs.test_type == RecordTestType.REGISTER_SUBJECT
+        ]
+        data_sets = [rs for rs in record_sets if rs.test_type != RecordTestType.REGISTER_SUBJECT]
+
+        existing_subjects: Set[str] = set()
+        if self.skip_existing_subjects:
+            existing_subjects = self._find_existing_uat_subjects(study_key, keyword_tag)
+
+        # Phase 1: Registration
+        for rs in registration_sets:
+            # Let's assume GeneratedRecordSet.payloads and GeneratedRecordSet.subject_keys are 1:1
+            filtered_payloads = []
+            for i, payload in enumerate(rs.payloads):
+                subj_key = rs.subject_keys[i] if i < len(rs.subject_keys) else None
+                if subj_key and subj_key in existing_subjects:
+                    logger.info("Skipping registration for existing subject: %s", subj_key)
+                    continue
+                filtered_payloads.append(payload)
+
+            if not filtered_payloads:
+                result.skipped_forms.append(rs.form_key)
+                continue
+
+            for chunk in self._chunk_payloads(filtered_payloads):
+                batch = self._submit_batch(
+                    study_key,
+                    chunk,
+                    phase="registration",
+                    form_key=rs.form_key,
+                    form_name=rs.form_name,
+                    email_notify=email_notify,
+                )
+                result.registration_batches.append(batch)
+
+        # Await registration completion if required
+        if self.await_registration and result.registration_batches:
+            self._await_registration_jobs(study_key, result.registration_batches)
+
+        # Phase 2: Data Submission
+        for rs in data_sets:
+            for chunk in self._chunk_payloads(rs.payloads):
+                batch = self._submit_batch(
+                    study_key,
+                    chunk,
+                    phase="data",
+                    form_key=rs.form_key,
+                    form_name=rs.form_name,
+                    email_notify=email_notify,
+                )
+                result.data_batches.append(batch)
+
+        result.completed_at = datetime.now(timezone.utc)
+        return result
+
+    def _chunk_payloads(self, payloads: List[Dict[str, Any]]) -> Iterator[List[Dict[str, Any]]]:
+        """Yield successive batch_size chunks of payloads."""
+        for i in range(0, len(payloads), self.batch_size):
+            yield payloads[i : i + self.batch_size]
+
+    def _submit_batch(
+        self,
+        study_key: str,
+        payloads: List[Dict[str, Any]],
+        phase: Literal["registration", "data"],
+        form_key: Optional[str],
+        form_name: Optional[str],
+        email_notify: Optional[Union[bool, str]],
+    ) -> BatchSubmission:
+        """Submit a single batch and return a BatchSubmission."""
+        job = self.sdk.create_record(study_key, payloads, email_notify=email_notify)
+        return BatchSubmission(
+            phase=phase,
+            form_key=form_key,
+            form_name=form_name,
+            record_count=len(payloads),
+            job=job,
+        )
+
+    def _await_registration_jobs(self, study_key: str, batches: List[BatchSubmission]) -> None:
+        """Block until all Phase 1 jobs reach terminal state."""
+        poller = JobPoller(get_job=self.sdk.get_job)
+        failed_batches = []
+
+        for batch in batches:
+            if not batch.job.batch_id:
+                continue
+
+            status = poller.run(
+                study_key,
+                batch.job.batch_id,
+                timeout=int(self.registration_timeout),
+            )
+            # Update the job state in the batch object
+            batch.job.state = status.state
+
+            if not status.is_successful:
+                failed_batches.append(batch)
+
+        if failed_batches:
+            raise BulkSubmissionError(
+                f"{len(failed_batches)} registration batches failed.",
+                failed_batches=failed_batches,
+            )
+
+    def _find_existing_uat_subjects(self, study_key: str, keyword_tag: str) -> Set[str]:
+        """Query subjects filtered by keyword to find pre-existing UAT subjects."""
+        subjects = self.sdk.get_subjects(study_key, keyword=keyword_tag)
+        existing_keys = set()
+        for subj in subjects:
+            key = getattr(subj, "subject_key", None) or getattr(subj, "subjectKey", None)
+            if key:
+                existing_keys.add(key)
+        return existing_keys

--- a/tests/unit/workflows/test_uat_submission.py
+++ b/tests/unit/workflows/test_uat_submission.py
@@ -5,12 +5,12 @@ from unittest.mock import MagicMock
 
 import pytest
 from imednet.spi.models import Job, JobStatus, Subject
-from imednet_workflows.uat.generator import GeneratedRecordSet
-from imednet_workflows.uat.models import RecordTestType
-from imednet_workflows.uat.submission import (
+from imednet_workflows.uat import (
     BatchSubmission,
     BulkRecordSubmissionWorkflow,
     BulkSubmissionError,
+    GeneratedRecordSet,
+    RecordTestType,
     SubmissionResult,
 )
 

--- a/tests/unit/workflows/test_uat_submission.py
+++ b/tests/unit/workflows/test_uat_submission.py
@@ -4,6 +4,7 @@ from datetime import datetime, timezone
 from unittest.mock import MagicMock
 
 import pytest
+
 from imednet.spi.models import Job, JobStatus, Subject
 from imednet_workflows.uat import (
     BatchSubmission,
@@ -17,23 +18,21 @@ from imednet_workflows.uat import (
 
 @pytest.fixture
 def mock_sdk():
+    """Fixture to provide a mocked SDK facade."""
     sdk = MagicMock()
     return sdk
 
 
 def test_submission_result_properties():
+    """Test the properties of SubmissionResult model."""
     job1 = Job(batch_id="batch1", state="COMPLETED")
     job2 = Job(batch_id="batch2", state="COMPLETED")
 
     result = SubmissionResult(
         study_key="test_study",
         started_at=datetime.now(timezone.utc),
-        registration_batches=[
-            BatchSubmission(phase="registration", record_count=2, job=job1)
-        ],
-        data_batches=[
-            BatchSubmission(phase="data", record_count=3, job=job2)
-        ]
+        registration_batches=[BatchSubmission(phase="registration", record_count=2, job=job1)],
+        data_batches=[BatchSubmission(phase="data", record_count=3, job=job2)],
     )
 
     assert result.total_records_submitted == 5
@@ -42,6 +41,7 @@ def test_submission_result_properties():
 
 
 def test_chunk_payloads():
+    """Test the payload chunking logic."""
     workflow = BulkRecordSubmissionWorkflow(MagicMock(), batch_size=2)
     payloads = [{"a": 1}, {"b": 2}, {"c": 3}]
     chunks = list(workflow._chunk_payloads(payloads))
@@ -52,6 +52,7 @@ def test_chunk_payloads():
 
 
 def test_phase1_only(mock_sdk):
+    """Test submission with only phase 1 (registration) records."""
     workflow = BulkRecordSubmissionWorkflow(mock_sdk, skip_existing_subjects=False)
     mock_sdk.create_record.return_value = Job(batch_id="job1", state="PENDING")
     mock_sdk.get_job.return_value = JobStatus(batch_id="job1", state="COMPLETED")
@@ -61,7 +62,7 @@ def test_phase1_only(mock_sdk):
         form_name="Registration",
         test_type=RecordTestType.REGISTER_SUBJECT,
         payloads=[{"data": 1}],
-        subject_keys=["S1"]
+        subject_keys=["S1"],
     )
 
     result = workflow.submit("study1", [rs])
@@ -73,6 +74,7 @@ def test_phase1_only(mock_sdk):
 
 
 def test_phase2_only(mock_sdk):
+    """Test submission with only phase 2 (data) records."""
     workflow = BulkRecordSubmissionWorkflow(mock_sdk, await_registration=False)
     mock_sdk.create_record.return_value = Job(batch_id="job2", state="PENDING")
 
@@ -81,7 +83,7 @@ def test_phase2_only(mock_sdk):
         form_name="Data Form",
         test_type=RecordTestType.UPDATE_SCHEDULED_RECORD,
         payloads=[{"data": 2}],
-        subject_keys=["S1"]
+        subject_keys=["S1"],
     )
 
     result = workflow.submit("study1", [rs])
@@ -92,6 +94,7 @@ def test_phase2_only(mock_sdk):
 
 
 def test_full_two_phase_flow(mock_sdk):
+    """Test the complete two-phase submission flow."""
     workflow = BulkRecordSubmissionWorkflow(mock_sdk, skip_existing_subjects=False)
 
     # Mock Phase 1 call
@@ -109,14 +112,14 @@ def test_full_two_phase_flow(mock_sdk):
         form_name="Registration",
         test_type=RecordTestType.REGISTER_SUBJECT,
         payloads=[{"data": 1}],
-        subject_keys=["S1"]
+        subject_keys=["S1"],
     )
     rs2 = GeneratedRecordSet(
         form_key="DATA",
         form_name="Data Form",
         test_type=RecordTestType.UPDATE_SCHEDULED_RECORD,
         payloads=[{"data": 2}],
-        subject_keys=["S1"]
+        subject_keys=["S1"],
     )
 
     result = workflow.submit("study1", [rs1, rs2])
@@ -128,6 +131,7 @@ def test_full_two_phase_flow(mock_sdk):
 
 
 def test_bulk_submission_error_on_phase1_failure(mock_sdk):
+    """Test that BulkSubmissionError is raised when phase 1 fails."""
     workflow = BulkRecordSubmissionWorkflow(mock_sdk, skip_existing_subjects=False)
 
     job1 = Job(batch_id="job1", state="PENDING")
@@ -141,7 +145,7 @@ def test_bulk_submission_error_on_phase1_failure(mock_sdk):
         form_name="Registration",
         test_type=RecordTestType.REGISTER_SUBJECT,
         payloads=[{"data": 1}],
-        subject_keys=["S1"]
+        subject_keys=["S1"],
     )
 
     with pytest.raises(BulkSubmissionError) as excinfo:
@@ -152,6 +156,7 @@ def test_bulk_submission_error_on_phase1_failure(mock_sdk):
 
 
 def test_batch_size_logic(mock_sdk):
+    """Test that payloads are correctly batched according to batch_size."""
     workflow = BulkRecordSubmissionWorkflow(mock_sdk, batch_size=2)
     mock_sdk.create_record.return_value = Job(batch_id="job", state="PENDING")
 
@@ -160,7 +165,7 @@ def test_batch_size_logic(mock_sdk):
         form_name="Data Form",
         test_type=RecordTestType.CREATE_NEW_RECORD,
         payloads=[{"d": 1}, {"d": 2}, {"d": 3}],
-        subject_keys=["S1", "S2", "S3"]
+        subject_keys=["S1", "S2", "S3"],
     )
 
     result = workflow.submit("study1", [rs])
@@ -172,6 +177,7 @@ def test_batch_size_logic(mock_sdk):
 
 
 def test_skip_existing_subjects_true(mock_sdk):
+    """Test that existing subjects are skipped during phase 1."""
     workflow = BulkRecordSubmissionWorkflow(mock_sdk, skip_existing_subjects=True)
 
     # Mock existing subject
@@ -184,7 +190,7 @@ def test_skip_existing_subjects_true(mock_sdk):
         form_name="Registration",
         test_type=RecordTestType.REGISTER_SUBJECT,
         payloads=[{"data": "for S1"}],
-        subject_keys=["S1"]
+        subject_keys=["S1"],
     )
 
     result = workflow.submit("study1", [rs])
@@ -196,6 +202,7 @@ def test_skip_existing_subjects_true(mock_sdk):
 
 
 def test_skip_existing_subjects_false(mock_sdk):
+    """Test that registration is attempted even if subjects exist when skip_existing_subjects=False."""
     workflow = BulkRecordSubmissionWorkflow(mock_sdk, skip_existing_subjects=False)
     mock_sdk.create_record.return_value = Job(batch_id="job1", state="PENDING")
     mock_sdk.get_job.return_value = JobStatus(batch_id="job1", state="COMPLETED")
@@ -205,7 +212,7 @@ def test_skip_existing_subjects_false(mock_sdk):
         form_name="Registration",
         test_type=RecordTestType.REGISTER_SUBJECT,
         payloads=[{"data": "for S1"}],
-        subject_keys=["S1"]
+        subject_keys=["S1"],
     )
 
     result = workflow.submit("study1", [rs])

--- a/tests/unit/workflows/test_uat_submission.py
+++ b/tests/unit/workflows/test_uat_submission.py
@@ -1,0 +1,215 @@
+"""Unit tests for BulkRecordSubmissionWorkflow."""
+
+from datetime import datetime, timezone
+from unittest.mock import MagicMock
+
+import pytest
+from imednet.spi.models import Job, JobStatus, Subject
+from imednet_workflows.uat.generator import GeneratedRecordSet
+from imednet_workflows.uat.models import RecordTestType
+from imednet_workflows.uat.submission import (
+    BatchSubmission,
+    BulkRecordSubmissionWorkflow,
+    BulkSubmissionError,
+    SubmissionResult,
+)
+
+
+@pytest.fixture
+def mock_sdk():
+    sdk = MagicMock()
+    return sdk
+
+
+def test_submission_result_properties():
+    job1 = Job(batch_id="batch1", state="COMPLETED")
+    job2 = Job(batch_id="batch2", state="COMPLETED")
+
+    result = SubmissionResult(
+        study_key="test_study",
+        started_at=datetime.now(timezone.utc),
+        registration_batches=[
+            BatchSubmission(phase="registration", record_count=2, job=job1)
+        ],
+        data_batches=[
+            BatchSubmission(phase="data", record_count=3, job=job2)
+        ]
+    )
+
+    assert result.total_records_submitted == 5
+    assert result.all_batch_ids == ["batch1", "batch2"]
+    assert len(result.all_batches) == 2
+
+
+def test_chunk_payloads():
+    workflow = BulkRecordSubmissionWorkflow(MagicMock(), batch_size=2)
+    payloads = [{"a": 1}, {"b": 2}, {"c": 3}]
+    chunks = list(workflow._chunk_payloads(payloads))
+
+    assert len(chunks) == 2
+    assert len(chunks[0]) == 2
+    assert len(chunks[1]) == 1
+
+
+def test_phase1_only(mock_sdk):
+    workflow = BulkRecordSubmissionWorkflow(mock_sdk, skip_existing_subjects=False)
+    mock_sdk.create_record.return_value = Job(batch_id="job1", state="PENDING")
+    mock_sdk.get_job.return_value = JobStatus(batch_id="job1", state="COMPLETED")
+
+    rs = GeneratedRecordSet(
+        form_key="REG",
+        form_name="Registration",
+        test_type=RecordTestType.REGISTER_SUBJECT,
+        payloads=[{"data": 1}],
+        subject_keys=["S1"]
+    )
+
+    result = workflow.submit("study1", [rs])
+
+    assert len(result.registration_batches) == 1
+    assert len(result.data_batches) == 0
+    assert result.registration_batches[0].record_count == 1
+    mock_sdk.create_record.assert_called_once()
+
+
+def test_phase2_only(mock_sdk):
+    workflow = BulkRecordSubmissionWorkflow(mock_sdk, await_registration=False)
+    mock_sdk.create_record.return_value = Job(batch_id="job2", state="PENDING")
+
+    rs = GeneratedRecordSet(
+        form_key="DATA",
+        form_name="Data Form",
+        test_type=RecordTestType.UPDATE_SCHEDULED_RECORD,
+        payloads=[{"data": 2}],
+        subject_keys=["S1"]
+    )
+
+    result = workflow.submit("study1", [rs])
+
+    assert len(result.registration_batches) == 0
+    assert len(result.data_batches) == 1
+    mock_sdk.create_record.assert_called_once()
+
+
+def test_full_two_phase_flow(mock_sdk):
+    workflow = BulkRecordSubmissionWorkflow(mock_sdk, skip_existing_subjects=False)
+
+    # Mock Phase 1 call
+    job1 = Job(batch_id="job1", state="PENDING")
+    # Mock Phase 2 call
+    job2 = Job(batch_id="job2", state="PENDING")
+
+    mock_sdk.create_record.side_effect = [job1, job2]
+
+    # Mock polling for Phase 1
+    mock_sdk.get_job.return_value = JobStatus(batch_id="job1", state="COMPLETED")
+
+    rs1 = GeneratedRecordSet(
+        form_key="REG",
+        form_name="Registration",
+        test_type=RecordTestType.REGISTER_SUBJECT,
+        payloads=[{"data": 1}],
+        subject_keys=["S1"]
+    )
+    rs2 = GeneratedRecordSet(
+        form_key="DATA",
+        form_name="Data Form",
+        test_type=RecordTestType.UPDATE_SCHEDULED_RECORD,
+        payloads=[{"data": 2}],
+        subject_keys=["S1"]
+    )
+
+    result = workflow.submit("study1", [rs1, rs2])
+
+    assert len(result.registration_batches) == 1
+    assert len(result.data_batches) == 1
+    assert mock_sdk.create_record.call_count == 2
+    mock_sdk.get_job.assert_called_with("study1", "job1")
+
+
+def test_bulk_submission_error_on_phase1_failure(mock_sdk):
+    workflow = BulkRecordSubmissionWorkflow(mock_sdk, skip_existing_subjects=False)
+
+    job1 = Job(batch_id="job1", state="PENDING")
+    mock_sdk.create_record.return_value = job1
+
+    # Mock polling failure
+    mock_sdk.get_job.return_value = JobStatus(batch_id="job1", state="FAILED")
+
+    rs1 = GeneratedRecordSet(
+        form_key="REG",
+        form_name="Registration",
+        test_type=RecordTestType.REGISTER_SUBJECT,
+        payloads=[{"data": 1}],
+        subject_keys=["S1"]
+    )
+
+    with pytest.raises(BulkSubmissionError) as excinfo:
+        workflow.submit("study1", [rs1])
+
+    assert "1 registration batches failed" in str(excinfo.value)
+    assert len(excinfo.value.failed_batches) == 1
+
+
+def test_batch_size_logic(mock_sdk):
+    workflow = BulkRecordSubmissionWorkflow(mock_sdk, batch_size=2)
+    mock_sdk.create_record.return_value = Job(batch_id="job", state="PENDING")
+
+    rs = GeneratedRecordSet(
+        form_key="DATA",
+        form_name="Data Form",
+        test_type=RecordTestType.CREATE_NEW_RECORD,
+        payloads=[{"d": 1}, {"d": 2}, {"d": 3}],
+        subject_keys=["S1", "S2", "S3"]
+    )
+
+    result = workflow.submit("study1", [rs])
+
+    assert len(result.data_batches) == 2
+    assert result.data_batches[0].record_count == 2
+    assert result.data_batches[1].record_count == 1
+    assert mock_sdk.create_record.call_count == 2
+
+
+def test_skip_existing_subjects_true(mock_sdk):
+    workflow = BulkRecordSubmissionWorkflow(mock_sdk, skip_existing_subjects=True)
+
+    # Mock existing subject
+    subj = MagicMock(spec=Subject)
+    subj.subject_key = "S1"
+    mock_sdk.get_subjects.return_value = [subj]
+
+    rs = GeneratedRecordSet(
+        form_key="REG",
+        form_name="Registration",
+        test_type=RecordTestType.REGISTER_SUBJECT,
+        payloads=[{"data": "for S1"}],
+        subject_keys=["S1"]
+    )
+
+    result = workflow.submit("study1", [rs])
+
+    assert len(result.registration_batches) == 0
+    assert "REG" in result.skipped_forms
+    mock_sdk.get_subjects.assert_called_once_with("study1", keyword="UAT")
+    mock_sdk.create_record.assert_not_called()
+
+
+def test_skip_existing_subjects_false(mock_sdk):
+    workflow = BulkRecordSubmissionWorkflow(mock_sdk, skip_existing_subjects=False)
+    mock_sdk.create_record.return_value = Job(batch_id="job1", state="PENDING")
+    mock_sdk.get_job.return_value = JobStatus(batch_id="job1", state="COMPLETED")
+
+    rs = GeneratedRecordSet(
+        form_key="REG",
+        form_name="Registration",
+        test_type=RecordTestType.REGISTER_SUBJECT,
+        payloads=[{"data": "for S1"}],
+        subject_keys=["S1"]
+    )
+
+    result = workflow.submit("study1", [rs])
+
+    assert len(result.registration_batches) == 1
+    mock_sdk.get_subjects.assert_not_called()
+    mock_sdk.create_record.assert_called_once()


### PR DESCRIPTION
This PR implements the `BulkRecordSubmissionWorkflow` to handle complex UAT data submission requirements for the iMednet API. It ensures that subjects are registered and jobs complete before dependent records are submitted, while also providing batching and idempotency.

Fixes #1208

---
*PR created automatically by Jules for task [2086274179292788003](https://jules.google.com/task/2086274179292788003) started by @fderuiter*